### PR TITLE
Discard unverifiable event wrappers

### DIFF
--- a/storygame/runtime/validation.py
+++ b/storygame/runtime/validation.py
@@ -94,9 +94,9 @@ class ProgressionValidator:
                 # and let the same route-subset recovery below prove the
                 # package-authorized effect; otherwise validation still rejects
                 # the proposal unchanged.
+                proposal = proposal.model_copy(update={"events": ()})
                 if not proposal.operations:
                     return proposal
-                proposal = proposal.model_copy(update={"events": ()})
             else:
                 return proposal.model_copy(
                     update={


### PR DESCRIPTION
Preserve narration but reject fact mutation when a provider event wrapper cannot be structurally proven.\n\nVerification: TMPDIR=/tmp uv run pytest -q