### PR TITLE
Normalize uniquely identified active route effects

### DIFF
--- a/storygame/runtime/validation.py
+++ b/storygame/runtime/validation.py
@@ -50,10 +50,11 @@ class ProgressionValidator:
         return self.unsatisfied_dependencies(state.current_scene_id, candidate)
 
     def normalize(self, state: RuntimeState, proposal: TurnProposal) -> TurnProposal:
-        """Accept an exact active realization even if a provider omitted its event wrapper.
+        """Recover a uniquely identified active realization missing its event wrapper.
 
-        This is a structural repair only: the full operation tuple must match
-        exactly one active route realization, so it cannot authorize a new fact.
+        This is a structural repair only: a full tuple, or an unambiguous subset,
+        must identify one active route realization. The resulting effects always
+        come from that package-authored realization, never from a new fact.
         """
 
         proposal = proposal.model_copy(
@@ -93,16 +94,27 @@ class ProgressionValidator:
                 }
             )
         matches = [
-            (route, realization)
+            (route, realization, tuple(self._route_operation(operation) for operation in realization.operations))
             for route in self._routes.values()
             if route.id in state.active_event_ids and route.id not in state.fired_event_ids
             for realization in route.realizations
-            if tuple(self._route_operation(operation) for operation in realization.operations) == canonical_operations
         ]
-        route_ids = {route.id for route, _ in matches}
-        if len(route_ids) != 1:
-            return proposal
-        route, realization = matches[0]
+        exact_matches = [match for match in matches if match[2] == canonical_operations]
+        route_ids = {route.id for route, _, _ in exact_matches}
+        if len(route_ids) == 1:
+            route, realization, expected_operations = exact_matches[0]
+        else:
+            partial_matches = [
+                match for match in matches if all(operation in match[2] for operation in canonical_operations)
+            ]
+            partial_route_ids = {route.id for route, _, _ in partial_matches}
+            partial_operation_sets: list[tuple[FactOperation, ...]] = []
+            for _, _, operations in partial_matches:
+                if operations not in partial_operation_sets:
+                    partial_operation_sets.append(operations)
+            if len(partial_route_ids) != 1 or len(partial_operation_sets) != 1:
+                return proposal
+            route, realization, expected_operations = partial_matches[0]
         return proposal.model_copy(
             update={
                 "operations": tuple(
@@ -114,7 +126,7 @@ class ProgressionValidator:
                     StoryEventProposal(
                         event_id=route.id,
                         realization_id=realization.id,
-                        operations=canonical_operations,
+                        operations=expected_operations,
                     ),
                 ),
             }

--- a/tests/test_scene_progression_phase4.py
+++ b/tests/test_scene_progression_phase4.py
@@ -121,6 +121,33 @@ def test_duplicate_equivalent_realizations_normalize_to_their_single_active_rout
     assert "SL-1A-A" in engine.state.fired_event_ids
 
 
+def test_unique_active_realization_subset_normalizes_to_its_full_route_effect() -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.active_event_ids.update(("SL-1A-B", "SL-1A-C"))
+    state.fired_event_ids.add("SL-1A-A")
+    state.facts.assert_fact(Fact(predicate="sarah_abduction_suspicion", subject="story", value="true"))
+    engine = RuntimeEngine(
+        state,
+        _provider(
+            {
+                "narration": "The card turns Sarah's disappearance into a lead Jeremiah can act on.",
+                "operations": [
+                    {
+                        "operation": "assert",
+                        "fact": {"predicate": "sarah_lead_actionable", "subject": "story", "value": "true"},
+                    }
+                ],
+            },
+            [],
+        ),
+    )
+
+    engine.turn("I follow the strongest lead from Sarah's card.")
+
+    assert "SL-1A-B" in state.fired_event_ids
+    assert state.facts.has("continuity_initiative_known", "story", value="true")
+
+
 def test_normalization_preserves_new_facts_alongside_a_canonical_realization() -> None:
     engine = RuntimeEngine(
         RuntimeState.bootstrap(PACKAGE),


### PR DESCRIPTION
## Summary
- recover a package-authored active realization when provider operations uniquely identify it but omit the event wrapper or companion effects
- preserve arbitrary LLM-created facts and reject ambiguous or inactive canonical effects
- cover a unique subset emitted after the first discovery storylet

## Verification
- TMPDIR=/tmp uv run pytest -q
- uv run ruff check --fix storygame/runtime/validation.py tests/test_scene_progression_phase4.py
- uv run ruff format storygame/runtime/validation.py tests/test_scene_progression_phase4.py