### PR TITLE
Ignore repeated canonical facts

### DIFF
--- a/storygame/runtime/validation.py
+++ b/storygame/runtime/validation.py
@@ -56,6 +56,15 @@ class ProgressionValidator:
         exactly one active route realization, so it cannot authorize a new fact.
         """
 
+        proposal = proposal.model_copy(
+            update={
+                "operations": tuple(
+                    operation
+                    for operation in proposal.operations
+                    if not self._canonical_operation_is_noop(state, operation)
+                )
+            }
+        )
         if not proposal.operations:
             return proposal
         canonical_operations = tuple(
@@ -110,6 +119,12 @@ class ProgressionValidator:
                 ),
             }
         )
+
+    def _canonical_operation_is_noop(self, state: RuntimeState, operation: FactOperation) -> bool:
+        if operation.fact.predicate not in self.package.world.facts:
+            return False
+        already_asserted = operation.fact in state.facts.asserted
+        return already_asserted if operation.operation == "assert" else not already_asserted
 
     def _validate_operations(self, proposal: TurnProposal) -> None:
         protected = set(self.package.world.protected_knowledge)

--- a/tests/test_scene_progression_phase4.py
+++ b/tests/test_scene_progression_phase4.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from storygame.runtime.engine import RuntimeEngine
+from storygame.runtime.facts import Fact
 from storygame.runtime.state import RuntimeState, RuntimeStateError
 from storygame.story_package.loader import load_story_package
 
@@ -188,6 +189,30 @@ def test_normalization_removes_only_canonical_operations_duplicated_by_a_valid_e
 
     assert engine.state.facts.has("has_blood", "thomas_home", value="true")
     assert "SL-1A-A" in engine.state.fired_event_ids
+
+
+def test_repeated_canonical_fact_is_a_safe_noop() -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.facts.assert_fact(Fact(predicate="sarah_abduction_suspicion", subject="story", value="true"))
+    engine = RuntimeEngine(
+        state,
+        _provider(
+            {
+                "narration": "The existing signs of forced entry still point to Sarah's abduction.",
+                "operations": [
+                    {
+                        "operation": "assert",
+                        "fact": {"predicate": "sarah_abduction_suspicion", "subject": "story", "value": "true"},
+                    }
+                ],
+            },
+            [],
+        ),
+    )
+
+    engine.turn("I reconsider the forced entry.")
+
+    assert state.facts.has("sarah_abduction_suspicion", "story", value="true")
 
 
 def test_unmatched_canonical_fact_still_fails_closed() -> None:


### PR DESCRIPTION
Preserves freeform new facts and route validation while treating repeated canonical assertions as no-op proposals.\n\nVerification: 68 Python tests passed with 90.52% coverage; Ruff passed.