### PR TITLE
Preserve new facts during route normalization

### DIFF
--- a/storygame/runtime/validation.py
+++ b/storygame/runtime/validation.py
@@ -58,12 +58,17 @@ class ProgressionValidator:
 
         if not proposal.operations or proposal.events:
             return proposal
+        canonical_operations = tuple(
+            operation for operation in proposal.operations if operation.fact.predicate in self.package.world.facts
+        )
+        if not canonical_operations:
+            return proposal
         matches = [
             (route, realization)
             for route in self._routes.values()
             if route.id in state.active_event_ids and route.id not in state.fired_event_ids
             for realization in route.realizations
-            if tuple(self._route_operation(operation) for operation in realization.operations) == proposal.operations
+            if tuple(self._route_operation(operation) for operation in realization.operations) == canonical_operations
         ]
         route_ids = {route.id for route, _ in matches}
         if len(route_ids) != 1:
@@ -71,12 +76,16 @@ class ProgressionValidator:
         route, realization = matches[0]
         return proposal.model_copy(
             update={
-                "operations": (),
+                "operations": tuple(
+                    operation
+                    for operation in proposal.operations
+                    if operation.fact.predicate not in self.package.world.facts
+                ),
                 "events": (
                     StoryEventProposal(
                         event_id=route.id,
                         realization_id=realization.id,
-                        operations=proposal.operations,
+                        operations=canonical_operations,
                     ),
                 ),
             }

--- a/tests/test_scene_progression_phase4.py
+++ b/tests/test_scene_progression_phase4.py
@@ -120,6 +120,56 @@ def test_duplicate_equivalent_realizations_normalize_to_their_single_active_rout
     assert "SL-1A-A" in engine.state.fired_event_ids
 
 
+def test_normalization_preserves_new_facts_alongside_a_canonical_realization() -> None:
+    engine = RuntimeEngine(
+        RuntimeState.bootstrap(PACKAGE),
+        _provider(
+            {
+                "narration": "A blood smear makes the forced entry impossible to dismiss.",
+                "operations": [
+                    {
+                        "operation": "assert",
+                        "fact": {"predicate": "has_blood", "subject": "thomas_home", "value": "true"},
+                    },
+                    {
+                        "operation": "assert",
+                        "fact": {"predicate": "sarah_abduction_suspicion", "subject": "story", "value": "true"},
+                    },
+                ],
+            },
+            [],
+        ),
+    )
+
+    engine.turn("I inspect the signs of forced entry.")
+
+    assert engine.state.facts.has("has_blood", "thomas_home", value="true")
+    assert "SL-1A-A" in engine.state.fired_event_ids
+
+
+def test_unmatched_canonical_fact_still_fails_closed() -> None:
+    engine = RuntimeEngine(
+        RuntimeState.bootstrap(PACKAGE),
+        _provider(
+            {
+                "narration": "The facility proof arrives too early.",
+                "operations": [
+                    {
+                        "operation": "assert",
+                        "fact": {"predicate": "facility_proof", "subject": "story", "value": "true"},
+                    }
+                ],
+            },
+            [],
+        ),
+    )
+
+    with pytest.raises(RuntimeStateError, match="validated storylet realization"):
+        engine.turn("I imagine proof from a distant facility.")
+
+    assert engine.state.facts.as_json() == []
+
+
 def test_unsatisfied_trigger_leaves_state_unchanged() -> None:
     engine = RuntimeEngine(
         RuntimeState.bootstrap(PACKAGE),


### PR DESCRIPTION
## Summary
- normalize only package-declared canonical operations into their active storylet route
- preserve LLM-proposed new world facts as validated top-level operations

## Verification
- env -u CLOUDFLARE_WORKER_URL -u CLOUDFLARE_WORKER_TOKEN -u FREYTAG_ALLOW_TEST_CLOCK TMPDIR=/tmp uv run pytest -q
- uv run ruff check --fix .
- uv run ruff format .