### PR TITLE
Accept selected knowledge IDs in reveal events

### DIFF
--- a/storygame/runtime/contracts.py
+++ b/storygame/runtime/contracts.py
@@ -30,6 +30,7 @@ class SceneTransitionProposal(_StrictModel):
 class StoryEventProposal(_StrictModel):
     event_id: str = Field(pattern=r"^[A-Za-z][A-Za-z0-9_-]*$")
     realization_id: str | None = Field(default=None, min_length=1)
+    knowledge_ids: tuple[str, ...] = ()
     operations: tuple[FactOperation, ...] = ()
 
 

--- a/tests/test_scene_runtime_phase2.py
+++ b/tests/test_scene_runtime_phase2.py
@@ -28,6 +28,13 @@ def test_provider_envelope_is_normalized_but_invalid_json_fails_closed() -> None
     assert proposal.narration == "Jeremiah looks around."
     structured = parse_turn_proposal({"segments": [{"kind": "action", "text": "Jeremiah checks the door."}]})
     assert structured.narration == "Jeremiah checks the door."
+    reveal = parse_turn_proposal(
+        {
+            "narration": "A damaged recording crackles to life.",
+            "events": [{"event_id": "SL-1A-B", "realization_id": "SL-1A-B-R2", "knowledge_ids": ["k_sl_1a_b_r2"]}],
+        }
+    )
+    assert reveal.events[0].knowledge_ids == ("k_sl_1a_b_r2",)
     with pytest.raises(RuntimeContractError):
         parse_turn_proposal({"content": "not JSON"})
     with pytest.raises(RuntimeContractError):


### PR DESCRIPTION
Adds the typed selected-knowledge field to reveal events so the Phase 3 Worker contract can represent the recording selection without an unknown-key rejection.