### PR TITLE
Added I/O typed contracts

### DIFF
--- a/.plans/forge.md
+++ b/.plans/forge.md
@@ -61,18 +61,18 @@ This revision applies recommendations **1-7**, with recommendation 2 changed to:
 - [x] **Quality exit criteria for hard-fail recovery met**
 - [x] Reversal branch satisfies revalidation and traceability requirements.
 
-- [ ] **Strict typed contracts for agent I/O**
-- [ ] Define schemas for:
-- [ ] `AgentProposal`
-- [ ] `StoryPatch`
-- [ ] `CritiqueReport`
-- [ ] `JudgeDecision`
-- [ ] `RevisionDirective`
-- [ ] Enforce structured outputs with bounded natural-language rationale.
-- [ ] Missing/invalid fields are rejected with deterministic error typing and no state mutation.
-- [ ] Boundary validation is explicit in parser/adapter layer.
-- [ ] **Quality exit criteria for typed contracts met**
-- [ ] Parser/adapters reject malformed contracts and prevent silent fallthrough.
+- [x] **Strict typed contracts for agent I/O**
+- [x] Define schemas for:
+- [x] `AgentProposal`
+- [x] `StoryPatch`
+- [x] `CritiqueReport`
+- [x] `JudgeDecision`
+- [x] `RevisionDirective`
+- [x] Enforce structured outputs with bounded natural-language rationale.
+- [x] Missing/invalid fields are rejected with deterministic error typing and no state mutation.
+- [x] Boundary validation is explicit in parser/adapter layer.
+- [x] **Quality exit criteria for typed contracts met**
+- [x] Parser/adapters reject malformed contracts and prevent silent fallthrough.
 
 - [ ] **Evaluation harness aligned to classic IF output contract**
 - [ ] Add golden-turn checks for diegetic output, debug internals, room-first structure, clarity prompts, and transcript-only echo.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Turn narration now runs through a deterministic multi-critic coherence gate (`st
 - preserved fields include committed room/action/goal and visible state anchors.
 - replan retry runs through the same critique/judge pipeline with bounded reversal rounds.
 - Debug mode prints a judge summary line with status, score, threshold, round, critic IDs, components, and decision ID.
+- Agent I/O contracts are enforced in `storygame.llm.contracts`:
+- `AgentProposal`, `StoryPatch`, `CritiqueReport`, `JudgeDecision`, and `RevisionDirective` have explicit parsers/adapters with `extra=forbid`.
+- natural-language fields (`rationale`, `feedback`, revision instruction) are length-bounded.
+- malformed payloads are rejected with deterministic contract error codes (for example: `CONTRACT_INVALID_CRITIQUE_REPORT`) rather than silently falling through.
 
 ## Running Ollama locally
 

--- a/storygame/llm/coherence.py
+++ b/storygame/llm/coherence.py
@@ -7,8 +7,18 @@ import time
 from typing import Protocol, TypedDict
 
 from storygame.llm.context import NarrationContext
+from storygame.llm.contracts import (
+    CRITIQUE_DIMENSIONS,
+    ContractValidationError,
+    CritiqueReport,
+    JudgeDecision,
+    RevisionDirective,
+    narration_to_agent_proposal,
+    parse_critique_report,
+    parse_judge_decision,
+    parse_revision_directive,
+)
 
-CRITIQUE_DIMENSIONS = ("continuity", "causality", "dialogue_fit")
 DEFAULT_WEIGHTS = {"continuity": 0.4, "causality": 0.4, "dialogue_fit": 0.2}
 DEFAULT_CRITICAL_FLOORS = {"continuity": 70, "causality": 70}
 DEFAULT_THRESHOLD = 80
@@ -22,24 +32,6 @@ MOTION_MARKER_PATTERN = re.compile(r"\b(go|head|move|walk|run|sprint|toward|towa
 ROOM_LOCATION_PATTERN = re.compile(r"\bin ([a-z][a-z0-9_ ]+)\b", re.IGNORECASE)
 WITH_ITEM_PATTERN = re.compile(r"\bwith the ([a-z][a-z0-9_ -]+)\b", re.IGNORECASE)
 CARDINAL_PATTERN = re.compile(r"\b(north|south|east|west|up|down)\b", re.IGNORECASE)
-
-
-class CritiqueReport(TypedDict):
-    critic_id: str
-    scores: dict[str, int]
-    feedback: str
-
-
-class JudgeDecision(TypedDict):
-    decision_id: str
-    status: str
-    round_index: int
-    threshold: int
-    total_score: int
-    rubric_components: dict[str, int]
-    critical_floors: dict[str, int]
-    critic_ids: tuple[str, ...]
-    critic_reports: tuple[CritiqueReport, ...]
 
 
 class CoherenceResult(TypedDict):
@@ -328,9 +320,10 @@ def judge_critique_round(
 ) -> JudgeDecision:
     if not reports:
         raise ValueError("judge_critique_round requires at least one critique report.")
+    validated_reports = tuple(parse_critique_report(dict(report)) for report in reports)
     chosen_floors = DEFAULT_CRITICAL_FLOORS if critical_floors is None else critical_floors
     chosen_weights = DEFAULT_WEIGHTS if weights is None else weights
-    ordered_reports = tuple(reports)
+    ordered_reports = tuple(validated_reports)
     component_scores = _average_dimension_scores(ordered_reports)
     weighted_total = sum(component_scores[dim] * chosen_weights[dim] for dim in CRITIQUE_DIMENSIONS)
     total_score = int(round(weighted_total))
@@ -338,20 +331,29 @@ def judge_critique_round(
     # Tie-break rule is deterministic: score exactly at threshold still fails on any critical-floor violation.
     status = "accepted" if total_score >= threshold and not floor_violations else "failed"
     critic_ids = tuple(report["critic_id"] for report in ordered_reports)
-    return {
-        "decision_id": _decision_id(round_index, component_scores, total_score, status, critic_ids),
-        "status": status,
-        "round_index": round_index,
-        "threshold": threshold,
-        "total_score": total_score,
-        "rubric_components": component_scores,
-        "critical_floors": dict(chosen_floors),
-        "critic_ids": critic_ids,
-        "critic_reports": ordered_reports,
-    }
+    rationale = (
+        "All thresholds and critical floors are satisfied."
+        if status == "accepted"
+        else "Threshold and floor requirements are not satisfied."
+    )
+    return parse_judge_decision(
+        {
+            "decision_id": _decision_id(round_index, component_scores, total_score, status, critic_ids),
+            "status": status,
+            "round_index": round_index,
+            "threshold": threshold,
+            "total_score": total_score,
+            "rubric_components": component_scores,
+            "critical_floors": dict(chosen_floors),
+            "critic_ids": critic_ids,
+            "critic_reports": ordered_reports,
+            "judge": "director",
+            "rationale": rationale,
+        }
+    )
 
 
-def _revision_directive(reports: tuple[CritiqueReport, ...], decision: JudgeDecision) -> str:
+def _revision_directive(reports: tuple[CritiqueReport, ...], decision: JudgeDecision) -> RevisionDirective:
     weakest = sorted(
         decision["rubric_components"].items(),
         key=lambda item: (item[1], item[0]),
@@ -364,21 +366,36 @@ def _revision_directive(reports: tuple[CritiqueReport, ...], decision: JudgeDeci
         focus = "mention continuity anchors from room facts and recent events"
     else:
         focus = "mention causality and dialogue while staying tied to the current goal"
-    return f"Revision directive: {focus}. Notes: {' | '.join(feedbacks[:2])}"
+    notes = " | ".join(feedbacks[:2])[:140]
+    payload = {
+        "directive_id": f"rev-round-{decision['round_index']}",
+        "target_agent_id": "narrator",
+        "focus_dimensions": (lowest,),
+        "instruction": f"{focus}. Notes: {notes}",
+        "rationale": "Judge-selected weakest rubric dimension requires revision.",
+    }
+    return parse_revision_directive(payload)
 
 
-def _validation_revision_directive(reports: tuple[ValidationReport, ...]) -> str:
+def _validation_revision_directive(reports: tuple[ValidationReport, ...]) -> RevisionDirective:
     failed = [report for report in reports if not report["passed"]]
     reason_codes: list[str] = []
     for report in failed:
         reason_codes.extend(report["reason_codes"])
     unique_codes = sorted(set(reason_codes))
-    return f"Revision directive: fix validation errors. reason_codes={','.join(unique_codes)}"
+    payload = {
+        "directive_id": f"rev-validation-{'-'.join(unique_codes) or 'none'}",
+        "target_agent_id": "narrator",
+        "focus_dimensions": ("continuity",),
+        "instruction": f"Fix deterministic validation errors. reason_codes={','.join(unique_codes)}",
+        "rationale": "Validator failures must be resolved before critique scoring.",
+    }
+    return parse_revision_directive(payload)
 
 
-def _context_with_revision(context: NarrationContext, directive: str) -> NarrationContext:
+def _context_with_memory_fragment(context: NarrationContext, fragment: str) -> NarrationContext:
     existing = list(context.memory_fragments)
-    existing.append(directive)
+    existing.append(fragment)
     revised_fragments = tuple(existing[-3:])
     return NarrationContext(
         room_name=context.room_name,
@@ -396,6 +413,10 @@ def _context_with_revision(context: NarrationContext, directive: str) -> Narrati
         action=context.action,
         memory_fragments=revised_fragments,
     )
+
+
+def _context_with_revision(context: NarrationContext, directive: RevisionDirective) -> NarrationContext:
+    return _context_with_memory_fragment(context, directive["instruction"])
 
 
 def _reversal_seed(context: NarrationContext, hard_fail_reason: str, decision_id: str) -> tuple[str, ...]:
@@ -476,7 +497,11 @@ class CoherenceGate:
         self._max_validation_revisions = max_validation_revisions
 
     def critique_round(self, context: NarrationContext, narration: str) -> tuple[CritiqueReport, ...]:
-        return tuple(critic.critique(context, narration) for critic in self._critics)
+        reports: list[CritiqueReport] = []
+        for critic in self._critics:
+            raw_report = critic.critique(context, narration)
+            reports.append(parse_critique_report(dict(raw_report)))
+        return tuple(reports)
 
     def validate_candidate(self, context: NarrationContext, narration: str) -> tuple[ValidationReport, ...]:
         return tuple(validator.validate(context, narration) for validator in self._validators)
@@ -501,17 +526,21 @@ class CoherenceGate:
             "threshold": self._threshold,
         }
         digest = hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()[:12]
-        return {
-            "decision_id": f"judge-vld-{validation_revisions}-{digest}",
-            "status": "failed",
-            "round_index": 0,
-            "threshold": self._threshold,
-            "total_score": 0,
-            "rubric_components": {dimension: 0 for dimension in CRITIQUE_DIMENSIONS},
-            "critical_floors": dict(self._critical_floors),
-            "critic_ids": (),
-            "critic_reports": (),
-        }
+        return parse_judge_decision(
+            {
+                "decision_id": f"judge-vld-{validation_revisions}-{digest}",
+                "status": "failed",
+                "round_index": 0,
+                "threshold": self._threshold,
+                "total_score": 0,
+                "rubric_components": {dimension: 0 for dimension in CRITIQUE_DIMENSIONS},
+                "critical_floors": dict(self._critical_floors),
+                "critic_ids": (),
+                "critic_reports": (),
+                "judge": "director",
+                "rationale": "Candidate failed deterministic validators before critique scoring.",
+            }
+        )
 
     def _run_scoring_pipeline(
         self,
@@ -547,7 +576,8 @@ class CoherenceGate:
                 hard_fail_reason = "BUDGET_WALL_CLOCK_TIMEOUT"
                 break
 
-            narration = narrator.generate(current_context)
+            proposal = narration_to_agent_proposal("narrator", narrator.generate(current_context))
+            narration = proposal["narration"]
             token_spend["narrator"] += _token_count(narration)
             if token_spend["narrator"] > self._max_tokens_per_role["narrator"]:
                 final_narration = narration
@@ -595,17 +625,21 @@ class CoherenceGate:
         if final_decision is None:
             if hard_fail_reason == "":
                 hard_fail_reason = "BUDGET_MAX_CRITIQUE_ROUNDS"
-            final_decision = {
-                "decision_id": f"judge-hard-fail-{hard_fail_reason.lower()}",
-                "status": "failed",
-                "round_index": max_rounds if hard_fail_reason == "BUDGET_MAX_CRITIQUE_ROUNDS" else 0,
-                "threshold": self._threshold,
-                "total_score": 0,
-                "rubric_components": {dimension: 0 for dimension in CRITIQUE_DIMENSIONS},
-                "critical_floors": dict(self._critical_floors),
-                "critic_ids": tuple(report["critic_id"] for report in final_reports),
-                "critic_reports": final_reports,
-            }
+            final_decision = parse_judge_decision(
+                {
+                    "decision_id": f"judge-hard-fail-{hard_fail_reason.lower()}",
+                    "status": "failed",
+                    "round_index": max_rounds if hard_fail_reason == "BUDGET_MAX_CRITIQUE_ROUNDS" else 0,
+                    "threshold": self._threshold,
+                    "total_score": 0,
+                    "rubric_components": {dimension: 0 for dimension in CRITIQUE_DIMENSIONS},
+                    "critical_floors": dict(self._critical_floors),
+                    "critic_ids": tuple(report["critic_id"] for report in final_reports),
+                    "critic_reports": final_reports,
+                    "judge": "director",
+                    "rationale": f"Hard fail triggered by {hard_fail_reason}.",
+                }
+            )
 
         now = self._time_source()
         elapsed_ms = int(round((now - start_time) * 1000))
@@ -633,18 +667,21 @@ class CoherenceGate:
         )
 
     def generate_with_gate(self, narrator, context: NarrationContext) -> CoherenceResult:
-        (
-            final_narration,
-            final_reports,
-            final_validator_reports,
-            validation_revisions,
-            final_decision,
-            telemetry,
-        ) = self._run_scoring_pipeline(
-            narrator,
-            context,
-            max_rounds=self._max_rounds,
-        )
+        try:
+            (
+                final_narration,
+                final_reports,
+                final_validator_reports,
+                validation_revisions,
+                final_decision,
+                telemetry,
+            ) = self._run_scoring_pipeline(
+                narrator,
+                context,
+                max_rounds=self._max_rounds,
+            )
+        except ContractValidationError as exc:
+            raise RuntimeError(exc.code) from exc
 
         reversal: ReversalReport = {
             "trigger_reason": "",
@@ -674,20 +711,23 @@ class CoherenceGate:
 
             reversal_context = context
             for seed_line in seed:
-                reversal_context = _context_with_revision(reversal_context, seed_line)
+                reversal_context = _context_with_memory_fragment(reversal_context, seed_line)
 
-            (
-                replan_narration,
-                replan_reports,
-                replan_validator_reports,
-                replan_validation_revisions,
-                replan_decision,
-                replan_telemetry,
-            ) = self._run_scoring_pipeline(
-                narrator,
-                reversal_context,
-                max_rounds=self._max_reversal_rounds,
-            )
+            try:
+                (
+                    replan_narration,
+                    replan_reports,
+                    replan_validator_reports,
+                    replan_validation_revisions,
+                    replan_decision,
+                    replan_telemetry,
+                ) = self._run_scoring_pipeline(
+                    narrator,
+                    reversal_context,
+                    max_rounds=self._max_reversal_rounds,
+                )
+            except ContractValidationError as exc:
+                raise RuntimeError(exc.code) from exc
 
             if replan_decision["status"] == "accepted":
                 final_narration = replan_narration

--- a/storygame/llm/contracts.py
+++ b/storygame/llm/contracts.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Literal, TypedDict, cast
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+CRITIQUE_DIMENSIONS = ("continuity", "causality", "dialogue_fit")
+MAX_RATIONALE_CHARS = 280
+MAX_FEEDBACK_CHARS = 280
+MAX_INSTRUCTION_CHARS = 320
+MAX_NARRATION_CHARS = 3000
+MAX_PATCH_OPERATIONS = 24
+
+
+class ContractValidationError(ValueError):
+    def __init__(self, code: str, contract_name: str, detail: str) -> None:
+        super().__init__(f"{code}: {contract_name}: {detail}")
+        self.code = code
+        self.contract_name = contract_name
+        self.detail = detail
+
+
+class ScoreVector(TypedDict):
+    continuity: int
+    causality: int
+    dialogue_fit: int
+
+
+class CriticalFloors(TypedDict):
+    continuity: int
+    causality: int
+
+
+class PatchOperation(TypedDict):
+    op: str
+    path: str
+    value: str
+
+
+class StoryPatch(TypedDict):
+    patch_id: str
+    operations: tuple[PatchOperation, ...]
+    rationale: str
+
+
+class AgentProposal(TypedDict):
+    agent_id: str
+    narration: str
+    story_patch: StoryPatch
+    rationale: str
+
+
+class CritiqueReport(TypedDict):
+    critic_id: str
+    scores: ScoreVector
+    feedback: str
+
+
+class JudgeDecision(TypedDict):
+    decision_id: str
+    status: str
+    round_index: int
+    threshold: int
+    total_score: int
+    rubric_components: ScoreVector
+    critical_floors: CriticalFloors
+    critic_ids: tuple[str, ...]
+    critic_reports: tuple[CritiqueReport, ...]
+    judge: str
+    rationale: str
+
+
+class RevisionDirective(TypedDict):
+    directive_id: str
+    target_agent_id: str
+    focus_dimensions: tuple[str, ...]
+    instruction: str
+    rationale: str
+
+
+class _ScoreVectorModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    continuity: int = Field(ge=0, le=100)
+    causality: int = Field(ge=0, le=100)
+    dialogue_fit: int = Field(ge=0, le=100)
+
+
+class _CriticalFloorsModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    continuity: int = Field(ge=0, le=100)
+    causality: int = Field(ge=0, le=100)
+
+
+class _PatchOperationModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    op: Literal["set", "add", "remove"]
+    path: str = Field(min_length=1, max_length=160)
+    value: str = Field(max_length=MAX_NARRATION_CHARS)
+
+
+class _StoryPatchModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    patch_id: str = Field(min_length=1, max_length=80)
+    operations: tuple[_PatchOperationModel, ...] = Field(max_length=MAX_PATCH_OPERATIONS)
+    rationale: str = Field(min_length=1, max_length=MAX_RATIONALE_CHARS)
+
+
+class _AgentProposalModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    agent_id: str = Field(min_length=1, max_length=80)
+    narration: str = Field(min_length=1, max_length=MAX_NARRATION_CHARS)
+    story_patch: _StoryPatchModel
+    rationale: str = Field(min_length=1, max_length=MAX_RATIONALE_CHARS)
+
+
+class _CritiqueReportModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    critic_id: str = Field(min_length=1, max_length=80)
+    scores: _ScoreVectorModel
+    feedback: str = Field(min_length=1, max_length=MAX_FEEDBACK_CHARS)
+
+
+class _JudgeDecisionModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    decision_id: str = Field(min_length=1, max_length=96)
+    status: Literal["accepted", "failed"]
+    round_index: int = Field(ge=0, le=100)
+    threshold: int = Field(ge=0, le=100)
+    total_score: int = Field(ge=0, le=100)
+    rubric_components: _ScoreVectorModel
+    critical_floors: _CriticalFloorsModel
+    critic_ids: tuple[str, ...] = Field(max_length=16)
+    critic_reports: tuple[_CritiqueReportModel, ...] = Field(max_length=16)
+    judge: str = Field(min_length=1, max_length=80)
+    rationale: str = Field(min_length=1, max_length=MAX_RATIONALE_CHARS)
+
+    @model_validator(mode="after")
+    def _validate_critic_references(self) -> _JudgeDecisionModel:
+        report_ids = tuple(report.critic_id for report in self.critic_reports)
+        if self.critic_ids != report_ids:
+            raise ValueError("critic_ids must match critic_reports order.")
+        return self
+
+
+class _RevisionDirectiveModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    directive_id: str = Field(min_length=1, max_length=96)
+    target_agent_id: str = Field(min_length=1, max_length=80)
+    focus_dimensions: tuple[Literal["continuity", "causality", "dialogue_fit"], ...] = Field(
+        min_length=1,
+        max_length=3,
+    )
+    instruction: str = Field(min_length=1, max_length=MAX_INSTRUCTION_CHARS)
+    rationale: str = Field(min_length=1, max_length=MAX_RATIONALE_CHARS)
+
+
+def _build_validation_error(
+    code: str,
+    contract_name: str,
+    exc: ValidationError,
+) -> ContractValidationError:
+    first = exc.errors()[0]
+    location = ".".join(str(chunk) for chunk in first["loc"])
+    detail = f"{location}:{first['type']}"
+    return ContractValidationError(code=code, contract_name=contract_name, detail=detail)
+
+
+def parse_story_patch(payload: dict[str, object]) -> StoryPatch:
+    try:
+        model = _StoryPatchModel.model_validate(payload)
+    except ValidationError as exc:
+        raise _build_validation_error("CONTRACT_INVALID_STORY_PATCH", "StoryPatch", exc) from exc
+    return cast(StoryPatch, model.model_dump(mode="python"))
+
+
+def parse_agent_proposal(payload: dict[str, object]) -> AgentProposal:
+    try:
+        model = _AgentProposalModel.model_validate(payload)
+    except ValidationError as exc:
+        raise _build_validation_error("CONTRACT_INVALID_AGENT_PROPOSAL", "AgentProposal", exc) from exc
+    return cast(AgentProposal, model.model_dump(mode="python"))
+
+
+def parse_critique_report(payload: dict[str, object]) -> CritiqueReport:
+    try:
+        model = _CritiqueReportModel.model_validate(payload)
+    except ValidationError as exc:
+        raise _build_validation_error("CONTRACT_INVALID_CRITIQUE_REPORT", "CritiqueReport", exc) from exc
+    return cast(CritiqueReport, model.model_dump(mode="python"))
+
+
+def parse_judge_decision(payload: dict[str, object]) -> JudgeDecision:
+    try:
+        model = _JudgeDecisionModel.model_validate(payload)
+    except ValidationError as exc:
+        raise _build_validation_error("CONTRACT_INVALID_JUDGE_DECISION", "JudgeDecision", exc) from exc
+    return cast(JudgeDecision, model.model_dump(mode="python"))
+
+
+def parse_revision_directive(payload: dict[str, object]) -> RevisionDirective:
+    try:
+        model = _RevisionDirectiveModel.model_validate(payload)
+    except ValidationError as exc:
+        raise _build_validation_error("CONTRACT_INVALID_REVISION_DIRECTIVE", "RevisionDirective", exc) from exc
+    return cast(RevisionDirective, model.model_dump(mode="python"))
+
+
+def narration_to_agent_proposal(agent_id: str, narration: str) -> AgentProposal:
+    digest_payload = {"agent_id": agent_id, "narration": narration}
+    digest = hashlib.sha256(json.dumps(digest_payload, sort_keys=True).encode("utf-8")).hexdigest()[:12]
+    return parse_agent_proposal(
+        {
+            "agent_id": agent_id,
+            "narration": narration,
+            "story_patch": {
+                "patch_id": f"patch-{digest}",
+                "operations": (),
+                "rationale": "Narration-only proposal.",
+            },
+            "rationale": "Narration generated for coherence validation.",
+        }
+    )

--- a/tests/test_llm_contracts.py
+++ b/tests/test_llm_contracts.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import pytest
+
+from storygame.llm.coherence import CoherenceGate, _EntityReachabilityValidator
+from storygame.llm.context import NarrationContext
+from storygame.llm.contracts import (
+    ContractValidationError,
+    parse_agent_proposal,
+    parse_critique_report,
+    parse_judge_decision,
+    parse_revision_directive,
+    parse_story_patch,
+)
+
+
+def _context() -> NarrationContext:
+    return NarrationContext(
+        room_name="Archive Hall",
+        room_description="Cold stone and ledger stacks.",
+        visible_items=("ledger", "inkpot"),
+        visible_npcs=("keeper",),
+        npc_facts=(),
+        exits=("east", "west"),
+        inventory=("bronze_key",),
+        recent_events=(),
+        phase="rising_action",
+        tension=0.5,
+        beat="progressive_complication",
+        goal="Follow the forged ledger trail.",
+        action="talk keeper",
+        memory_fragments=(),
+    )
+
+
+def test_contract_parsers_accept_valid_payloads():
+    patch = parse_story_patch(
+        {
+            "patch_id": "patch-1",
+            "operations": (
+                {"op": "set", "path": "goal", "value": "Follow ledger east"},
+                {"op": "add", "path": "memory", "value": "keeper testimony"},
+            ),
+            "rationale": "Apply deterministic updates from accepted narration.",
+        }
+    )
+    proposal = parse_agent_proposal(
+        {
+            "agent_id": "narrator",
+            "narration": "You question the keeper and follow the trail east.",
+            "story_patch": patch,
+            "rationale": "Grounded in visible facts and current objective.",
+        }
+    )
+    report = parse_critique_report(
+        {
+            "critic_id": "continuity",
+            "scores": {"continuity": 84, "causality": 82, "dialogue_fit": 79},
+            "feedback": "Continuity anchors are explicit and stable.",
+        }
+    )
+    decision = parse_judge_decision(
+        {
+            "decision_id": "judge-001",
+            "status": "accepted",
+            "round_index": 1,
+            "threshold": 80,
+            "total_score": 82,
+            "rubric_components": {"continuity": 84, "causality": 82, "dialogue_fit": 79},
+            "critical_floors": {"continuity": 70, "causality": 70},
+            "critic_ids": ("continuity",),
+            "critic_reports": (report,),
+            "judge": "director",
+            "rationale": "All thresholds and critical floors are satisfied.",
+        }
+    )
+    directive = parse_revision_directive(
+        {
+            "directive_id": "rev-001",
+            "target_agent_id": "narrator",
+            "focus_dimensions": ("causality",),
+            "instruction": "Tie the next line to the latest event with explicit causality.",
+            "rationale": "Causality score remains the weakest component.",
+        }
+    )
+
+    assert proposal["agent_id"] == "narrator"
+    assert patch["operations"][0]["op"] == "set"
+    assert decision["judge"] == "director"
+    assert directive["focus_dimensions"] == ("causality",)
+
+
+def test_contract_parser_rejects_missing_fields_with_deterministic_error_code():
+    with pytest.raises(ContractValidationError) as exc_info:
+        parse_critique_report(
+            {
+                "critic_id": "continuity",
+                "scores": {"continuity": 84, "causality": 82, "dialogue_fit": 79},
+            }
+        )
+
+    exc = exc_info.value
+    assert exc.code == "CONTRACT_INVALID_CRITIQUE_REPORT"
+    assert exc.contract_name == "CritiqueReport"
+
+
+def test_contract_parser_rejects_oversized_rationale():
+    with pytest.raises(ContractValidationError) as exc_info:
+        parse_revision_directive(
+            {
+                "directive_id": "rev-002",
+                "target_agent_id": "narrator",
+                "focus_dimensions": ("continuity",),
+                "instruction": "Keep room and inventory facts explicit.",
+                "rationale": "x" * 281,
+            }
+        )
+
+    assert exc_info.value.code == "CONTRACT_INVALID_REVISION_DIRECTIVE"
+
+
+def test_coherence_gate_rejects_malformed_critic_contracts():
+    class _InvalidCritic:
+        critic_id = "broken"
+
+        def critique(self, context: NarrationContext, narration: str) -> dict[str, object]:  # noqa: ARG002
+            return {"critic_id": "broken", "scores": {"continuity": 99, "causality": 99, "dialogue_fit": 99}}
+
+    class _Narrator:
+        def generate(self, context: NarrationContext) -> str:  # noqa: ARG002
+            return "The keeper points east because the forged ledger was moved after the alarm."
+
+    gate = CoherenceGate(
+        critics=(_InvalidCritic(),),
+        validators=(_EntityReachabilityValidator(),),
+        max_rounds=1,
+    )
+
+    with pytest.raises(RuntimeError, match="CONTRACT_INVALID_CRITIQUE_REPORT"):
+        gate.generate_with_gate(_Narrator(), _context())


### PR DESCRIPTION
feat(llm): enforce strict typed contracts for agent I/O

- add parser/adapter contract layer in `storygame.llm.contracts`
- define explicit schemas for `AgentProposal`, `StoryPatch`, `CritiqueReport`, `JudgeDecision`, and `RevisionDirective`
- enforce bounded natural-language fields and forbid unknown payload fields
- introduce deterministic contract validation errors (`CONTRACT_INVALID_*`)
- wire coherence gate boundaries to validate critic reports, judge decisions, and revision directives
- reject malformed contracts deterministically with no silent fallthrough or state mutation
- add TDD coverage in `tests/test_llm_contracts.py`, including malformed critic contract integration path
- update `.plans/forge.md` and README to mark/document typed-contract completion