### PR TITLE
Normalize duplicate canonical event operations

### DIFF
--- a/storygame/runtime/validation.py
+++ b/storygame/runtime/validation.py
@@ -56,13 +56,33 @@ class ProgressionValidator:
         exactly one active route realization, so it cannot authorize a new fact.
         """
 
-        if not proposal.operations or proposal.events:
+        if not proposal.operations:
             return proposal
         canonical_operations = tuple(
             operation for operation in proposal.operations if operation.fact.predicate in self.package.world.facts
         )
         if not canonical_operations:
             return proposal
+        if proposal.events:
+            event_operations = {
+                operation
+                for event in proposal.events
+                if event.event_id in state.active_event_ids and event.event_id not in state.fired_event_ids
+                if (route := self._routes.get(event.event_id)) is not None
+                for realization in route.realizations
+                if realization.id == event.realization_id
+                if event.operations == tuple(self._route_operation(operation) for operation in realization.operations)
+                for operation in event.operations
+            }
+            if not event_operations:
+                return proposal
+            return proposal.model_copy(
+                update={
+                    "operations": tuple(
+                        operation for operation in proposal.operations if operation not in event_operations
+                    )
+                }
+            )
         matches = [
             (route, realization)
             for route in self._routes.values()

--- a/tests/test_scene_progression_phase4.py
+++ b/tests/test_scene_progression_phase4.py
@@ -147,6 +147,49 @@ def test_normalization_preserves_new_facts_alongside_a_canonical_realization() -
     assert "SL-1A-A" in engine.state.fired_event_ids
 
 
+def test_normalization_removes_only_canonical_operations_duplicated_by_a_valid_event() -> None:
+    engine = RuntimeEngine(
+        RuntimeState.bootstrap(PACKAGE),
+        _provider(
+            {
+                "narration": "The forced entry makes Sarah's disappearance look targeted.",
+                "operations": [
+                    {
+                        "operation": "assert",
+                        "fact": {"predicate": "has_blood", "subject": "thomas_home", "value": "true"},
+                    },
+                    {
+                        "operation": "assert",
+                        "fact": {"predicate": "sarah_abduction_suspicion", "subject": "story", "value": "true"},
+                    },
+                ],
+                "events": [
+                    {
+                        "event_id": "SL-1A-A",
+                        "realization_id": "SL-1A-A-R1",
+                        "operations": [
+                            {
+                                "operation": "assert",
+                                "fact": {
+                                    "predicate": "sarah_abduction_suspicion",
+                                    "subject": "story",
+                                    "value": "true",
+                                },
+                            }
+                        ],
+                    }
+                ],
+            },
+            [],
+        ),
+    )
+
+    engine.turn("I inspect the signs of forced entry.")
+
+    assert engine.state.facts.has("has_blood", "thomas_home", value="true")
+    assert "SL-1A-A" in engine.state.fired_event_ids
+
+
 def test_unmatched_canonical_fact_still_fails_closed() -> None:
     engine = RuntimeEngine(
         RuntimeState.bootstrap(PACKAGE),


### PR DESCRIPTION
## Summary
- retain new freeform facts from LLM proposals
- drop only canonical operations duplicated by a valid active route event
- fail closed for unmatched canonical effects

## Verification
- real configured provider through RuntimeEngine committed  successfully
- env -u CLOUDFLARE_WORKER_URL -u CLOUDFLARE_WORKER_TOKEN -u FREYTAG_ALLOW_TEST_CLOCK TMPDIR=/tmp uv run pytest -q
- uv run ruff check --fix .
- uv run ruff format .