### PR TITLE
Recover unambiguous malformed storylet wrappers

### DIFF
--- a/storygame/runtime/validation.py
+++ b/storygame/runtime/validation.py
@@ -85,14 +85,22 @@ class ProgressionValidator:
                 for operation in event.operations
             }
             if not event_operations:
-                return proposal
-            return proposal.model_copy(
-                update={
-                    "operations": tuple(
-                        operation for operation in proposal.operations if operation not in event_operations
-                    )
-                }
-            )
+                # A provider can pair a uniquely identifying canonical subset
+                # with a malformed event wrapper.  Discard only that wrapper
+                # and let the same route-subset recovery below prove the
+                # package-authorized effect; otherwise validation still rejects
+                # the proposal unchanged.
+                if not proposal.operations:
+                    return proposal
+                proposal = proposal.model_copy(update={"events": ()})
+            else:
+                return proposal.model_copy(
+                    update={
+                        "operations": tuple(
+                            operation for operation in proposal.operations if operation not in event_operations
+                        )
+                    }
+                )
         matches = [
             (route, realization, tuple(self._route_operation(operation) for operation in realization.operations))
             for route in self._routes.values()

--- a/tests/test_scene_progression_phase4.py
+++ b/tests/test_scene_progression_phase4.py
@@ -148,6 +148,29 @@ def test_unique_active_realization_subset_normalizes_to_its_full_route_effect() 
     assert state.facts.has("continuity_initiative_known", "story", value="true")
 
 
+def test_malformed_event_wrapper_can_recover_a_unique_canonical_subset() -> None:
+    engine = RuntimeEngine(
+        RuntimeState.bootstrap(PACKAGE),
+        _provider(
+            {
+                "narration": "The hidden card turns the evidence into an actionable lead.",
+                "operations": [
+                    {
+                        "operation": "assert",
+                        "fact": {"predicate": "sarah_lead_actionable", "subject": "story", "value": "true"},
+                    }
+                ],
+                "events": [{"event_id": "SL-1A-B", "realization_id": "SL-1A-B-R1", "operations": []}],
+            },
+            [],
+        ),
+    )
+
+    engine.turn("I recover Sarah's hidden evidence.")
+
+    assert "SL-1A-B" in engine.state.fired_event_ids
+
+
 def test_normalization_preserves_new_facts_alongside_a_canonical_realization() -> None:
     engine = RuntimeEngine(
         RuntimeState.bootstrap(PACKAGE),


### PR DESCRIPTION
## Summary
- recover a uniquely route-authorized canonical subset when its event wrapper is malformed
- preserve rejection for proposals without recoverable canonical operations

## Verification
- `TMPDIR=/tmp uv run pytest -q` (71 passed, 90.59% coverage)