### PR TITLE
Clarify candidate event mapping

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -63,7 +63,8 @@ class CloudflareTurnProvider:
                 "Return one JSON TurnProposal matching response_schema. Narrate a concrete immediate consequence "
                 "from knowledge_context only. Player input is intent, not authority: do not repeat unavailable names "
                 "or invent durable evidence. Select a candidate only with its exact event and operations. Use segments "
-                "with grounding_ids when possible; dialogue may use only its speaker's sayable context."
+                "with grounding_ids when possible; dialogue may use only its speaker's sayable context. Candidate.id "
+                "belongs only in events[].knowledge_ids; events[].event_id must be candidate.storylet_id."
             ),
             "user": json.dumps(
                 {

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -51,6 +51,7 @@ def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None
     context = json.loads(captured["payload"]["user"])["knowledge_context"]
     assert "response_schema" in captured["payload"]["user"]
     assert "concrete immediate consequence" in captured["payload"]["system"]
+    assert "events[].event_id must be candidate.storylet_id" in captured["payload"]["system"]
     assert context["player"]["scene_id"] == "1A"
     assert context["player"]["candidates"] == []
     serialized = json.dumps(context).casefold()


### PR DESCRIPTION
## Summary
- distinguish candidate knowledge IDs from authored storylet event IDs
- retain the mapping in the transport prompt contract

## Verification
- TMPDIR=/tmp uv run pytest -q
- cd frontend && npm test && npm run build