### PR TITLE
Return typed errors for invalid provider contracts

### DIFF
--- a/storygame/web_demo.py
+++ b/storygame/web_demo.py
@@ -15,7 +15,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from storygame.runtime.cloudflare import CloudflareTurnProvider, NarrationProviderError
-from storygame.runtime.contracts import TurnProposal
+from storygame.runtime.contracts import RuntimeContractError, TurnProposal
 from storygame.runtime.engine import RuntimeEngine
 from storygame.runtime.persistence import RuntimeSaveError, RuntimeStateSqliteStore
 from storygame.runtime.state import RuntimeState, RuntimeStateError
@@ -209,6 +209,8 @@ def create_demo_app(
             if error.worker_revision:
                 headers["X-Worker-Revision"] = error.worker_revision
             raise HTTPException(status_code=error.status_code, detail=error.message, headers=headers) from error
+        except RuntimeContractError as error:
+            raise HTTPException(status_code=422, detail="provider response violates the turn contract") from error
         except RuntimeStateError as error:
             raise HTTPException(status_code=409, detail=str(error)) from error
         store.save(body.session_id, state)

--- a/tests/test_web_demo.py
+++ b/tests/test_web_demo.py
@@ -3,6 +3,7 @@
 from fastapi.testclient import TestClient
 
 from storygame.runtime.cloudflare import NarrationProviderError
+from storygame.runtime.contracts import RuntimeContractError
 from storygame.web_demo import create_demo_app
 
 
@@ -110,6 +111,27 @@ def test_adapter_exposes_a_safe_worker_error_code_header(tmp_path) -> None:
     assert response.headers["X-Narration-Error-Code"] == "WORKER_CONFIGURATION_ERROR"
     assert response.headers["X-Trace-ID"] == "trace-123"
     assert response.headers["X-Worker-Revision"] == "worker-456"
+
+
+def test_adapter_returns_cors_safe_invalid_provider_contract(tmp_path) -> None:
+    def invalid_provider(_state):
+        def reject(_input):
+            raise RuntimeContractError("provider response violates the turn contract")
+
+        return reject
+
+    app = create_demo_app(store_path=tmp_path / "sessions.sqlite", provider_factory=invalid_provider)
+    with TestClient(app) as client:
+        session_id = client.post("/api/v1/session", json={"story_id": "continuity_initiative"}).json()["session_id"]
+        response = client.post(
+            "/api/v1/turn",
+            json={"session_id": session_id, "player_input": "I listen."},
+            headers={"Origin": "http://127.0.0.1:4173"},
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "provider response violates the turn contract"}
+    assert response.headers["access-control-allow-origin"] == "*"
 
 
 def test_turn_request_accepts_the_pre_scene_command_field(tmp_path) -> None:


### PR DESCRIPTION
Turns with malformed provider output now return a CORS-safe typed 422 response instead of falling through to a bare server error. Includes a hosted-adapter regression test.