### PR TITLE
Expose safe provider contract diagnostics

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -8,7 +8,12 @@ from os import getenv
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-from storygame.runtime.contracts import RuntimeContractError, TurnProposal, parse_turn_proposal
+from storygame.runtime.contracts import (
+    RuntimeContractError,
+    TurnProposal,
+    contract_error_summary,
+    parse_turn_proposal,
+)
 from storygame.runtime.knowledge import KnowledgeProjector, TurnKnowledgeContext
 from storygame.runtime.state import RuntimeState
 
@@ -96,7 +101,12 @@ class CloudflareTurnProvider:
         except HTTPError as error:
             raise self._narration_error(error) from error
         except RuntimeContractError as error:
-            raise NarrationProviderError("narration service returned an invalid proposal", 502) from error
+            summary = contract_error_summary(error) or "invalid proposal"
+            raise NarrationProviderError(
+                f"narration service returned an invalid proposal ({summary})",
+                502,
+                "INVALID_PROPOSAL",
+            ) from error
         except (URLError, OSError, TimeoutError, ValueError, json.JSONDecodeError) as error:
             raise NarrationProviderError("narration service is unavailable") from error
 
@@ -115,7 +125,12 @@ class CloudflareTurnProvider:
         except HTTPError as error:
             raise self._narration_error(error) from error
         except RuntimeContractError as error:
-            raise NarrationProviderError("narration service returned an invalid proposal", 502) from error
+            summary = contract_error_summary(error) or "invalid proposal"
+            raise NarrationProviderError(
+                f"narration service returned an invalid proposal ({summary})",
+                502,
+                "INVALID_PROPOSAL",
+            ) from error
         except (URLError, OSError, TimeoutError, ValueError, json.JSONDecodeError) as error:
             raise NarrationProviderError("narration service is unavailable") from error
 

--- a/storygame/runtime/contracts.py
+++ b/storygame/runtime/contracts.py
@@ -94,3 +94,12 @@ def parse_turn_proposal(envelope: object) -> TurnProposal:
         return TurnProposal.model_validate(payload)
     except ValidationError as error:
         raise RuntimeContractError("provider response violates the turn contract") from error
+
+
+def contract_error_summary(error: RuntimeContractError) -> str:
+    """Return safe validation paths/types without returning untrusted provider values."""
+
+    cause = error.__cause__
+    if not isinstance(cause, ValidationError):
+        return "invalid JSON" if isinstance(cause, json.JSONDecodeError) else ""
+    return ", ".join(f"{'.'.join(str(part) for part in issue['loc'])}:{issue['type']}" for issue in cause.errors())

--- a/storygame/web_demo.py
+++ b/storygame/web_demo.py
@@ -15,7 +15,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from storygame.runtime.cloudflare import CloudflareTurnProvider, NarrationProviderError
-from storygame.runtime.contracts import RuntimeContractError, TurnProposal
+from storygame.runtime.contracts import RuntimeContractError, TurnProposal, contract_error_summary
 from storygame.runtime.engine import RuntimeEngine
 from storygame.runtime.persistence import RuntimeSaveError, RuntimeStateSqliteStore
 from storygame.runtime.state import RuntimeState, RuntimeStateError
@@ -114,6 +114,12 @@ def _scene_opening(state: RuntimeState) -> str:
     )
 
 
+def _contract_error_detail(error: RuntimeContractError) -> str:
+    """Expose only schema paths/types; never provider prose or rejected values."""
+    summary = contract_error_summary(error)
+    return f"provider response violates the turn contract ({summary})" if summary else str(error)
+
+
 def create_demo_app(
     *,
     channel: str | None = None,
@@ -210,7 +216,7 @@ def create_demo_app(
                 headers["X-Worker-Revision"] = error.worker_revision
             raise HTTPException(status_code=error.status_code, detail=error.message, headers=headers) from error
         except RuntimeContractError as error:
-            raise HTTPException(status_code=422, detail="provider response violates the turn contract") from error
+            raise HTTPException(status_code=422, detail=_contract_error_detail(error)) from error
         except RuntimeStateError as error:
             raise HTTPException(status_code=409, detail=str(error)) from error
         store.save(body.session_id, state)

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -179,6 +179,28 @@ def test_transport_recovers_once_from_a_malformed_provider_envelope(monkeypatch)
     assert "previous response was invalid" in payloads[1]["system"]
 
 
+def test_transport_reports_safe_contract_shape_after_failed_recovery(monkeypatch) -> None:
+    payloads: list[dict[str, object]] = []
+    provider = CloudflareTurnProvider(
+        worker_url="https://worker.example/turn", token="", state=RuntimeState.bootstrap(PACKAGE)
+    )
+
+    def open_request(request, timeout):
+        payloads.append(json.loads(request.data))
+        return _Response({"narration": '{"segments":[]}'})
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+
+    with pytest.raises(NarrationProviderError) as caught:
+        provider("I listen.")
+
+    assert caught.value.status_code == 502
+    assert caught.value.error_code == "INVALID_PROPOSAL"
+    assert caught.value.message.endswith(":value_error)")
+    assert "segments" not in caught.value.message
+    assert len(payloads) == 2
+
+
 def test_transport_preserves_worker_capacity_classification(monkeypatch) -> None:
     provider = CloudflareTurnProvider(
         worker_url="https://worker.example/turn",


### PR DESCRIPTION
## Summary
- retain one malformed-output recovery attempt
- return only validation paths/types for exhausted provider contract failures
- cover the diagnostics and retry ceiling

## Verification
- TMPDIR=/tmp uv run pytest -q
- cd frontend && npm test && npm run build