### PR TITLE
Normalize equivalent storylet realizations

### DIFF
--- a/docs/testing-runbook.md
+++ b/docs/testing-runbook.md
@@ -302,7 +302,7 @@ Expected: every reached scene receives a passing verdict for canon consistency, 
 
 **Notes:** This is intentionally separate from deterministic state assertions. It skips when `OPENAI_API_KEY` or `E2E_TEST_CLOCK_SECONDS` is absent. Start the local API with `FREYTAG_ALLOW_TEST_CLOCK=1`, then use `E2E_TEST_CLOCK_SECONDS=120`; Vite adds this value to the ordinary JSON turn body, avoiding a CORS preflight. Each turn is bounded to 30 seconds (override with `E2E_TURN_TIMEOUT_MS`) and partial progress is written to `artifacts/e2e-llm-canon-progress.{json,md}`.
 
-Last verified safely: 2026-08-27 — `npm test` passed 5 tests and Playwright discovered the tagged `@llm-canon` test with a placeholder API base URL; no live model calls were made.
+Last verified: 2026-08-27 — `source .env && cd frontend && npm run test:e2e -- --grep @llm-canon` reached the configured scene-v1 staging API, but turn 1 failed with HTTP 409: `canonical facts must use a validated storylet realization`. The provider had emitted an operation shared by equivalent realizations of the same active storylet, which the structural repair incorrectly treated as cross-route ambiguity. Normalization now accepts equivalent matches belonging to one active route and selects its stable first realization; `TMPDIR=/tmp uv run pytest -q` passed (64 tests, 90.37% coverage) and PR CI passed. Staging deploys only from `main`, so merge and deployment are required before the next live retry.
 
 ## Deterministic E2E pacing clock
 

--- a/storygame/runtime/validation.py
+++ b/storygame/runtime/validation.py
@@ -65,7 +65,8 @@ class ProgressionValidator:
             for realization in route.realizations
             if tuple(self._route_operation(operation) for operation in realization.operations) == proposal.operations
         ]
-        if len(matches) != 1:
+        route_ids = {route.id for route, _ in matches}
+        if len(route_ids) != 1:
             return proposal
         route, realization = matches[0]
         return proposal.model_copy(

--- a/tests/test_scene_progression_phase4.py
+++ b/tests/test_scene_progression_phase4.py
@@ -98,6 +98,28 @@ def test_exact_active_realization_operations_are_safely_normalized_into_an_event
     assert "SL-1A-B" in engine.state.fired_event_ids
 
 
+def test_duplicate_equivalent_realizations_normalize_to_their_single_active_route() -> None:
+    engine = RuntimeEngine(
+        RuntimeState.bootstrap(PACKAGE),
+        _provider(
+            {
+                "narration": "The forced entry makes Sarah's disappearance look targeted.",
+                "operations": [
+                    {
+                        "operation": "assert",
+                        "fact": {"predicate": "sarah_abduction_suspicion", "subject": "story", "value": "true"},
+                    }
+                ],
+            },
+            [],
+        ),
+    )
+
+    engine.turn("I inspect the signs of forced entry.")
+
+    assert "SL-1A-A" in engine.state.fired_event_ids
+
+
 def test_unsatisfied_trigger_leaves_state_unchanged() -> None:
     engine = RuntimeEngine(
         RuntimeState.bootstrap(PACKAGE),


### PR DESCRIPTION
## Summary
- normalize duplicate equivalent realization operations to their single active route
- cover the provider-format repair with a scene-1A regression
- record the live canon-E2E failure signature in the testing runbook

## Verification
- TMPDIR=/tmp uv run pytest -q
- uv run ruff check --fix .
- uv run ruff format .
- source .env && cd frontend && npm run test:e2e -- --grep @llm-canon (fails on currently deployed staging SHA before this fix)