### PR TITLE
Project canonical candidate operations

### DIFF
--- a/storygame/runtime/knowledge.py
+++ b/storygame/runtime/knowledge.py
@@ -162,5 +162,15 @@ class KnowledgeProjector:
             entity_ids=item.entity_ids,
             storylet_id=item.source.storylet_id,
             realization_id=item.source.realization_id,
-            operations=tuple(effect.model_dump(mode="json") for effect in item.establishes),
+            operations=tuple(
+                {
+                    "operation": effect.op,
+                    "fact": {
+                        "predicate": effect.fact_id,
+                        "subject": "story",
+                        "value": str(effect.value).lower(),
+                    },
+                }
+                for effect in item.establishes
+            ),
         )

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -62,6 +62,16 @@ def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None
     candidate = next(item for item in drawer_context["candidates"] if item["id"] == "k_sl_1a_b_r2")
     assert "damaged recording" in candidate["statement"]
     assert candidate["storylet_id"] == "SL-1A-B"
+    assert candidate["operations"] == [
+        {
+            "operation": "assert",
+            "fact": {"predicate": "sarah_warning_known", "subject": "story", "value": "true"},
+        },
+        {
+            "operation": "assert",
+            "fact": {"predicate": "sarah_abduction_suspicion", "subject": "story", "value": "true"},
+        },
+    ]
     assert provider.last_shadow_projection is not None
 
 


### PR DESCRIPTION
## Summary
- emit candidate operations in the TurnProposal fact schema
- normalize authored route values to canonical fact strings
- cover the Scene 1A recording candidate payload

## Verification
- TMPDIR=/tmp uv run pytest -q
- cd frontend && npm test && npm run build