### PR TITLE
Canonicalize selected knowledge event operations

### DIFF
--- a/storygame/runtime/validation.py
+++ b/storygame/runtime/validation.py
@@ -58,6 +58,9 @@ class ProgressionValidator:
         """
 
         proposal = proposal.model_copy(
+            update={"events": tuple(self._canonicalize_selected_knowledge_event(event) for event in proposal.events)}
+        )
+        proposal = proposal.model_copy(
             update={
                 "operations": tuple(
                     operation
@@ -66,6 +69,7 @@ class ProgressionValidator:
                 )
             }
         )
+
         if not proposal.operations:
             return proposal
         canonical_operations = tuple(
@@ -138,6 +142,29 @@ class ProgressionValidator:
                     ),
                 ),
             }
+        )
+
+    def _canonicalize_selected_knowledge_event(self, event: StoryEventProposal) -> StoryEventProposal:
+        """Use package operations only when selected knowledge proves this exact realization."""
+
+        if not event.knowledge_ids:
+            return event
+        route = self._routes.get(event.event_id)
+        realization = (
+            next((item for item in route.realizations if item.id == event.realization_id), None) if route else None
+        )
+        if realization is None:
+            return event
+        knowledge = self.package.knowledge_indexes.by_id
+        if not all(
+            item_id in knowledge
+            and knowledge[item_id].source.storylet_id == route.id
+            and knowledge[item_id].source.realization_id == realization.id
+            for item_id in event.knowledge_ids
+        ):
+            return event
+        return event.model_copy(
+            update={"operations": tuple(self._route_operation(operation) for operation in realization.operations)}
         )
 
     def _canonical_operation_is_noop(self, state: RuntimeState, operation: FactOperation) -> bool:

--- a/tests/test_scene_progression_phase4.py
+++ b/tests/test_scene_progression_phase4.py
@@ -6,12 +6,28 @@ from pathlib import Path
 
 import pytest
 
+from storygame.runtime.contracts import StoryEventProposal
 from storygame.runtime.engine import RuntimeEngine
 from storygame.runtime.facts import Fact
 from storygame.runtime.state import RuntimeState, RuntimeStateError
+from storygame.runtime.validation import ProgressionValidator
 from storygame.story_package.loader import load_story_package
 
 PACKAGE = load_story_package(Path("data/stories/continuity-initiative"))
+
+
+def test_selected_knowledge_canonicalizes_its_exact_realization_operations() -> None:
+    event = StoryEventProposal(
+        event_id="SL-1A-B",
+        realization_id="SL-1A-B-R1",
+        knowledge_ids=("k_sl_1a_b_r1",),
+        operations=(),
+    )
+
+    normalized = ProgressionValidator(PACKAGE)._canonicalize_selected_knowledge_event(event)
+
+    assert normalized.operations
+    assert all(operation.fact.value == "true" for operation in normalized.operations)
 
 
 def _provider(payload: dict[str, object], calls: list[str]):


### PR DESCRIPTION
## Summary
- canonicalize operations only when selected knowledge proves the exact authored realization
- retain strict validation for every other event

## Verification
- TMPDIR=/tmp uv run pytest -q