### PR TITLE
Revise to multiple LLM agents instead of deterministic ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,19 @@ flowchart TD
 ```
 ## Agent Definitions
 Agent behavior is centered in [storygame/llm/coherence.py](storygame/llm/coherence.py), with contract shapes in [storygame/llm/contracts.py](storygame/llm/contracts.py) and narrator backends in [storygame/llm/adapters.py](storygame/llm/adapters.py).
+Story-design agent orchestration is implemented in [storygame/llm/story_director.py](storygame/llm/story_director.py), with explicit per-agent prompt builders in [storygame/llm/story_agents/prompts.py](storygame/llm/story_agents/prompts.py) and JSON contracts in [storygame/llm/story_agents/contracts.py](storygame/llm/story_agents/contracts.py).
 
 There are **5 narrative agents** in the default pipeline:
 - **1 narrator** (`agent_id="narrator"`): proposes candidate narration each round.
 - **3 critics** (`continuity`, `causality`, `dialogue_fit`): score and provide focused feedback.
 - **1 judge** (`judge="director"`): deterministically accepts/fails rounds using thresholds/floors.
+
+Story-quality checks now enforced in prompts/revision directives:
+- Opening setup guidance: 3-4 paragraphs, establish who/where/immediate objective, keep future twists hidden.
+- Turn-order guidance: room name -> room description -> items in prose -> exits -> NPC/background activity.
+- Continuity revisions explicitly call out setup anchors and spoiler discipline when continuity is weakest.
+- Opening scene now passes through a deterministic story-editor pass before display to strip legacy/meta phrasing and repair obvious coherence issues.
+- Every player-facing output now passes through an output-editor gate; when narrator mode is `openai` or `ollama`, this gate uses an LLM critic pass and falls back to deterministic editing if unavailable.
 
 There are also **4 deterministic validators** run before critics:
 - `entity_reachability`

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -51,6 +51,9 @@ Current runtime generation is package-driven.
 - `storygame.llm.adapters` defines narrator integrations (`mock`, `none`, `openai`, `ollama`).
 - `storygame.llm.context` constructs constrained narration context.
 - `storygame.llm.coherence` runs deterministic multi-critic scoring, judging, budgets, telemetry, and constrained reversal.
+- `storygame.llm.story_director` orchestrates story-design LLM agents (architect/character/plot/narrator/editor).
+- `storygame.llm.story_agents.prompts` defines per-agent prompt templates.
+- `storygame.llm.story_agents.contracts` defines per-agent JSON contracts and parsers.
 - `storygame.llm.contracts` defines and validates strict typed contracts:
   - `AgentProposal`
   - `StoryPatch`
@@ -116,6 +119,11 @@ flowchart LR
 - Non-debug mode keeps player-facing, diegetic output.
 - Turn output is room-first.
 - Room output uses plain title + prose layout (no bracketed room labels, no event bullet prefixes).
+- Story prompts enforce opening-scene guidance for turn 0 (3-4 paragraphs with who/where/immediate objective).
+- Story prompts enforce spoiler discipline (later twists are withheld until revealed by progression/events).
+- Revision directives reinforce turn sequencing priorities: room name, room description, items, exits, then NPC/background.
+- A deterministic opening-scene story editor runs before display to remove legacy/meta phrasing and fix obvious narrative incoherence.
+- Output editor gate runs on every user-facing response; OpenAI/Ollama modes use an LLM critic rewrite pass with deterministic fallback.
 - Signal hints are objective-driven from generated map topology (targeting package terminal room), not hardcoded world landmarks.
 - Parse failures on non-command input return in-world dialog through freeform roleplay.
 - Policy-impossible freeform actions return constrained boundary responses with no state mutation.
@@ -124,6 +132,7 @@ flowchart LR
 
 ### Coherence Gate
 - Critics: `continuity`, `causality`, `dialogue_fit`.
+- Critic score payloads use explicit `ScoreVector` contract keys (`continuity`, `causality`, `dialogue_fit`) for static and runtime validation alignment.
 - Judge: deterministic single arbiter with fixed weighted rubric.
 - Threshold and critical floors are enforced deterministically.
 - Hard limits: rounds, per-role tokens, wall-clock timeout.

--- a/storygame/cli.py
+++ b/storygame/cli.py
@@ -18,6 +18,8 @@ from storygame.engine.world import build_default_state
 from storygame.llm.adapters import MockNarrator, Narrator, OllamaAdapter, OpenAIAdapter, SilentNarrator
 from storygame.llm.coherence import build_default_coherence_gate
 from storygame.llm.context import build_narration_context
+from storygame.llm.output_editor import OutputEditor, build_output_editor
+from storygame.llm.story_director import StoryDirector
 from storygame.memory import MAX_MEMORY_NOTES, MemoryStore, SqliteVectorMemory, normalize_tag
 from storygame.persistence.savegame_sqlite import SqliteSaveStore
 from storygame.plot.freytag import get_phase
@@ -81,6 +83,43 @@ def _humanize_token(token: str) -> str:
     return token.replace("_", " ")
 
 
+def _lowercase_location_phrase(location: str) -> str:
+    words = location.split()
+    if not words:
+        return "the area"
+    return f"the {' '.join(word.lower() for word in words)}"
+
+
+def _with_indefinite_article(phrase: str) -> str:
+    cleaned = phrase.strip()
+    if not cleaned:
+        return cleaned
+    first = cleaned[0].lower()
+    article = "an" if first in {"a", "e", "i", "o", "u"} else "a"
+    return f"{article} {cleaned}"
+
+
+def _opening_story_editor(paragraphs: list[str]) -> list[str]:
+    forbidden = (
+        "neutral mystery scene",
+        "move the story toward resolution",
+        "where you are:",
+        "cast:",
+    )
+    cleaned: list[str] = []
+    for paragraph in paragraphs:
+        normalized = " ".join(paragraph.split())
+        for fragment in forbidden:
+            normalized = normalized.replace(fragment, "")
+            normalized = normalized.replace(fragment.title(), "")
+        normalized = normalized.strip(" ,")
+        if normalized.lower().endswith("tasked with."):
+            normalized = normalized[: -len("tasked with.")].rstrip(" ,.;")
+            normalized = f"{normalized} and forced to take one final case."
+        cleaned.append(normalized)
+    return [paragraph for paragraph in cleaned if paragraph]
+
+
 def _joined_with_and(values: tuple[str, ...] | list[str]) -> str:
     if not values:
         return ""
@@ -103,19 +142,24 @@ def _room_lines(state: GameState) -> str:
         suffix = "item" if junk_count == 1 else "items"
         verb = "is" if junk_count == 1 else "are"
         pieces.append(f"There {verb} {junk_count} other unremarkable {suffix} nearby.")
-    if room.npc_ids:
-        visible_npcs = tuple(_humanize_token(npc) for npc in room.npc_ids)
-        verb = "is" if len(visible_npcs) == 1 else "are"
-        pieces.append(f"{_joined_with_and(list(visible_npcs)).title()} {verb} here.")
     if room.exits:
         exits = tuple(sorted(room.exits.keys()))
         if len(exits) == 1:
             pieces.append(f"The only exit is to the {exits[0]}.")
         else:
             pieces.append(f"Exits lead {_joined_with_and([f'to the {direction}' for direction in exits])}.")
+    if room.npc_ids:
+        visible_npcs = tuple(_humanize_token(npc) for npc in room.npc_ids)
+        verb = "is" if len(visible_npcs) == 1 else "are"
+        pieces.append(f"{_joined_with_and(list(visible_npcs)).title()} {verb} here.")
     if signal_hint:
         pieces.append(signal_hint.replace("Signal: ", ""))
     return "\n".join(pieces)
+
+
+def _setup_phase_lines(state: GameState) -> list[str]:
+    director = StoryDirector("mock")
+    return director.compose_opening(state)
 
 
 def _public_event_message(message_key: str) -> str:
@@ -199,13 +243,23 @@ def _build_memory_tag_set(state: GameState, action) -> tuple[str, ...]:
     room = state.world.rooms[state.player.location]
     action_target = normalize_tag(action.target) if action.target else ""
     goal_words = tuple(normalize_tag(word) for word in state.active_goal.split() if word)[:2]
-    base_tags = (
-        f"room_{state.player.location}",
+    ordered_tags: list[str] = [
         f"beat_{state.beat_history[-1]}" if state.beat_history else "beat_unknown",
         f"goal_{goal_words[0]}" if goal_words else "goal",
-    )
-    npc_tags = tuple(f"npc_{npc}" for npc in room.npc_ids)
-    return tuple(sorted(set(base_tags + (action_target,) + npc_tags)))[:MAX_MEMORY_NOTES]
+    ]
+    if action_target:
+        ordered_tags.append(action_target)
+        ordered_tags.append(f"npc_{action_target}")
+    for npc in room.npc_ids:
+        ordered_tags.append(npc)
+        ordered_tags.append(f"npc_{npc}")
+    ordered_tags.append(f"room_{state.player.location}")
+
+    deduped: list[str] = []
+    for tag in ordered_tags:
+        if tag and tag not in deduped:
+            deduped.append(tag)
+    return tuple(deduped[:MAX_MEMORY_NOTES])
 
 
 class SaveStore(Protocol):
@@ -243,6 +297,8 @@ def run_turn(
     memory_store: MemoryStore | None = None,
     memory_slot: str = "default",
     freeform_adapter: FreeformProposalAdapter = DEFAULT_FREEFORM_ADAPTER,
+    output_editor: OutputEditor | None = None,
+    story_director: StoryDirector | None = None,
 ):
     action = parse_command(raw)
     if action.kind == ActionKind.QUIT:
@@ -406,7 +462,10 @@ def run_turn(
         "rationale": str(judge_decision.get("rationale", "")),
     }
 
-    return next_state, [line for line in lines if line], action.raw, beat_type, True
+    editor = build_output_editor("mock") if output_editor is None else output_editor
+    director = StoryDirector("mock", editor) if story_director is None else story_director
+    reviewed_lines = director.review_turn(next_state, [line for line in lines if line], events, debug)
+    return next_state, reviewed_lines, action.raw, beat_type, True
 
 
 def run_replay(
@@ -510,6 +569,8 @@ def main(argv: list[str] | None = None) -> None:
     )
     rng = Random(args.seed)
     narrator: Narrator = _build_narrator(args.narrator)
+    output_editor = build_output_editor(args.narrator)
+    story_director = StoryDirector(args.narrator, output_editor)
     save_store: SqliteSaveStore | None = SqliteSaveStore(args.save_db) if args.save_db is not None else None
     memory_store: SqliteVectorMemory | None = SqliteVectorMemory(args.memory_db) if args.memory_db is not None else None
     autosave_slot = args.autosave_slot
@@ -525,9 +586,10 @@ def main(argv: list[str] | None = None) -> None:
         transcript_handle = transcript_path.open("w", encoding="utf-8")
 
     try:
-        header = _room_lines(state)
-        _emit_cli_line(console, header)
-        _write_transcript_line(transcript_handle, header)
+        setup_lines = story_director.compose_opening(state)
+        for line in setup_lines:
+            _emit_cli_line(console, line)
+            _write_transcript_line(transcript_handle, line)
 
         if args.replay is not None:
             commands = [line.strip() for line in args.replay.read_text().splitlines() if line.strip()]
@@ -542,6 +604,8 @@ def main(argv: list[str] | None = None) -> None:
                     save_store=save_store,
                     memory_store=memory_store,
                     memory_slot=memory_slot,
+                    output_editor=output_editor,
+                    story_director=story_director,
                 )
                 if autosave_slot is not None and save_store is not None:
                     save_store.save_run(
@@ -569,6 +633,8 @@ def main(argv: list[str] | None = None) -> None:
                 save_store=save_store,
                 memory_store=memory_store,
                 memory_slot=memory_slot,
+                output_editor=output_editor,
+                story_director=story_director,
             )
             for line in lines:
                 _emit_cli_line(console, line)

--- a/storygame/engine/rules.py
+++ b/storygame/engine/rules.py
@@ -79,6 +79,7 @@ def apply_action(state: GameState, action: Action, rng) -> tuple[GameState, list
     events: list[Event] = []
 
     room_id = player_location(next_state)
+
     def _commit() -> tuple[GameState, list[Event]]:
         for event in events:
             ops = event_fact_ops(event)

--- a/storygame/engine/simulation.py
+++ b/storygame/engine/simulation.py
@@ -11,13 +11,73 @@ from storygame.plot.beat_manager import select_beat
 from storygame.plot.tension import apply_tension_events
 
 
+def _refresh_active_goal(state: GameState) -> None:
+    goals = state.world_package.get("goals", {})
+    setup_goal = str(goals.get("setup", "")).strip()
+    primary_goal = str(goals.get("primary", "")).strip()
+    secondary_goals = tuple(str(goal).strip() for goal in goals.get("secondary", ()) if str(goal).strip())
+
+    if setup_goal and state.turn_index <= 3 and state.progress < 0.2:
+        state.active_goal = setup_goal
+        return
+
+    if secondary_goals and state.progress >= 0.75:
+        state.active_goal = secondary_goals[0]
+        return
+
+    if primary_goal:
+        state.active_goal = primary_goal
+
+
+def _story_reveal_events(state: GameState) -> list[Event]:
+    package = state.world_package
+    story_plan = package.get("story_plan", {})
+    hidden_threads = tuple(
+        str(thread).strip() for thread in story_plan.get("hidden_threads", ()) if str(thread).strip()
+    )
+    schedule = tuple(story_plan.get("reveal_schedule", ()))
+    if not hidden_threads or not schedule:
+        return []
+
+    reveal_events: list[Event] = []
+    for entry in schedule:
+        if not isinstance(entry, dict):
+            continue
+        thread_index = int(entry.get("thread_index", -1))
+        min_progress = float(entry.get("min_progress", 1.0))
+        if thread_index < 0 or thread_index >= len(hidden_threads):
+            continue
+        if state.progress < min_progress:
+            continue
+        flag = f"story_reveal_{thread_index}"
+        if state.player.flags.get(flag, False):
+            continue
+
+        reveal_text = hidden_threads[thread_index]
+        state.player.flags[flag] = True
+        reveal_events.append(
+            Event(
+                type="story_reveal",
+                message_key=f"New lead: {reveal_text}",
+                entities=(f"thread_{thread_index}",),
+                tags=("story_reveal",),
+                turn_index=state.turn_index,
+                delta_tension=0.02,
+            )
+        )
+    return reveal_events
+
+
 def apply_events_to_state(state: GameState, events: list[Event]) -> GameState:
     if not events:
+        _refresh_active_goal(state)
         return state
     for event in events:
         state.progress = max(0.0, min(1.0, state.progress + event.delta_progress))
         state.tension = state.tension + event.delta_tension
-    return apply_tension_events(state, events)
+    state = apply_tension_events(state, events)
+    _refresh_active_goal(state)
+    return state
 
 
 def advance_turn(
@@ -44,7 +104,12 @@ def advance_turn(
         next_state, narrative_events = apply_event_template(next_state, template, rng)
     next_state = apply_events_to_state(next_state, narrative_events)
 
-    all_events = action_events + narrative_events
+    reveal_events = _story_reveal_events(next_state)
+    if reveal_events:
+        next_state.append_events(reveal_events)
+        next_state = apply_events_to_state(next_state, reveal_events)
+
+    all_events = action_events + narrative_events + reveal_events
     return next_state, all_events, beat.type, template_key
 
 

--- a/storygame/engine/world.py
+++ b/storygame/engine/world.py
@@ -26,6 +26,22 @@ def _item_kind_for_index(index: int) -> str:
     return "evidence"
 
 
+def _room_name_for_display(room_id: str, genre: str) -> str:
+    if genre == "mystery" and room_id == "front_steps":
+        return "Outside The Mansion"
+    return _humanize_identifier(room_id)
+
+
+def _room_description(room_id: str, genre: str, tone: str) -> str:
+    location = room_id.replace("_", " ")
+    if genre == "mystery" and room_id == "front_steps":
+        return (
+            "Stone steps lead toward the mansion entrance while the street behind you stays active with distant "
+            "voices and restless weather."
+        )
+    return f"A {tone} {genre} location around {location}, detailed enough to investigate without revealing its secrets at once."
+
+
 def _build_items(package: dict) -> dict[str, Item]:
     item_ids = tuple(package["item_graph"]["items"])
     primary_goal = str(package["goals"]["primary"])
@@ -81,7 +97,7 @@ def _build_room_exits(paths: tuple[dict, ...] | list[dict]) -> dict[str, dict[st
 def _build_rooms(package: dict, items: dict[str, Item], npcs: dict[str, Npc]) -> dict[str, Room]:
     room_ids = tuple(package["map"]["rooms"])
     exits = _build_room_exits(tuple(package["map"]["paths"]))
-    item_ids = tuple(item_id for item_id in items.keys() if item_id != "field_kit")
+    item_ids = tuple(item_id for item_id in items if item_id != "field_kit")
     npc_ids = tuple(npcs.keys())
 
     rooms: dict[str, Room] = {}
@@ -96,11 +112,8 @@ def _build_rooms(package: dict, items: dict[str, Item], npcs: dict[str, Npc]) ->
 
         rooms[room_id] = Room(
             id=room_id,
-            name=_humanize_identifier(room_id),
-            description=(
-                f"A {package['tone']} {package['genre']} scene. "
-                f"The objective is to move the story toward resolution."
-            ),
+            name=_room_name_for_display(room_id, package["genre"]),
+            description=_room_description(room_id, package["genre"], package["tone"]),
             exits=dict(exits.get(room_id, {})),
             item_ids=tuple(assigned_items),
             npc_ids=tuple(assigned_npcs),
@@ -144,7 +157,34 @@ def build_default_state(
     rooms = _build_rooms(package, items, npcs)
 
     start_room = package["map"]["rooms"][0]
-    player = PlayerState(location=start_room, inventory=(), flags={"started": True})
+    opening_inventory: list[str] = ["field_kit"]
+    if package["genre"] == "mystery" and "case_file" in items:
+        opening_inventory.append("case_file")
+
+    start_room_state = rooms[start_room]
+    start_room_state.item_ids = tuple(
+        item_id for item_id in start_room_state.item_ids if item_id not in opening_inventory
+    )
+    if not start_room_state.item_ids:
+        replacement_item = ""
+        replacement_room = ""
+        for room_id, room_state in rooms.items():
+            for item_id in room_state.item_ids:
+                if item_id not in opening_inventory:
+                    replacement_item = item_id
+                    replacement_room = room_id
+                    break
+            if replacement_item:
+                break
+        if replacement_item:
+            start_room_state.item_ids = (replacement_item,)
+            if replacement_room and replacement_room != start_room:
+                source_room = rooms[replacement_room]
+                source_room.item_ids = tuple(item_id for item_id in source_room.item_ids if item_id != replacement_item)
+
+    player = PlayerState(
+        location=start_room, inventory=tuple(dict.fromkeys(opening_inventory)), flags={"started": True}
+    )
     world = WorldState(rooms=rooms, items=items, npcs=npcs)
 
     state = GameState(
@@ -157,7 +197,7 @@ def build_default_state(
         plot_curve_id=package["curve_id"],
         story_outline_id=package["outline"]["id"],
         world_package=package,
-        active_goal=package["goals"]["primary"],
+        active_goal=str(package["goals"].get("setup", package["goals"]["primary"])),
     )
     initialize_world_facts(state)
     sync_legacy_views(state)

--- a/storygame/engine/world_builder.py
+++ b/storygame/engine/world_builder.py
@@ -59,6 +59,18 @@ _ITEM_TEMPLATES: dict[str, tuple[str, ...]] = {
     "thriller": ("cipher_sheet", "surveillance_tape", "access_chip"),
 }
 
+_DEFAULT_SETUP_OBJECTIVES: dict[str, str] = {
+    "mystery": "Review the case file, question your first witness, and identify the strongest lead.",
+    "thriller": "Stabilize the situation, verify your intel, and secure the first trustworthy contact.",
+    "horror": "Survey the immediate threat, gather protective tools, and establish a safe next move.",
+}
+
+_DEFAULT_PRIMARY_OBJECTIVES: dict[str, str] = {
+    "mystery": "Uncover who is behind the case and why the truth was buried.",
+    "thriller": "Expose the operation driving the crisis and stop it before escalation.",
+    "horror": "Understand what is haunting the situation and break its hold before it spreads.",
+}
+
 
 def _clean_outline_sentence(outline_text: str) -> str:
     text = outline_text.strip()
@@ -68,31 +80,175 @@ def _clean_outline_sentence(outline_text: str) -> str:
     return sentence
 
 
-def _primary_goal_for_genre(genre: str, outline_text: str) -> str:
-    seed_sentence = _clean_outline_sentence(outline_text)
-    if genre == "mystery":
-        return "Map the relay route and expose the conspiracy behind the case."
-    if genre == "thriller":
-        return "Identify the central threat and stop the final operation before the deadline."
-    if genre == "horror":
-        return "Survive the escalating threat and break the source of the haunting."
-    if genre == "romance":
-        return "Navigate the relationship conflict and secure an earned reunion."
-    if genre == "fantasy":
-        return "Resolve the prophecy conflict and prevent the realm from falling into chaos."
-    if genre == "action":
-        return "Disrupt the hostile plan and win the final confrontation."
-    if genre == "adventure":
-        return "Complete the expedition and return with decisive proof."
-    if genre == "sci-fi":
-        return "Resolve the technology crisis and choose a future the world can live with."
-    if genre == "suspense":
-        return "Stay ahead of the threat and survive long enough to expose the truth."
-    if genre == "drama":
-        return "Resolve the central personal conflict and face its consequences honestly."
-    if seed_sentence:
-        return seed_sentence
-    return f"Resolve the central conflict in this {genre} scenario."
+def _trim_goal_fragment(text: str, max_len: int = 120) -> str:
+    normalized = re.sub(r"\s+", " ", text).strip(" .,:;-")
+    if len(normalized) <= max_len:
+        return normalized
+    shortened = normalized[:max_len].rsplit(" ", 1)[0].strip()
+    return shortened if shortened else normalized[:max_len]
+
+
+def _sanitize_goal_anchor(anchor: str) -> str:
+    cleaned = _trim_goal_fragment(anchor, max_len=140)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip(" .,:;-")
+    cleaned = re.sub(r"\b(is|was|are|were)\s+tasked\s+with$", "", cleaned, flags=re.IGNORECASE).strip(" ,;:-")
+    cleaned = re.sub(r"\b(tasked|assigned|ordered|forced)\s+to$", "", cleaned, flags=re.IGNORECASE).strip(" ,;:-")
+    return cleaned
+
+
+def _anchor_is_non_actionable(anchor: str) -> bool:
+    lowered = anchor.lower().strip()
+    if not lowered:
+        return True
+    if "is tasked with" in lowered or "are tasked with" in lowered:
+        return True
+    if lowered.startswith(("a detective", "an investigator", "you, a detective", "you are a detective")):
+        return True
+    if lowered.endswith(("tasked with", "assigned to", "ordered to", "forced to")):
+        return True
+    return False
+
+
+def _outline_fragments(outline_text: str) -> list[str]:
+    fragments: list[str] = []
+    for raw_line in outline_text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        lowered = line.lower()
+        for prefix in ("premise:", "outline:", "scene:", "characters:"):
+            if lowered.startswith(prefix):
+                line = line[len(prefix) :].strip()
+                break
+        if not line:
+            continue
+        parts = re.split(r"[.!?]\s+", line)
+        for part in parts:
+            cleaned = _trim_goal_fragment(part, max_len=140)
+            if len(cleaned) < 20:
+                continue
+            if cleaned not in fragments:
+                fragments.append(cleaned)
+            if len(fragments) >= 6:
+                return fragments
+    return fragments
+
+
+def _build_outline_goals(genre: str, outline_text: str, beat_candidates: list[str]) -> dict[str, Any]:
+    fragments = _outline_fragments(outline_text)
+    anchor = fragments[0] if fragments else _clean_outline_sentence(outline_text)
+    anchor = _sanitize_goal_anchor(anchor)
+    use_anchor = not _anchor_is_non_actionable(anchor)
+
+    if use_anchor:
+        setup = f"Get oriented and secure your first reliable lead: {anchor}."
+        primary = f"Define and confront the core conflict: {anchor}."
+    else:
+        setup = _DEFAULT_SETUP_OBJECTIVES.get(
+            genre,
+            "Survey the situation, confirm your first lead, and choose a concrete next action.",
+        )
+        primary = _DEFAULT_PRIMARY_OBJECTIVES.get(
+            genre,
+            f"Define and confront the core conflict in this {genre} scenario.",
+        )
+
+    secondary: list[str] = []
+    for fragment in fragments[1:3]:
+        secondary.append(f"Pursue this emerging thread: {fragment}.")
+    for moment in beat_candidates:
+        if len(secondary) >= 3:
+            break
+        secondary.append(f"Reach beat: {moment}")
+
+    return {"setup": setup, "primary": primary, "secondary": secondary[:3]}
+
+
+def _select_protagonist_name(seed: int, genre: str) -> str:
+    names = (
+        "Rowan Vale",
+        "Mara Quinn",
+        "Elias Ward",
+        "Sable Mercer",
+        "Noah Kade",
+        "Iris Holloway",
+    )
+    return names[_stable_hash(f"{genre}|{seed}|protagonist") % len(names)]
+
+
+def _split_setup_and_future_threads(outline_text: str) -> tuple[str, tuple[str, ...]]:
+    normalized = _trim_goal_fragment(_clean_outline_sentence(outline_text), max_len=420)
+    if not normalized:
+        return "", ()
+
+    spoiler_markers = (
+        " that leads ",
+        " which leads ",
+        " leading to ",
+        " and a choice ",
+        " and must choose ",
+        " where they must choose ",
+    )
+    lowered = normalized.lower()
+    split_index = -1
+    for marker in spoiler_markers:
+        idx = lowered.find(marker)
+        if idx >= 0 and (split_index < 0 or idx < split_index):
+            split_index = idx
+
+    if split_index < 0:
+        return normalized, ()
+
+    public_setup = normalized[:split_index].strip(" ,;")
+    hidden_text = _trim_goal_fragment(normalized[split_index:].strip(" ,;"), max_len=420)
+    return public_setup, (hidden_text,) if hidden_text else ()
+
+
+def _public_setting_line(genre: str) -> str:
+    settings = {
+        "mystery": "The estate stands at the edge of a rain-soaked district where every visitor brings a new rumor.",
+        "thriller": "The residence overlooks a restless city perimeter where patrol lights never fully go dark.",
+        "horror": "The house sits beyond a fog-bound road where the wind carries sounds that never resolve.",
+        "fantasy": "The manor rises above old stone paths and watchfires that mark the border of a fragile realm.",
+    }
+    return settings.get(
+        genre,
+        "The residence is isolated from the nearest town, with only a narrow road and uncertain weather beyond it.",
+    )
+
+
+def _build_story_plan(genre: str, seed: int, outline_text: str, goals: dict[str, Any]) -> dict[str, Any]:
+    protagonist_name = _select_protagonist_name(seed, genre)
+    public_setup, hidden_threads = _split_setup_and_future_threads(outline_text)
+    if not public_setup:
+        public_setup = _trim_goal_fragment(
+            str(goals["setup"]).replace("Get oriented and secure your first reliable lead: ", "")
+        )
+
+    setup_paragraphs = [
+        (
+            f"{protagonist_name} has kept a low profile for years, taking only the work that can be handled in silence. "
+            f"{public_setup}."
+        ),
+        _public_setting_line(genre),
+        f"The first practical objective is simple and immediate: {goals['setup']}",
+        "What this case truly means is still hidden; the larger truths should surface only as the investigation advances.",
+    ]
+
+    reveal_schedule = tuple(
+        {
+            "thread_index": index,
+            "min_progress": round(0.55 + (0.2 * index), 2),
+        }
+        for index in range(len(hidden_threads))
+    )
+
+    return {
+        "protagonist_name": protagonist_name,
+        "setup_paragraphs": tuple(setup_paragraphs),
+        "hidden_threads": hidden_threads,
+        "reveal_schedule": reveal_schedule,
+    }
 
 
 def _story_outlines_path() -> Path:
@@ -155,10 +311,20 @@ def _stable_hash(text: str) -> int:
 
 def _extract_character_names(outline_text: str) -> list[str]:
     names: list[str] = []
+    ignored_labels = {
+        "premise",
+        "settings",
+        "characters",
+        "outline",
+        "scene",
+        "situation",
+    }
     for line in outline_text.splitlines():
-        match = re.match(r"^([A-Z][A-Za-z .'-]{1,60}):\\s", line.strip())
+        match = re.match(r"^([A-Z][A-Za-z .'-]{1,60}):\s", line.strip())
         if match:
             candidate = match.group(1).strip()
+            if candidate.lower() in ignored_labels:
+                continue
             if candidate not in names:
                 names.append(candidate)
         if len(names) >= 8:
@@ -227,9 +393,10 @@ def build_world_package(
     character_names = _extract_character_names(outline["outline"])
     map_section = _build_map_for_genre(normalized_genre)
     item_ids = list(_ITEM_TEMPLATES[normalized_genre])
-    primary_goal = _primary_goal_for_genre(normalized_genre, str(outline["outline"]))
-
     beat_candidates = list(curve["obligatory_moments"])
+    goals = _build_outline_goals(normalized_genre, str(outline["outline"]), beat_candidates)
+    story_plan = _build_story_plan(normalized_genre, seed, str(outline["outline"]), goals)
+
     trigger_seeds = [
         {"name": moment, "trigger": f"beat:{moment}", "effect": "advance_tension"}
         for moment in curve["obligatory_moments"]
@@ -255,10 +422,8 @@ def build_world_package(
             "factions": [f"{normalized_genre}_faction"],
         },
         "map": map_section,
-        "goals": {
-            "primary": primary_goal,
-            "secondary": [f"Reach beat: {moment}" for moment in beat_candidates[:3]],
-        },
+        "goals": goals,
+        "story_plan": story_plan,
         "beat_candidates": beat_candidates,
         "item_graph": {
             "items": item_ids,

--- a/storygame/llm/coherence.py
+++ b/storygame/llm/coherence.py
@@ -13,6 +13,7 @@ from storygame.llm.contracts import (
     CritiqueReport,
     JudgeDecision,
     RevisionDirective,
+    ScoreVector,
     narration_to_agent_proposal,
     parse_critique_report,
     parse_judge_decision,
@@ -101,7 +102,7 @@ def _token_count(text: str) -> int:
     return len(re.findall(r"\S+", text))
 
 
-def _base_dimension_scores(context: NarrationContext, narration: str) -> dict[str, int]:
+def _base_dimension_scores(context: NarrationContext, narration: str) -> ScoreVector:
     narration_tokens = _token_set(narration)
     goal_tokens = {token for token in _token_set(context.goal) if len(token) >= 5}
     event_tokens: set[str] = set()
@@ -135,10 +136,13 @@ def _base_dimension_scores(context: NarrationContext, narration: str) -> dict[st
     if in_length_band:
         dialogue_fit += 20
 
+    continuity_score = max(0, min(100, continuity))
+    causality_score = max(0, min(100, causality))
+    dialogue_fit_score = max(0, min(100, dialogue_fit))
     return {
-        "continuity": max(0, min(100, continuity)),
-        "causality": max(0, min(100, causality)),
-        "dialogue_fit": max(0, min(100, dialogue_fit)),
+        "continuity": continuity_score,
+        "causality": causality_score,
+        "dialogue_fit": dialogue_fit_score,
     }
 
 
@@ -148,10 +152,16 @@ def _feedback_for_dimension(dimension: str, score: int) -> str:
     if score >= 70:
         return f"{dimension} is acceptable but can tighten references."
     if dimension == "continuity":
-        return "Reference room facts, recent events, and active goal more explicitly."
+        return (
+            "Reference room facts, recent events, and active goal explicitly; keep who/where/objective clear and "
+            "avoid revealing unrevealed twists."
+        )
     if dimension == "causality":
-        return "Use explicit causal links (for example: because/after) tied to the prior event."
-    return "Make dialogue more direct and grounded in the player's action."
+        return "Use explicit causal links (for example: because/after) tied to the prior event and action."
+    return (
+        "Make dialogue more direct and grounded in the player's action, then place NPC/background interaction after "
+        "room/exits context."
+    )
 
 
 class _DefaultCritic:
@@ -195,13 +205,13 @@ class _EntityReachabilityValidator:
                 if npc_name:
                     labels.append(npc_name)
                 npc_labels[npc_id] = tuple(dict.fromkeys(label for label in labels if label))
-        for npc_id, labels in npc_labels.items():
+        for npc_id, known_labels in npc_labels.items():
             if npc_id in visible_npcs:
                 continue
-            if not labels:
+            if not known_labels:
                 continue
             presence_claims: list[str] = []
-            for label in labels:
+            for label in known_labels:
                 presence_claims.extend(
                     (
                         f"{label} is here",
@@ -395,9 +405,15 @@ def _revision_directive(reports: tuple[CritiqueReport, ...], decision: JudgeDeci
     if lowest == "causality":
         focus = "mention causality and dialogue with explicit links to prior events"
     elif lowest == "continuity":
-        focus = "mention continuity anchors from room facts and recent events"
+        focus = (
+            "mention continuity anchors from room facts and recent events; keep who/where/objective explicit; "
+            "do not reveal later twists early"
+        )
     else:
-        focus = "mention causality and dialogue while staying tied to the current goal"
+        focus = (
+            "mention causality and dialogue while staying tied to the current goal, and preserve room->items->exits->"
+            "npc/background ordering"
+        )
     notes = " | ".join(feedbacks[:2])[:140]
     payload = {
         "directive_id": f"rev-round-{decision['round_index']}",

--- a/storygame/llm/output_editor.py
+++ b/storygame/llm/output_editor.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Protocol
+
+
+class OutputEditor(Protocol):
+    def review_opening(self, lines: list[str], active_goal: str) -> list[str]: ...
+
+    def review_turn(self, lines: list[str], active_goal: str, turn_index: int, debug: bool = False) -> list[str]: ...
+
+
+class DeterministicOutputEditor:
+    _OPENING_DROP_PREFIXES = (
+        "where you are:",
+        "cast:",
+        "immediate objective:",
+    )
+    _OPENING_DROP_CONTAINS = (
+        "neutral mystery scene",
+        "move the story toward resolution",
+    )
+    _OPENING_ROOM_BLOCK_PREFIXES = (
+        "you can see ",
+        "the only exit is ",
+        "exits lead ",
+    )
+
+    def review_opening(self, lines: list[str], active_goal: str) -> list[str]:
+        edited: list[str] = []
+        seen: set[str] = set()
+        for raw in lines:
+            line = " ".join(raw.split()).strip()
+            if not line:
+                continue
+            lowered = line.lower()
+            if any(lowered.startswith(prefix) for prefix in self._OPENING_DROP_PREFIXES):
+                continue
+            if any(fragment in lowered for fragment in self._OPENING_DROP_CONTAINS):
+                continue
+            if any(lowered.startswith(prefix) for prefix in self._OPENING_ROOM_BLOCK_PREFIXES):
+                continue
+            if lowered in seen:
+                continue
+            seen.add(lowered)
+            edited.append(line)
+        return edited[:4]
+
+    def review_turn(self, lines: list[str], active_goal: str, turn_index: int, debug: bool = False) -> list[str]:
+        if debug or not lines:
+            return lines
+
+        if turn_index <= 1:
+            return [line for line in lines if line]
+
+        filtered: list[str] = [lines[0]]
+        goal_text = active_goal.strip().lower()
+        for line in lines[1:]:
+            if goal_text and goal_text in line.lower():
+                continue
+            filtered.append(line)
+        return [line for line in filtered if line]
+
+
+class OpenAIOutputEditor:
+    def __init__(self, fallback: OutputEditor | None = None) -> None:
+        self._fallback = DeterministicOutputEditor() if fallback is None else fallback
+        self._api_key = os.getenv("OPENAI_API_KEY", "")
+        self._base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1/chat/completions")
+        self._model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+        self._timeout = float(os.getenv("OPENAI_TIMEOUT", "10.0"))
+
+    def review_opening(self, lines: list[str], active_goal: str) -> list[str]:
+        return self._review_with_llm(lines, active_goal, opening=True)
+
+    def review_turn(self, lines: list[str], active_goal: str, turn_index: int, debug: bool = False) -> list[str]:
+        if debug:
+            return lines
+        return self._review_with_llm(lines, active_goal, opening=False)
+
+    def _review_with_llm(self, lines: list[str], active_goal: str, opening: bool) -> list[str]:
+        if not self._api_key:
+            return self._fallback.review_opening(lines, active_goal) if opening else self._fallback.review_turn(lines, active_goal, 2)
+
+        system = (
+            "You are a strict fiction output editor. Rewrite minimally and return JSON only: "
+            "{\"lines\": [\"...\"]}. Do not invent facts. Remove awkward repetition."
+        )
+        if opening:
+            instruction = (
+                "Opening scene rules: exactly 3-4 paragraphs; no room-block format lines; no meta wording; "
+                "natural prose and second-person framing where needed."
+            )
+        else:
+            instruction = (
+                "Turn rules: keep room block as provided first; avoid repeating full game goals unless naturally prompted."
+            )
+        user = json.dumps({"instruction": instruction, "active_goal": active_goal, "lines": lines}, ensure_ascii=True)
+        request = {
+            "model": self._model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "temperature": 0.0,
+            "max_tokens": 512,
+        }
+        http_request = urllib.request.Request(
+            self._base_url,
+            data=json.dumps(request).encode("utf-8"),
+            method="POST",
+            headers={"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(http_request, timeout=self._timeout) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+                content = str(payload["choices"][0]["message"]["content"]).strip()
+                parsed = json.loads(content)
+                reviewed = [str(line).strip() for line in parsed.get("lines", []) if str(line).strip()]
+                if reviewed:
+                    return reviewed[:4] if opening else reviewed
+        except Exception:  # noqa: BLE001
+            pass
+        return self._fallback.review_opening(lines, active_goal) if opening else self._fallback.review_turn(lines, active_goal, 2)
+
+
+class OllamaOutputEditor:
+    def __init__(self, fallback: OutputEditor | None = None) -> None:
+        self._fallback = DeterministicOutputEditor() if fallback is None else fallback
+        self._base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/api/chat")
+        self._model = os.getenv("OLLAMA_MODEL", "llama3.2")
+        self._timeout = float(os.getenv("OLLAMA_TIMEOUT", "180.0"))
+
+    def review_opening(self, lines: list[str], active_goal: str) -> list[str]:
+        return self._review_with_llm(lines, active_goal, opening=True)
+
+    def review_turn(self, lines: list[str], active_goal: str, turn_index: int, debug: bool = False) -> list[str]:
+        if debug:
+            return lines
+        return self._review_with_llm(lines, active_goal, opening=False)
+
+    def _review_with_llm(self, lines: list[str], active_goal: str, opening: bool) -> list[str]:
+        instruction = (
+            "Opening scene: return 3-4 polished paragraphs only."
+            if opening
+            else "Turn output: keep room block first and reduce repetitive goal reminders."
+        )
+        request = {
+            "model": self._model,
+            "messages": [
+                {"role": "system", "content": "Strict fiction editor. Return JSON only with key 'lines'."},
+                {
+                    "role": "user",
+                    "content": json.dumps(
+                        {"instruction": instruction, "active_goal": active_goal, "lines": lines},
+                        ensure_ascii=True,
+                    ),
+                },
+            ],
+            "stream": False,
+            "options": {"temperature": 0.0, "num_predict": 512},
+        }
+        http_request = urllib.request.Request(
+            self._base_url,
+            data=json.dumps(request).encode("utf-8"),
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(http_request, timeout=self._timeout) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+                content = ""
+                if "message" in payload and "content" in payload["message"]:
+                    content = str(payload["message"]["content"]).strip()
+                elif "response" in payload:
+                    content = str(payload["response"]).strip()
+                if content:
+                    parsed = json.loads(content)
+                    reviewed = [str(line).strip() for line in parsed.get("lines", []) if str(line).strip()]
+                    if reviewed:
+                        return reviewed[:4] if opening else reviewed
+        except Exception:  # noqa: BLE001
+            pass
+        return self._fallback.review_opening(lines, active_goal) if opening else self._fallback.review_turn(lines, active_goal, 2)
+
+
+def build_output_editor(mode: str) -> OutputEditor:
+    if mode == "openai":
+        return OpenAIOutputEditor()
+    if mode == "ollama":
+        return OllamaOutputEditor()
+    return DeterministicOutputEditor()

--- a/storygame/llm/prompts.py
+++ b/storygame/llm/prompts.py
@@ -7,6 +7,11 @@ SYSTEM_CONSTRAINTS = (
     "Never mention details not present in the context slice.",
     "Do not change world state or output commands.",
     "Never use memory fragments to override engine facts.",
+    "Opening scene (turn 0 only): write 3-4 paragraphs.",
+    "Opening scene must establish who the player is, where they are, and the immediate objective.",
+    "Opening scene should use concrete sensory details and atmosphere grounded in known context.",
+    "Turn format after opening: room name, room description, items naturally in prose, exits, then NPC interactions or background events.",
+    "Spoiler discipline: do not reveal later twists early.",
 )
 
 

--- a/storygame/llm/story_agents/__init__.py
+++ b/storygame/llm/story_agents/__init__.py
@@ -1,0 +1,43 @@
+from storygame.llm.story_agents.agents import (
+    CharacterDesignerAgent,
+    DefaultCharacterDesignerAgent,
+    DefaultNarratorOpeningAgent,
+    DefaultPlotDesignerAgent,
+    DefaultStoryArchitectAgent,
+    NarratorOpeningAgent,
+    PlotDesignerAgent,
+    StoryArchitectAgent,
+)
+from storygame.llm.story_agents.contracts import (
+    StoryAgentContractError,
+    parse_character_designer_output,
+    parse_narrator_opening_output,
+    parse_plot_designer_output,
+    parse_story_architect_output,
+)
+from storygame.llm.story_agents.prompts import (
+    build_character_designer_prompt,
+    build_narrator_opening_prompt,
+    build_plot_designer_prompt,
+    build_story_architect_prompt,
+)
+
+__all__ = [
+    "StoryArchitectAgent",
+    "CharacterDesignerAgent",
+    "PlotDesignerAgent",
+    "NarratorOpeningAgent",
+    "DefaultStoryArchitectAgent",
+    "DefaultCharacterDesignerAgent",
+    "DefaultPlotDesignerAgent",
+    "DefaultNarratorOpeningAgent",
+    "StoryAgentContractError",
+    "parse_story_architect_output",
+    "parse_character_designer_output",
+    "parse_plot_designer_output",
+    "parse_narrator_opening_output",
+    "build_story_architect_prompt",
+    "build_character_designer_prompt",
+    "build_plot_designer_prompt",
+    "build_narrator_opening_prompt",
+]

--- a/storygame/llm/story_agents/agents.py
+++ b/storygame/llm/story_agents/agents.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.request
+from typing import Any, Protocol
+
+from storygame.engine.state import GameState
+from storygame.llm.story_agents.contracts import (
+    StoryAgentContractError,
+    parse_character_designer_output,
+    parse_narrator_opening_output,
+    parse_plot_designer_output,
+    parse_story_architect_output,
+)
+from storygame.llm.story_agents.prompts import (
+    build_character_designer_prompt,
+    build_narrator_opening_prompt,
+    build_plot_designer_prompt,
+    build_story_architect_prompt,
+)
+
+
+def _json_from_text(text: str) -> dict[str, Any] | None:
+    try:
+        return json.loads(text)
+    except Exception:
+        pass
+    match = re.search(r"\{.*\}", text, flags=re.DOTALL)
+    if not match:
+        return None
+    try:
+        return json.loads(match.group(0))
+    except Exception:
+        return None
+
+
+def _chat_complete(mode: str, system: str, user: str) -> str:
+    if mode == "openai":
+        api_key = os.getenv("OPENAI_API_KEY", "")
+        if not api_key:
+            return ""
+        base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1/chat/completions")
+        model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+        timeout = float(os.getenv("OPENAI_TIMEOUT", "10.0"))
+        request = {
+            "model": model,
+            "messages": [{"role": "system", "content": system}, {"role": "user", "content": user}],
+            "temperature": 0.2,
+            "max_tokens": 900,
+        }
+        http_request = urllib.request.Request(
+            base_url,
+            data=json.dumps(request).encode("utf-8"),
+            method="POST",
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(http_request, timeout=timeout) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            return str(payload["choices"][0]["message"]["content"]).strip()
+        except Exception:
+            return ""
+
+    if mode == "ollama":
+        base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/api/chat")
+        model = os.getenv("OLLAMA_MODEL", "llama3.2")
+        timeout = float(os.getenv("OLLAMA_TIMEOUT", "180.0"))
+        request = {
+            "model": model,
+            "messages": [{"role": "system", "content": system}, {"role": "user", "content": user}],
+            "stream": False,
+            "options": {"temperature": 0.2, "num_predict": 900},
+        }
+        http_request = urllib.request.Request(
+            base_url,
+            data=json.dumps(request).encode("utf-8"),
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(http_request, timeout=timeout) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            if "message" in payload and "content" in payload["message"]:
+                return str(payload["message"]["content"]).strip()
+            if "response" in payload:
+                return str(payload["response"]).strip()
+            return ""
+        except Exception:
+            return ""
+    return ""
+
+
+def _summary_premise(state: GameState) -> str:
+    source_text = str(state.world_package.get("outline", {}).get("source_text", "")).strip()
+    premise = source_text.splitlines()[0].strip() if source_text else ""
+    if premise.lower().startswith("premise:"):
+        premise = premise[len("premise:") :].strip()
+    if premise.lower().startswith("situation:"):
+        premise = premise[len("situation:") :].strip()
+    premise = re.sub(
+        r"\b(that leads|which leads|leading to|and a choice between|and must choose).*$",
+        "",
+        premise,
+        flags=re.IGNORECASE,
+    ).strip(" ,;.")
+    return premise
+
+
+class StoryArchitectAgent(Protocol):
+    def run(self, state: GameState) -> dict[str, Any]: ...
+
+
+class CharacterDesignerAgent(Protocol):
+    def run(self, state: GameState, architect: dict[str, Any]) -> dict[str, Any]: ...
+
+
+class PlotDesignerAgent(Protocol):
+    def run(self, state: GameState, architect: dict[str, Any], cast: dict[str, Any]) -> dict[str, Any]: ...
+
+
+class NarratorOpeningAgent(Protocol):
+    def run(self, state: GameState, architect: dict[str, Any], cast: dict[str, Any], plan: dict[str, Any]) -> list[str]: ...
+
+
+class DefaultStoryArchitectAgent:
+    def __init__(self, mode: str) -> None:
+        self._mode = mode
+
+    def run(self, state: GameState) -> dict[str, Any]:
+        premise = _summary_premise(state)
+        protagonist = str(state.world_package.get("story_plan", {}).get("protagonist_name", "")).strip() or "The Detective"
+        fallback = {
+            "protagonist_name": protagonist,
+            "protagonist_background": premise or "A detective with a bruised record has taken one more case.",
+            "secrets_to_hide": list(state.world_package.get("story_plan", {}).get("hidden_threads", ())),
+            "tone": state.story_tone,
+        }
+        if self._mode not in {"openai", "ollama"}:
+            return fallback
+        system, user = build_story_architect_prompt(premise, protagonist, state.story_genre, state.story_tone)
+        payload = _json_from_text(_chat_complete(self._mode, system, user))
+        if payload is None:
+            return fallback
+        try:
+            parsed = parse_story_architect_output(payload)
+        except StoryAgentContractError:
+            return fallback
+        return dict(parsed)
+
+
+class DefaultCharacterDesignerAgent:
+    def __init__(self, mode: str) -> None:
+        self._mode = mode
+
+    def run(self, state: GameState, architect: dict[str, Any]) -> dict[str, Any]:
+        contacts: list[dict[str, str]] = []
+        for room in state.world.rooms.values():
+            for npc_id in room.npc_ids:
+                npc = state.world.npcs.get(npc_id)
+                if not npc:
+                    continue
+                contacts.append({"name": npc.name, "role": "assistant" if not contacts else "contact", "trait": "observant"})
+        if not contacts:
+            contacts = [{"name": "Mina Cole", "role": "assistant", "trait": "steady"}]
+        fallback = {"contacts": contacts[:3]}
+        if self._mode not in {"openai", "ollama"}:
+            return fallback
+        system, user = build_character_designer_prompt(str(architect.get("protagonist_name", "")), contacts)
+        payload = _json_from_text(_chat_complete(self._mode, system, user))
+        if payload is None:
+            return fallback
+        try:
+            parsed = parse_character_designer_output(payload)
+        except StoryAgentContractError:
+            return fallback
+        return {"contacts": parsed["contacts"][:3] or contacts[:3]}
+
+
+class DefaultPlotDesignerAgent:
+    def __init__(self, mode: str) -> None:
+        self._mode = mode
+
+    def run(self, state: GameState, architect: dict[str, Any], cast: dict[str, Any]) -> dict[str, Any]:
+        goal = state.active_goal
+        contacts = cast.get("contacts", [])
+        assistant = contacts[0]["name"] if contacts else ""
+        actionable = goal
+        if goal.lower().startswith("get oriented and secure your first reliable lead"):
+            actionable = "Review the case file and field kit, then choose the first person or place to investigate."
+        fallback = {"assistant_name": assistant or "Assistant", "actionable_objective": actionable}
+        if self._mode not in {"openai", "ollama"}:
+            return fallback
+        system, user = build_plot_designer_prompt(goal, fallback["assistant_name"])
+        payload = _json_from_text(_chat_complete(self._mode, system, user))
+        if payload is None:
+            return fallback
+        try:
+            parsed = parse_plot_designer_output(payload)
+        except StoryAgentContractError:
+            return fallback
+        return dict(parsed)
+
+
+class DefaultNarratorOpeningAgent:
+    def __init__(self, mode: str) -> None:
+        self._mode = mode
+
+    def run(self, state: GameState, architect: dict[str, Any], cast: dict[str, Any], plan: dict[str, Any]) -> list[str]:
+        room = state.world.rooms[state.player.location]
+        protagonist = str(architect.get("protagonist_name", "")).strip() or "the detective"
+        background = str(architect.get("protagonist_background", "")).strip()
+        contacts = cast.get("contacts", [])
+        assistant_name = str(plan.get("assistant_name", "")).strip()
+        assistant_trait = str(contacts[0].get("trait", "")).strip() if contacts else ""
+        assistant_role = str(contacts[0].get("role", "")).strip() if contacts else ""
+
+        inventory = [item.replace("_", " ") for item in state.player.inventory]
+        carry_line = "At your side you carry " + ", ".join(f"a {item}" for item in inventory[:2]) + "." if inventory else "Your hands are empty for now."
+        paragraph_1 = (
+            f"The air around the {room.name.lower()} bites with evening cold as damp stone keeps the day's last heat "
+            "and distant traffic thins into rumor."
+        )
+        paragraph_2 = (
+            f"You are {protagonist}. {carry_line} "
+            f"{assistant_name} stays close as your {assistant_role or 'assistant'}, "
+            f"their tone {assistant_trait or 'measured'} while they wait for your first instruction."
+        )
+        paragraph_3 = (
+            f"Your history sits just behind your eyes: {background}"
+            if background
+            else "Your history sits just behind your eyes, unresolved but sharp enough to focus your judgment."
+        )
+        objective = str(plan.get("actionable_objective", state.active_goal)).strip()
+        if assistant_name:
+            paragraph_4 = (
+                f"{assistant_name} breaks the silence. \"Your immediate objective is practical: start with the case file "
+                f"and field kit. {objective}\""
+            )
+        else:
+            paragraph_4 = f"Your immediate objective is practical and immediate: {objective}"
+
+        opening = [paragraph_1, paragraph_2, paragraph_3, paragraph_4]
+        if self._mode in {"openai", "ollama"}:
+            system, user = build_narrator_opening_prompt("\n\n".join(opening))
+            payload = _json_from_text(_chat_complete(self._mode, system, user))
+            if payload is not None:
+                try:
+                    parsed = parse_narrator_opening_output(payload)
+                    opening = parsed["paragraphs"][:4]
+                except StoryAgentContractError:
+                    pass
+        return opening

--- a/storygame/llm/story_agents/contracts.py
+++ b/storygame/llm/story_agents/contracts.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import TypedDict, cast
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+
+class StoryAgentContractError(ValueError):
+    def __init__(self, code: str, detail: str) -> None:
+        super().__init__(f"{code}: {detail}")
+        self.code = code
+        self.detail = detail
+
+
+class CharacterContact(TypedDict):
+    name: str
+    role: str
+    trait: str
+
+
+class StoryArchitectOutput(TypedDict):
+    protagonist_name: str
+    protagonist_background: str
+    secrets_to_hide: list[str]
+    tone: str
+
+
+class CharacterDesignerOutput(TypedDict):
+    contacts: list[CharacterContact]
+
+
+class PlotDesignerOutput(TypedDict):
+    assistant_name: str
+    actionable_objective: str
+
+
+class NarratorOpeningOutput(TypedDict):
+    paragraphs: list[str]
+
+
+class _StoryArchitectModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    protagonist_name: str = Field(min_length=1, max_length=80)
+    protagonist_background: str = Field(min_length=1, max_length=500)
+    secrets_to_hide: list[str] = Field(default_factory=list, max_length=8)
+    tone: str = Field(min_length=1, max_length=40)
+
+
+class _CharacterContactModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=80)
+    role: str = Field(min_length=1, max_length=60)
+    trait: str = Field(min_length=1, max_length=60)
+
+
+class _CharacterDesignerModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    contacts: list[_CharacterContactModel] = Field(min_length=1, max_length=8)
+
+
+class _PlotDesignerModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    assistant_name: str = Field(min_length=1, max_length=80)
+    actionable_objective: str = Field(min_length=1, max_length=300)
+
+
+class _NarratorOpeningModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    paragraphs: list[str] = Field(min_length=3, max_length=4)
+
+
+def _raise_contract_error(code: str, exc: ValidationError) -> StoryAgentContractError:
+    first = exc.errors()[0]
+    location = ".".join(str(chunk) for chunk in first["loc"])
+    return StoryAgentContractError(code, f"{location}:{first['type']}")
+
+
+def parse_story_architect_output(payload: dict) -> StoryArchitectOutput:
+    try:
+        model = _StoryArchitectModel.model_validate(payload)
+    except ValidationError as exc:
+        raise _raise_contract_error("STORY_ARCHITECT_CONTRACT_INVALID", exc) from exc
+    return cast(StoryArchitectOutput, model.model_dump(mode="python"))
+
+
+def parse_character_designer_output(payload: dict) -> CharacterDesignerOutput:
+    try:
+        model = _CharacterDesignerModel.model_validate(payload)
+    except ValidationError as exc:
+        raise _raise_contract_error("CHARACTER_DESIGNER_CONTRACT_INVALID", exc) from exc
+    contacts = model.model_dump(mode="python")["contacts"]
+    invalid_placeholder = {"premise", "scene", "outline", "characters"}
+    for contact in contacts:
+        if contact["name"].strip().lower() in invalid_placeholder:
+            raise StoryAgentContractError("CHARACTER_DESIGNER_CONTRACT_INVALID", "contacts.name:placeholder_label")
+    return cast(CharacterDesignerOutput, {"contacts": contacts})
+
+
+def parse_plot_designer_output(payload: dict) -> PlotDesignerOutput:
+    try:
+        model = _PlotDesignerModel.model_validate(payload)
+    except ValidationError as exc:
+        raise _raise_contract_error("PLOT_DESIGNER_CONTRACT_INVALID", exc) from exc
+    return cast(PlotDesignerOutput, model.model_dump(mode="python"))
+
+
+def parse_narrator_opening_output(payload: dict) -> NarratorOpeningOutput:
+    try:
+        model = _NarratorOpeningModel.model_validate(payload)
+    except ValidationError as exc:
+        raise _raise_contract_error("NARRATOR_OPENING_CONTRACT_INVALID", exc) from exc
+    paragraphs = [paragraph.strip() for paragraph in model.paragraphs if paragraph.strip()]
+    if len(paragraphs) < 3:
+        raise StoryAgentContractError("NARRATOR_OPENING_CONTRACT_INVALID", "paragraphs:min_length")
+    return cast(NarratorOpeningOutput, {"paragraphs": paragraphs[:4]})

--- a/storygame/llm/story_agents/prompts.py
+++ b/storygame/llm/story_agents/prompts.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+
+
+def build_story_architect_prompt(premise: str, protagonist_hint: str, genre: str, tone: str) -> tuple[str, str]:
+    system = (
+        "You are Story Architect Agent. Return JSON only with keys: "
+        "protagonist_name, protagonist_background, secrets_to_hide, tone. "
+        "Keep spoilers out of protagonist_background."
+    )
+    user = json.dumps(
+        {
+            "premise": premise,
+            "protagonist_hint": protagonist_hint,
+            "genre": genre,
+            "tone": tone,
+        },
+        ensure_ascii=True,
+    )
+    return system, user
+
+
+def build_character_designer_prompt(protagonist_name: str, contacts_seed: list[dict]) -> tuple[str, str]:
+    system = (
+        "You are Character Designer Agent. Return JSON only with key contacts, where contacts is a list of "
+        "objects with fields: name, role, trait. Do not use placeholders like Premise/Scene."
+    )
+    user = json.dumps(
+        {
+            "protagonist_name": protagonist_name,
+            "contacts_seed": contacts_seed,
+        },
+        ensure_ascii=True,
+    )
+    return system, user
+
+
+def build_plot_designer_prompt(active_goal: str, assistant_name: str) -> tuple[str, str]:
+    system = (
+        "You are Plot Designer Agent. Return JSON only with keys assistant_name and actionable_objective. "
+        "actionable_objective must be concrete and immediately playable."
+    )
+    user = json.dumps(
+        {
+            "active_goal": active_goal,
+            "assistant_name": assistant_name,
+        },
+        ensure_ascii=True,
+    )
+    return system, user
+
+
+def build_narrator_opening_prompt(opening_draft: str) -> tuple[str, str]:
+    system = (
+        "You are Narrator Agent. Return JSON only with key paragraphs (3 to 4 paragraphs). "
+        "Second person voice, no spoilers, no meta-game phrasing."
+    )
+    user = json.dumps({"opening_draft": opening_draft}, ensure_ascii=True)
+    return system, user

--- a/storygame/llm/story_director.py
+++ b/storygame/llm/story_director.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from storygame.engine.state import Event, GameState
+from storygame.llm.output_editor import OutputEditor, build_output_editor
+from storygame.llm.story_agents.agents import (
+    CharacterDesignerAgent,
+    DefaultCharacterDesignerAgent,
+    DefaultNarratorOpeningAgent,
+    DefaultPlotDesignerAgent,
+    DefaultStoryArchitectAgent,
+    NarratorOpeningAgent,
+    PlotDesignerAgent,
+    StoryArchitectAgent,
+)
+
+
+class StoryDirector:
+    def __init__(
+        self,
+        mode: str,
+        output_editor: OutputEditor | None = None,
+        story_architect: StoryArchitectAgent | None = None,
+        character_designer: CharacterDesignerAgent | None = None,
+        plot_designer: PlotDesignerAgent | None = None,
+        narrator_opening: NarratorOpeningAgent | None = None,
+    ) -> None:
+        self._output_editor = build_output_editor(mode) if output_editor is None else output_editor
+        self._story_architect = DefaultStoryArchitectAgent(mode) if story_architect is None else story_architect
+        self._character_designer = DefaultCharacterDesignerAgent(mode) if character_designer is None else character_designer
+        self._plot_designer = DefaultPlotDesignerAgent(mode) if plot_designer is None else plot_designer
+        self._narrator_opening = DefaultNarratorOpeningAgent(mode) if narrator_opening is None else narrator_opening
+
+    def compose_opening(self, state: GameState) -> list[str]:
+        architect = self._story_architect.run(state)
+        cast = self._character_designer.run(state, architect)
+        plan = self._plot_designer.run(state, architect, cast)
+        opening = self._narrator_opening.run(state, architect, cast, plan)
+        return self._output_editor.review_opening(opening, state.active_goal)
+
+    def review_turn(self, state: GameState, lines: list[str], events: list[Event], debug: bool = False) -> list[str]:
+        event_hint = ""
+        if events:
+            event_hint = " ".join(event.message_key for event in events if event.message_key)[:240]
+        enriched = list(lines)
+        if event_hint and len(enriched) > 0 and event_hint.lower() not in "\n".join(enriched).lower():
+            enriched.append(event_hint)
+        return self._output_editor.review_turn(enriched, state.active_goal, state.turn_index, debug)

--- a/storygame/web.py
+++ b/storygame/web.py
@@ -11,10 +11,12 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
-from storygame.cli import _build_narrator, run_turn
+from storygame.cli import _build_narrator, _setup_phase_lines, run_turn
 from storygame.engine.state import GameState
 from storygame.engine.world import build_default_state
 from storygame.llm.adapters import Narrator
+from storygame.llm.output_editor import build_output_editor
+from storygame.llm.story_director import StoryDirector
 from storygame.persistence.savegame_sqlite import SqliteSaveStore
 from storygame.plot.freytag import get_phase
 
@@ -121,6 +123,8 @@ def create_app(
     sessions: dict[str, _SessionState] = {}
     resolved_narrator_mode = _resolve_narrator_mode(narrator_mode)
     narrator: Narrator = _build_narrator(resolved_narrator_mode)
+    output_editor = build_output_editor(resolved_narrator_mode)
+    story_director = StoryDirector(resolved_narrator_mode, output_editor)
 
     @app.get("/", response_class=HTMLResponse)
     async def index() -> str:
@@ -129,6 +133,7 @@ def create_app(
     @app.post("/turn", response_model=TurnResponse)
     def submit_turn(payload: TurnRequest) -> TurnResponse:
         run_id = payload.run_id
+        session_started = False
         if run_id is not None and run_id in sessions:
             session = sessions[run_id]
         elif run_id is None:
@@ -143,22 +148,56 @@ def create_app(
                 Random(payload.seed),
             )
             sessions[run_id] = session
+            session_started = True
         else:
             raise HTTPException(status_code=404, detail=f"Unknown run_id '{run_id}'.")
 
+        start_state = session.state
+        bootstrap_only = session_started and payload.command.strip().lower() in {"", "look", "start"}
+        if bootstrap_only:
+            room = start_state.world.rooms[start_state.player.location]
+            response_state = StateSnapshot(
+                run_id=run_id,
+                location=start_state.player.location,
+                room_name=room.name,
+                inventory=list(start_state.player.inventory),
+                genre=start_state.story_genre,
+                tone=start_state.story_tone,
+                session_length=start_state.session_length,
+                plot_curve_id=start_state.plot_curve_id,
+                story_outline_id=start_state.story_outline_id,
+                objective=start_state.active_goal,
+                phase=str(get_phase(start_state.progress)),
+                progress=start_state.progress,
+                tension=start_state.tension,
+                turn_index=start_state.turn_index,
+            )
+            return TurnResponse(
+                run_id=run_id,
+                command=payload.command,
+                action_raw=payload.command,
+                beat="setup_scene",
+                continued=True,
+                lines=story_director.compose_opening(start_state),
+                state=response_state,
+            )
+
         scoped_store = _ScopedSaveStore(store, run_id)
         next_state, lines, action_raw, beat_type, continued = run_turn(
-            session.state,
+            start_state,
             payload.command,
             session.rng,
             narrator,
             debug=payload.debug,
             save_store=scoped_store,
             memory_slot=run_id,
+            output_editor=output_editor,
+            story_director=story_director,
         )
 
         room = next_state.world.rooms[next_state.player.location]
         sessions[run_id].state = next_state
+        response_lines = list(lines)
         response_state = StateSnapshot(
             run_id=run_id,
             location=next_state.player.location,
@@ -181,7 +220,7 @@ def create_app(
             action_raw=action_raw,
             beat=beat_type,
             continued=continued,
-            lines=list(lines),
+            lines=response_lines,
             state=response_state,
         )
 
@@ -404,17 +443,33 @@ _WEB_UI_HTML = """<!doctype html>
       });
 
       newGame.addEventListener("click", () => {
+        startNewGame();
+      });
+
+      async function startNewGame() {
         localStorage.removeItem("freytag-run-id");
         runId = null;
         runIdLabel.textContent = "none";
         transcript.textContent = "";
-      });
-
-      if (runId) {
-        runIdLabel.textContent = runId;
+        inventory.textContent = "(empty)";
+        objective.textContent = "-";
+        phase.textContent = "-";
+        tension.textContent = "-";
+        progress.textContent = "-";
+        await turn("look");
       }
 
-      appendLine("Ready. Save/load are available via commands, e.g. save checkpoint / load checkpoint.");
+      async function bootstrap() {
+        if (runId) {
+          runIdLabel.textContent = runId;
+        } else {
+          await startNewGame();
+        }
+
+        appendLine("Ready. Save/load are available via commands, e.g. save checkpoint / load checkpoint.");
+      }
+
+      bootstrap();
     </script>
   </body>
 </html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import urllib.request
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _block_outbound_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _blocked_urlopen(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise RuntimeError("Outbound network is disabled in tests. Mock urllib.request.urlopen in this test.")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _blocked_urlopen)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from storygame.cli import (
     _event_lines,
     _room_distance,
     _room_lines,
+    _setup_phase_lines,
     _signal_hint,
     _write_transcript_line,
     main,
@@ -392,6 +393,94 @@ def test_run_turn_freeform_rejects_unreachable_target_without_fact_updates():
     assert beat_type == "freeform_roleplay"
     assert any("no one here" in line.lower() for line in lines)
     assert next_state.player.flags == initial_flags
+
+
+def test_run_turn_applies_output_editor_before_returning_lines():
+    class _PassThroughEditor:
+        def review_opening(self, lines, active_goal):  # noqa: ANN001
+            return lines
+
+        def review_turn(self, lines, active_goal, turn_index, debug=False):  # noqa: ANN001
+            return [line.replace("Echoes", "Edited echoes") for line in lines]
+
+    state = build_default_state(seed=93)
+    next_state, lines, _action_raw, _beat, continued = run_turn(
+        state,
+        "look",
+        Random(93),
+        SilentNarrator(),
+        output_editor=_PassThroughEditor(),
+    )
+
+    assert continued is True
+    assert next_state.turn_index == 1
+    assert any("edited echoes" in line.lower() for line in lines)
+
+
+def test_setup_phase_lines_include_who_where_and_objective():
+    state = build_default_state(seed=90, genre="fantasy", tone="epic")
+    lines = _setup_phase_lines(state)
+    room = state.world.rooms[state.player.location]
+
+    assert 3 <= len(lines) <= 4
+    assert any(room.name.lower() in paragraph.lower() for paragraph in lines)
+    assert any("objective" in paragraph.lower() for paragraph in lines)
+    assert all(not paragraph.lower().startswith("where you are:") for paragraph in lines)
+    assert all(not paragraph.lower().startswith("cast:") for paragraph in lines)
+    assert all("immediate objective:" not in paragraph.lower() for paragraph in lines)
+    assert all("the only exit is to" not in paragraph.lower() for paragraph in lines)
+    assert any("case file" in paragraph.lower() or state.active_goal in paragraph for paragraph in lines)
+
+
+def test_setup_phase_lines_story_editor_removes_legacy_meta_fragments():
+    state = build_default_state(seed=91, genre="mystery", tone="neutral")
+    lines = _setup_phase_lines(state)
+    joined = "\n".join(lines).lower()
+
+    assert "neutral mystery scene" not in joined
+    assert "move the story toward resolution" not in joined
+    assert "where you are:" not in joined
+    assert "cast:" not in joined
+    assert "tasked with." not in joined
+
+
+def test_setup_phase_lines_place_identity_after_environment_and_use_named_contact():
+    state = build_default_state(seed=123, genre="mystery", tone="dark")
+    lines = _setup_phase_lines(state)
+    assert len(lines) >= 3
+
+    first = lines[0].lower()
+    second = lines[1].lower() if len(lines) > 1 else ""
+    joined = "\n".join(lines).lower()
+
+    assert "you are " not in first
+    assert "you are " in second
+    assert "premise waits nearby" not in joined
+    assert "premise:" not in joined
+
+
+def test_setup_phase_lines_weave_background_and_actionable_objective():
+    state = build_default_state(seed=124, genre="mystery", tone="dark")
+    lines = _setup_phase_lines(state)
+    joined = "\n".join(lines).lower()
+
+    assert "the case in front of you starts simply" not in joined
+    assert "your history" in joined
+    assert "case file" in joined
+    assert "field kit" in joined
+    assert "get oriented and secure your first reliable lead" not in joined
+
+
+def test_main_replay_emits_setup_phase_before_commands(tmp_path):
+    replay = tmp_path / "commands.txt"
+    transcript = tmp_path / "transcript.txt"
+    replay.write_text("look\n", encoding="utf-8")
+
+    main(["--seed", "4", "--replay", str(replay), "--transcript", str(transcript)])
+
+    lines = transcript.read_text(encoding="utf-8").splitlines()
+    command_index = next(i for i, line in enumerate(lines) if line == ">LOOK")
+    assert command_index >= 3
 
 
 def test_save_persists_last_accepted_judge_decision(tmp_path):

--- a/tests/test_coherence_gate.py
+++ b/tests/test_coherence_gate.py
@@ -6,10 +6,12 @@ from storygame.llm.coherence import (
     DEFAULT_THRESHOLD,
     CritiqueReport,
     ValidationReport,
+    _revision_directive,
     build_default_coherence_gate,
     judge_critique_round,
 )
 from storygame.llm.context import NarrationContext
+from storygame.llm.contracts import parse_critique_report
 
 
 def _context(memory_fragments: tuple[str, ...] = ()) -> NarrationContext:
@@ -46,6 +48,15 @@ def test_default_critics_return_all_rubric_dimensions():
     assert len(reports) >= 3
     for report in reports:
         assert set(report["scores"].keys()) == set(CRITIQUE_DIMENSIONS)
+
+
+def test_default_critics_emit_contract_valid_payloads():
+    gate = build_default_coherence_gate()
+    reports = gate.critique_round(_context(), "You ask the guide about the forged directive.")
+
+    for report in reports:
+        parsed = parse_critique_report(dict(report))
+        assert parsed["critic_id"] == report["critic_id"]
 
 
 def test_judge_uses_weighted_rubric_threshold_and_floors():
@@ -283,3 +294,56 @@ def test_validator_rejects_non_visible_npc_presence_claims():
     reports = gate.validate_candidate(context, "The witness is here in the market beside you.")
     reason_codes = {reason for report in reports if not report["passed"] for reason in report["reason_codes"]}
     assert "VLD_NPC_NOT_VISIBLE" in reason_codes
+
+
+def test_validator_rejects_non_visible_npc_name_presence_claims():
+    gate = build_default_coherence_gate()
+    context = NarrationContext(
+        room_name="Salt Market",
+        room_description="Bright awnings and bargaining voices fill the plaza.",
+        visible_items=("route_key",),
+        visible_npcs=(),
+        npc_facts=(
+            {
+                "id": "witness",
+                "name": "Harbor Ferryman",
+                "pronouns": "he/him",
+                "identity": "male dockworker and river guide",
+                "description": "An old witness that knows the tide.",
+                "location": "district",
+            },
+        ),
+        exits=("south", "east"),
+        inventory=("torch",),
+        recent_events=(),
+        phase="rising_action",
+        tension=0.3,
+        beat="progressive_complication",
+        goal="Map the relay route and expose the district conspiracy.",
+        action="look",
+        memory_fragments=(),
+    )
+    reports = gate.validate_candidate(context, "The harbor ferryman stands here in the market beside you.")
+    reason_codes = {reason for report in reports if not report["passed"] for reason in report["reason_codes"]}
+    assert "VLD_NPC_NOT_VISIBLE" in reason_codes
+
+
+def test_revision_directive_for_continuity_includes_setup_and_spoiler_checks():
+    reports: tuple[CritiqueReport, ...] = (
+        {
+            "critic_id": "continuity",
+            "scores": {"continuity": 55, "causality": 82, "dialogue_fit": 80},
+            "feedback": "Continuity needs clearer anchors.",
+        },
+        {
+            "critic_id": "causality",
+            "scores": {"continuity": 60, "causality": 83, "dialogue_fit": 79},
+            "feedback": "Causality is adequate.",
+        },
+    )
+    decision = judge_critique_round(reports, threshold=80, critical_floors=DEFAULT_CRITICAL_FLOORS, round_index=2)
+
+    directive = _revision_directive(reports, decision)
+    instruction = directive["instruction"].lower()
+    assert "who/where/objective" in instruction
+    assert "do not reveal later twists early" in instruction

--- a/tests/test_if_output_contract.py
+++ b/tests/test_if_output_contract.py
@@ -43,6 +43,35 @@ def test_non_debug_output_is_room_first_and_hides_internal_labels():
     assert all(" beat at " not in line.lower() for line in lines)
 
 
+def test_per_turn_room_block_follows_expected_section_order():
+    state = build_default_state(seed=133)
+    room = state.world.rooms[state.player.location]
+    _next_state, lines, _action_raw, _beat, _continued = run_turn(
+        state,
+        "look",
+        Random(133),
+        SilentNarrator(),
+        debug=False,
+    )
+
+    room_block = lines[0].splitlines()
+    assert room_block[0] == room.name
+    assert room.description in room_block[1]
+
+    item_index = next(i for i, line in enumerate(room_block) if "you can see" in line.lower())
+    exit_index = next(i for i, line in enumerate(room_block) if "exit" in line.lower())
+    assert item_index < exit_index
+
+    npc_line_indices = [
+        i for i, line in enumerate(room_block) if " is here." in line.lower() or " are here." in line.lower()
+    ]
+    if npc_line_indices:
+        assert npc_line_indices[0] > exit_index
+
+    assert len(lines) >= 2
+    assert lines[1].strip()
+
+
 def test_unknown_non_command_input_uses_in_world_roleplay_response():
     state = build_default_state(seed=32)
     npc_id = state.world.rooms[state.player.location].npc_ids[0]

--- a/tests/test_output_editor.py
+++ b/tests/test_output_editor.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from storygame.llm.output_editor import DeterministicOutputEditor
+
+
+def test_deterministic_editor_trims_legacy_opening_lines():
+    editor = DeterministicOutputEditor()
+    opening = [
+        "Where you are: Front Steps. A neutral mystery scene.",
+        "Cast: Guide, Rival, Witness",
+        "The air around the front steps bites with cold rain.",
+        "You can see case file and field kit.",
+        "Your immediate objective is clear: Find the first lead.",
+        "The only exit is to the north.",
+    ]
+
+    reviewed = editor.review_opening(opening, "Find the first lead.")
+    joined = "\n".join(reviewed).lower()
+    assert "where you are:" not in joined
+    assert "cast:" not in joined
+    assert "neutral mystery scene" not in joined
+    assert "the only exit is to" not in joined
+    assert len(reviewed) <= 4
+
+
+def test_deterministic_editor_reduces_goal_repetition_after_first_turn():
+    editor = DeterministicOutputEditor()
+    goal = "Find the hidden ledger."
+    turn_lines = [
+        "Archive Room\nDust and records line the shelves.\nYou can see ledger page.\nThe only exit is to the east.\nMina waits here.",
+        "You remind yourself: Find the hidden ledger.",
+        "A distant bell echoes through the hall.",
+    ]
+
+    reviewed = editor.review_turn(turn_lines, goal, turn_index=3, debug=False)
+    assert len(reviewed) == 2
+    assert all(goal.lower() not in line.lower() for line in reviewed[1:])

--- a/tests/test_prompt_snapshots.py
+++ b/tests/test_prompt_snapshots.py
@@ -5,6 +5,7 @@ from storygame.engine.simulation import advance_turn
 from storygame.engine.world import build_default_state
 from storygame.llm.adapters import MockNarrator
 from storygame.llm.context import build_narration_context
+from storygame.llm.prompts import build_prompt
 
 
 def test_mock_narrator_snapshot_output():
@@ -32,3 +33,25 @@ def test_mock_narrator_supports_memory_fragments():
     result = MockNarrator().generate(context)
     assert isinstance(result, str)
     assert "beat at" in result
+
+
+def test_prompt_includes_if_storytelling_quality_checklist():
+    state = build_default_state(seed=2)
+    rng = Random(2)
+    state, _events, beat, _template = advance_turn(state, parse_command("look"), rng)
+    context = build_narration_context(state, parse_command("look"), beat)
+
+    prompt = build_prompt(context)
+    system_text = prompt["system"].lower()
+
+    assert "opening scene (turn 0 only)" in system_text
+    assert "3-4 paragraphs" in system_text
+    assert "who the player is" in system_text
+    assert "where they are" in system_text
+    assert "immediate objective" in system_text
+    assert "room name" in system_text
+    assert "room description" in system_text
+    assert "items naturally" in system_text
+    assert "exits" in system_text
+    assert "npc interactions or background events" in system_text
+    assert "do not reveal later twists early" in system_text

--- a/tests/test_story_agent_contracts.py
+++ b/tests/test_story_agent_contracts.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+from storygame.llm.story_agents.contracts import (
+    StoryAgentContractError,
+    parse_character_designer_output,
+    parse_narrator_opening_output,
+    parse_plot_designer_output,
+    parse_story_architect_output,
+)
+from storygame.llm.story_agents.prompts import (
+    build_character_designer_prompt,
+    build_narrator_opening_prompt,
+    build_plot_designer_prompt,
+    build_story_architect_prompt,
+)
+
+
+def test_story_agent_contracts_accept_valid_payloads():
+    architect = parse_story_architect_output(
+        {
+            "protagonist_name": "Noah Kade",
+            "protagonist_background": "A detective returning for one last case.",
+            "secrets_to_hide": ["late reveal 1"],
+            "tone": "dark",
+        }
+    )
+    cast = parse_character_designer_output(
+        {"contacts": [{"name": "Mina Cole", "role": "assistant", "trait": "observant"}]}
+    )
+    plot = parse_plot_designer_output(
+        {"assistant_name": "Mina Cole", "actionable_objective": "Review the case file and pick first lead."}
+    )
+    opening = parse_narrator_opening_output(
+        {"paragraphs": ["p1", "p2", "p3"]}
+    )
+
+    assert architect["protagonist_name"] == "Noah Kade"
+    assert cast["contacts"][0]["name"] == "Mina Cole"
+    assert plot["assistant_name"] == "Mina Cole"
+    assert len(opening["paragraphs"]) == 3
+
+
+def test_story_agent_contracts_reject_invalid_shapes():
+    with pytest.raises(StoryAgentContractError):
+        parse_story_architect_output({"protagonist_name": "", "tone": "dark"})
+    with pytest.raises(StoryAgentContractError):
+        parse_character_designer_output({"contacts": [{"name": "Premise", "role": "assistant"}]})
+    with pytest.raises(StoryAgentContractError):
+        parse_plot_designer_output({"assistant_name": "", "actionable_objective": ""})
+    with pytest.raises(StoryAgentContractError):
+        parse_narrator_opening_output({"paragraphs": ["only one"]})
+
+
+def test_story_agent_prompts_contain_contract_and_json_instruction():
+    system, user = build_story_architect_prompt("A detective returns.", "Noah", "mystery", "dark")
+    assert "json only" in system.lower()
+    assert "protagonist_name" in system
+    assert "premise" in user.lower()
+
+    system, _user = build_character_designer_prompt("Noah", [{"name": "Mina"}])
+    assert "contacts" in system
+
+    system, _user = build_plot_designer_prompt("Goal", "Mina")
+    assert "actionable_objective" in system
+
+    system, _user = build_narrator_opening_prompt("draft")
+    assert "paragraphs" in system

--- a/tests/test_story_coherence.py
+++ b/tests/test_story_coherence.py
@@ -64,7 +64,8 @@ def test_story_goal_is_specific_and_not_just_follow_bell_signal():
 
     goal = state.active_goal.lower()
     assert "bell signal" not in goal
-    assert "threat" in goal
+    assert "get oriented" in goal
+    assert len(goal) > 40
 
 
 def test_npcs_do_not_follow_player_between_rooms_without_trigger():

--- a/tests/test_story_director_orchestration.py
+++ b/tests/test_story_director_orchestration.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from storygame.engine.state import Event
+from storygame.engine.world import build_default_state
+from storygame.llm.story_director import StoryDirector
+
+
+class _StubArchitect:
+    def run(self, state):  # noqa: ANN001
+        return {"protagonist_name": "Stub Protagonist"}
+
+
+class _StubCharacter:
+    def run(self, state, architect):  # noqa: ANN001
+        return {"contacts": [{"name": "Stub Ally", "role": "assistant", "trait": "sharp"}]}
+
+
+class _StubPlot:
+    def run(self, state, architect, cast):  # noqa: ANN001
+        return {"assistant_name": "Stub Ally", "actionable_objective": "Open the case file first."}
+
+
+class _StubNarrator:
+    def run(self, state, architect, cast, plan):  # noqa: ANN001
+        return [
+            "P1",
+            "P2",
+            "P3",
+        ]
+
+
+class _StubEditor:
+    def review_opening(self, lines, active_goal):  # noqa: ANN001
+        return [f"edited:{line}" for line in lines]
+
+    def review_turn(self, lines, active_goal, turn_index, debug=False):  # noqa: ANN001
+        return [f"turn:{line}" for line in lines]
+
+
+def test_story_director_supports_swappable_agent_components():
+    state = build_default_state(seed=7)
+    director = StoryDirector(
+        "mock",
+        output_editor=_StubEditor(),
+        story_architect=_StubArchitect(),
+        character_designer=_StubCharacter(),
+        plot_designer=_StubPlot(),
+        narrator_opening=_StubNarrator(),
+    )
+
+    opening = director.compose_opening(state)
+    assert opening == ["edited:P1", "edited:P2", "edited:P3"]
+
+    reviewed_turn = director.review_turn(
+        state,
+        ["Room block", "Some event"],
+        [Event(type="story_event", message_key="Reminder")],
+    )
+    assert reviewed_turn[0].startswith("turn:")

--- a/tests/test_story_reveals.py
+++ b/tests/test_story_reveals.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from random import Random
+
+from storygame.engine.parser import parse_command
+from storygame.engine.simulation import advance_turn
+from storygame.engine.world import build_default_state
+
+
+def test_story_reveal_emits_once_when_progress_threshold_is_met():
+    state = build_default_state(seed=201, genre="mystery")
+    state.world_package["story_plan"]["hidden_threads"] = ("The buried case file points to a missing witness.",)
+    state.world_package["story_plan"]["reveal_schedule"] = ({"thread_index": 0, "min_progress": 0.0},)
+
+    rng = Random(201)
+    next_state, events, _beat, _template = advance_turn(state, parse_command("look"), rng)
+    reveal_events = [event for event in events if event.type == "story_reveal"]
+    assert len(reveal_events) == 1
+    assert "missing witness" in reveal_events[0].message_key.lower()
+    assert next_state.player.flags.get("story_reveal_0") is True
+
+    later_state, later_events, _beat, _template = advance_turn(next_state, parse_command("look"), rng)
+    assert not [event for event in later_events if event.type == "story_reveal"]
+    assert later_state.player.flags.get("story_reveal_0") is True
+
+
+def test_story_reveal_waits_until_threshold():
+    state = build_default_state(seed=202, genre="mystery")
+    state.world_package["story_plan"]["hidden_threads"] = ("A final ledger links the suspect to the magistrate.",)
+    state.world_package["story_plan"]["reveal_schedule"] = ({"thread_index": 0, "min_progress": 0.95},)
+    state.progress = 0.1
+
+    rng = Random(202)
+    _next_state, events, _beat, _template = advance_turn(state, parse_command("look"), rng)
+    assert not [event for event in events if event.type == "story_reveal"]

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -20,6 +20,10 @@ def test_turn_endpoint_starts_run_and_tracks_session(tmp_path):
 
     payload = response.json()
     assert "run_id" in payload
+    assert payload["state"]["turn_index"] == 0
+    assert all(not line.startswith("Where you are: ") for line in payload["lines"])
+    assert all("Immediate objective:" not in line for line in payload["lines"])
+    assert all("The only exit is to" not in line for line in payload["lines"])
     start_location = payload["state"]["location"]
     assert payload["state"]["genre"] == "thriller"
     assert payload["state"]["session_length"] == "long"
@@ -37,6 +41,7 @@ def test_turn_endpoint_starts_run_and_tracks_session(tmp_path):
     payload = response.json()
     assert payload["run_id"] == run_id
     assert payload["state"]["location"] != start_location
+    assert payload["state"]["turn_index"] == 1
     assert response.status_code == 200
 
 
@@ -96,3 +101,12 @@ def test_resolve_narrator_mode_prefers_explicit_and_env(monkeypatch):
 
     monkeypatch.setenv("FREYTAG_NARRATOR", "none")
     assert _resolve_narrator_mode("  ") == "none"
+
+
+def test_web_ui_bootstraps_new_scene_after_new_game_click(tmp_path):
+    client = _client(tmp_path)
+    response = client.get("/")
+    assert response.status_code == 200
+    html = response.text
+    assert "async function startNewGame()" in html
+    assert "await startNewGame();" in html

--- a/tests/test_world_builder.py
+++ b/tests/test_world_builder.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from storygame.engine.world_builder import build_world_package, select_story_outline
+import textwrap
+from random import Random
+
+from storygame.engine.parser import parse_command
+from storygame.engine.simulation import advance_turn
+from storygame.engine.world import build_default_state
+from storygame.engine.world_builder import _extract_character_names, build_world_package, select_story_outline
 
 
 def test_select_story_outline_filters_by_genre() -> None:
@@ -36,6 +42,102 @@ def test_build_world_package_has_required_sections() -> None:
     assert package["entities"]["npcs"]
     assert package["map"]["rooms"]
     assert package["goals"]["primary"]
+    assert package["goals"]["setup"]
     assert package["beat_candidates"]
     assert package["item_graph"]["items"]
     assert package["trigger_seeds"]
+
+
+def test_build_world_package_derives_goals_from_outline_text(tmp_path) -> None:
+    outlines = tmp_path / "story_outlines.yaml"
+    outlines.write_text(
+        textwrap.dedent(
+            """
+            stories:
+              - id: mystery_custom_001
+                genre: mystery
+                outline: |
+                  Premise: The mayor vanished after the lantern festival and the town square was sealed.
+                  Scene: Old town square.
+                  Characters: Inspector Vale, Archivist Rowan.
+            """
+        ).strip()
+    )
+
+    package = build_world_package(
+        genre="mystery",
+        session_length="medium",
+        seed=7,
+        tone="neutral",
+        outlines_path=outlines,
+    )
+
+    primary = package["goals"]["primary"].lower()
+    setup = package["goals"]["setup"].lower()
+    assert "mayor vanished" in primary
+    assert "lantern festival" in setup
+    assert "relay route" not in primary
+
+
+def test_active_goal_starts_with_setup_then_refines_to_primary() -> None:
+    state = build_default_state(seed=91, genre="drama", tone="dark")
+    setup_goal = state.world_package["goals"]["setup"]
+    primary_goal = state.world_package["goals"]["primary"]
+    assert state.active_goal == setup_goal
+
+    rng = Random(91)
+    for _ in range(6):
+        state, _events, _beat, _template = advance_turn(state, parse_command("look"), rng)
+
+    assert state.active_goal == primary_goal
+
+
+def test_story_agent_plan_expands_setup_and_hides_future_spoilers(tmp_path) -> None:
+    outlines = tmp_path / "story_outlines.yaml"
+    outlines.write_text(
+        textwrap.dedent(
+            """
+            stories:
+              - id: mystery_detective_001
+                genre: mystery
+                outline: |
+                  Situation: A detective, embittered by a past failure and now living the life of a recluse in a secluded mansion, is tasked with solving one last case that leads him to a confrontation with the ghosts of his past and a choice between justice and mercy.
+            """
+        ).strip()
+    )
+
+    package = build_world_package(
+        genre="mystery",
+        session_length="medium",
+        seed=12,
+        outlines_path=outlines,
+    )
+
+    plan = package["story_plan"]
+    assert plan["protagonist_name"]
+    assert len(plan["setup_paragraphs"]) in {3, 4}
+    opening_text = "\n".join(plan["setup_paragraphs"]).lower()
+    assert "choice between justice and mercy" not in opening_text
+    assert "confrontation with the ghosts of his past" not in opening_text
+
+    hidden_text = "\n".join(plan["hidden_threads"]).lower()
+    assert "choice between justice and mercy" in hidden_text
+    assert "ghosts of his past" in hidden_text
+    setup_goal = package["goals"]["setup"].lower()
+    assert "tasked with." not in setup_goal
+    assert "is tasked with" not in setup_goal
+    assert "case file" in setup_goal
+
+
+def test_extract_character_names_reads_outline_character_lines() -> None:
+    outline = "Characters:\nAri Vale: Investigator.\nMina Cole: Archivist.\n"
+    names = _extract_character_names(outline)
+    assert names[:2] == ["Ari Vale", "Mina Cole"]
+
+
+def test_extract_character_names_ignores_outline_section_labels() -> None:
+    outline = "Premise: A detective returns.\nScene: Manor gate.\nCharacters:\nAri Vale: Investigator.\n"
+    names = _extract_character_names(outline)
+    assert "Premise" not in names
+    assert "Scene" not in names
+    assert names[0] == "Ari Vale"

--- a/tests/test_world_presentation.py
+++ b/tests/test_world_presentation.py
@@ -20,16 +20,22 @@ def test_room_lines_include_room_identity_and_navigation():
     assert "exit" in lines.lower()
 
 
+def test_starting_state_avoids_meta_room_text_and_starts_with_kit():
+    state = build_default_state(seed=35, genre="mystery")
+    room = state.world.rooms[state.player.location]
+
+    assert "move the story toward resolution" not in room.description.lower()
+    assert "neutral mystery scene" not in room.description.lower()
+    assert "field_kit" in state.player.inventory
+    assert "field_kit" not in room.item_ids
+
+
 def test_context_filters_inventory_to_actionable_items():
     state = build_default_state(seed=32, genre="thriller")
-    room = state.world.rooms[state.player.location]
-    item_id = room.item_ids[0]
-
-    state = apply_action(state, parse_command(f"take {item_id}"), Random(32))[0]
     context = build_narration_context(state, parse_command("look"), "hook")
     payload = context.as_dict()
 
-    assert item_id in payload["inventory"]
+    assert "field_kit" in payload["inventory"]
     assert payload["npc_facts"]
 
 


### PR DESCRIPTION
Refactor story architecture into swappable LLM agents and harden objective/output quality

- Introduce explicit story-agent layer with per-agent prompts and JSON contracts:
  - add `storygame/llm/story_agents/prompts.py`
  - add `storygame/llm/story_agents/contracts.py`
  - add `storygame/llm/story_agents/agents.py`
  - export APIs via `storygame/llm/story_agents/__init__.py`
- Split `StoryDirector` into composable agent components (architect/character/plot/narrator) with DI support and keep deterministic engine boundaries intact.
- Wire StoryDirector + output editor across CLI and web startup/turn paths so all player-facing text is reviewed through agent orchestration.
- Add output editor gate module and apply it to opening + per-turn output, with LLM-backed rewrite in openai/ollama modes and deterministic fallback.
- Improve opening coherence:
  - remove legacy/meta scaffolding from opening flow
  - enforce better role/identity placement and actionable objective phrasing
  - fix placeholder character leakage (e.g., “Premise” as a name)
- Fix character extraction regex/filters to ignore section labels and keep real names.
- Improve world presentation defaults:
  - remove meta room description text
  - set better mystery start-room naming/description
  - keep playable item distribution while avoiding setup clutter
- Harden goal synthesis:
  - sanitize non-actionable anchors
  - reject dangling clauses like “is tasked with”
  - use actionable genre defaults when premise fragments are unsuitable
- Stabilize tests against hangs by blocking outbound network globally in test runs (`tests/conftest.py`).
- Add/expand tests:
  - `tests/test_story_agent_contracts.py`
  - `tests/test_story_director_orchestration.py`
  - `tests/test_output_editor.py`
  - updates to CLI/web/world/world_builder presentation and regression tests
- Update README/PRD to document new story-agent architecture and output-editor behavior.