### PR TITLE
Keep unestablished references out of scene context

### DIFF
--- a/storygame/runtime/context.py
+++ b/storygame/runtime/context.py
@@ -117,10 +117,24 @@ class SceneContextBuilder:
         facts = tuple(fact for fact in state.facts.asserted if self._is_safe_fact(fact, state))
         local_ids = self._expand_related_entity_ids(facts, local_ids, entity_by_id)
         references = self.resolve_references(player_input, entities)
-        local_ids.update(references.matched_ids)
-        local_facts = self._related_facts(facts, local_ids)
         referenced_ids = set(references.matched_ids) - {location.id}
         referenced_history = self._related_facts(facts, referenced_ids)
+        # A name in player input is not, by itself, authority to disclose a
+        # package entity. Only retain references the session has already made
+        # public through a safe fact; otherwise a future character or place
+        # could be surfaced merely by being named.
+        established_ids = {
+            entity_id
+            for fact in referenced_history
+            for entity_id in (fact.subject, fact.object)
+            if entity_id is not None
+        }
+        references = references.model_copy(
+            update={"matched_ids": tuple(item for item in references.matched_ids if item in established_ids)}
+        )
+        local_ids.update(references.matched_ids)
+        local_facts = self._related_facts(facts, local_ids)
+        referenced_history = self._related_facts(facts, set(references.matched_ids) - {location.id})
         return SceneContext(
             scene_id=scene.metadata.scene_id,
             freytag_phase=scene.metadata.freytag_phase,

--- a/tests/test_scene_context.py
+++ b/tests/test_scene_context.py
@@ -40,6 +40,16 @@ def test_unambiguous_reference_adds_public_entity_and_history_only() -> None:
     assert "janus_selection_system" not in context.prompt()
 
 
+def test_unestablished_future_reference_does_not_expand_scene_context() -> None:
+    state = _state()
+
+    context = SceneContextBuilder().build(state, "Could Gabriel Dexter have left a message?")
+
+    assert context.reference_resolution.matched_ids == ()
+    assert "gabriel" not in {entity.id for entity in context.entities}
+    assert "gabriel" not in context.prompt()
+
+
 def test_owned_entity_is_local_without_exposing_private_facts() -> None:
     state = _state()
     state.facts.assert_fact(Fact(predicate="custody", subject="jeremiah", object="transit_card"))


### PR DESCRIPTION
## Summary
- require safe session history before a named package entity is added to the LLM scene context
- keep previously established public references available
- cover future-name prompt injection without restricting freeform new facts

## Verification
- TMPDIR=/tmp uv run pytest -q
- uv run ruff check --fix storygame/runtime/context.py tests/test_scene_context.py
- uv run ruff format storygame/runtime/context.py tests/test_scene_context.py