### PR TITLE
Make the full canon journey playable end to end

### DIFF
--- a/data/stories/continuity-initiative/knowledge.yaml
+++ b/data/stories/continuity-initiative/knowledge.yaml
@@ -211,28 +211,28 @@ scene_frames:
     beside an overturned chair, while her laptop and work bag are gone.
   pressure: Find evidence of Michelle's disappearance
 - scene_id: 1B
-  situation: Enter 1B
+  situation: 'A damaged public park holding Michelle''s dead drop: an ordinary bench with a transit access card, a handwritten number sequence, a photograph of Michelle with an unidentified man, and a list of earlier disappearance dates hidden beneath it. A watcher lingers across the park while emergency patrols sweep the paths.'
   pressure: Follow Michelle's lead and survive the park
 - scene_id: 1C
-  situation: Enter 1C
+  situation: A supposedly abandoned freight terminal above an underground installation. The transit card opens the service level; fresh tire tracks, air vents, and heavy electrical service confirm the site is active. An observation shaft overlooks a prisoner processing area, and an unattended logistics terminal glows nearby.
   pressure: Confirm the facility and its purpose
 - scene_id: 2A
-  situation: Enter 2A
+  situation: Brandon's fortified hideout inside an abandoned communications center, stocked with servers and leaked Initiative documents. The facility's overstressed cooling and support-column monitoring requires outside inspectors - a flaw that false credentials could exploit to reach its restricted corridors.
   pressure: Enter the facility under false identities
 - scene_id: 2B
-  situation: Enter 2B
+  situation: 'The facility''s records archive: selection files, development records naming the system''s authors, and corrupted prisoner files threaded with oddly familiar phrasing. A medical terminal''s maintenance reports carry a rhythm that reads like a message.'
   pressure: Secure evidence while judging Brandon's betrayal
 - scene_id: 2C
-  situation: Enter 2C
+  situation: 'The command levels during an accelerating crisis: private executive channels, transfer orders, and a purge countdown already moving. In the maintenance network, a coded message waits for someone who knows Michelle''s phrasing.'
   pressure: Survive the purge clock and choose a combined mission
 - scene_id: 3A
-  situation: Enter 3A
+  situation: 'The detention sector: holding blocks, stolen radios, a medical level bearing the experiments, and an imprisoned senior official whose emergency military override codes expire the moment the new authority activates.'
   pressure: Reach Michelle and join the uprising
 - scene_id: 3B
-  situation: Enter 3B
+  situation: Security corridors between the resistance and Rebecca's executive office. The predictive system anticipates every rational move; only conflicting, irrational emergencies confuse it. Beyond the office lies the external broadcast relay chamber.
   pressure: Overload JANUS and seize the broadcast
 - scene_id: 3C
-  situation: Enter 3C
+  situation: 'Rebecca''s office and the broadcast chamber as the facility begins to fail: the open relay, the national broadcast controls, a portable archive naming conspirators and prisoner locations, and escape routes that will not stay open long.'
   pressure: Expose the network and escape
 knowledge:
 - id: k_sl_1a_a_r1
@@ -472,10 +472,11 @@ knowledge:
     entity_ids: []
     priority: 0
 - id: k_sl_1b_b_r2
-  statement: 'Brandon admits he knew Michelle, but his evasions leave Kristin unsure whether he came to help or watch her.'
+  statement: 'Brandon admits he knew Michelle and insists the missing may still be alive, but his evasions leave Kristin unsure whether he came to help or watch her.'
   entity_ids: []
   aliases:
   - brandon identified
+  - missing may be alive
   audience:
     kind: public
     player_visible: true
@@ -485,6 +486,9 @@ knowledge:
   establishes:
   - op: assert
     fact_id: brandon_identified
+    value: true
+  - op: assert
+    fact_id: missing_may_be_alive
     value: true
   source:
     kind: storylet_realization
@@ -528,10 +532,11 @@ knowledge:
     entity_ids: []
     priority: 0
 - id: k_sl_1b_c_r2
-  statement: 'Brandon enters a code no civilian should know, getting them clear of the ambush while deepening Kristin’s suspicion.'
+  statement: 'Brandon enters a code no civilian should know, getting them clear toward the freight route while deepening Kristin’s suspicion.'
   entity_ids: []
   aliases:
   - brandon retains system access
+  - transport route identified
   - park pursuit resolved
   audience:
     kind: public
@@ -546,6 +551,9 @@ knowledge:
   establishes:
   - op: assert
     fact_id: brandon_retains_system_access
+    value: true
+  - op: assert
+    fact_id: transport_route_identified
     value: true
   - op: assert
     fact_id: park_pursuit_resolved
@@ -630,9 +638,10 @@ knowledge:
     entity_ids: []
     priority: 0
 - id: k_sl_1c_b_r2
-  statement: 'Kristin glimpses a woman who could be Michelle in a transfer line, but the view vanishes before she can be sure.'
+  statement: 'Kristin sees sedated captives alive in the processing line and glimpses a woman who could be Michelle before the view vanishes.'
   entity_ids: []
   aliases:
+  - captives confirmed alive
   - michelle possible sighting
   audience:
     kind: public
@@ -643,6 +652,9 @@ knowledge:
   - fact_id: facility_proof
     equals: true
   establishes:
+  - op: assert
+    fact_id: captives_confirmed_alive
+    value: true
   - op: assert
     fact_id: michelle_possible_sighting
     value: true
@@ -1246,34 +1258,11 @@ knowledge:
     entity_ids: []
     priority: 0
 - id: k_sl_3a_b_r1
-  statement: 'Kristin learns Charles’s planned survivors were conditioned to support his story before their public release.'
+  statement: 'Michelle shows Kristin the experiment records proving planned "survivors" were conditioned to support Charles''s story, and the framed official hands over expiring military override codes.'
   entity_ids: []
   aliases:
   - conditioned release plan known
-  audience:
-    kind: public
-    player_visible: true
-  available_in_scenes:
-  - 3A
-  requires:
-  - fact_id: michelle_reached
-    equals: true
-  establishes:
-  - op: assert
-    fact_id: conditioned_release_plan_known
-    value: true
-  source:
-    kind: storylet_realization
-    storylet_id: SL-3A-B
-    realization_id: SL-3A-B-R1
-  relevance:
-    entity_ids: []
-    priority: 0
-- id: k_sl_3a_b_r2
-  statement: 'Michelle shows Kristin the medical level where prisoners were subjected to memory, compliance, and resistance experiments.'
-  entity_ids: []
-  aliases:
-  - behavioral experiments known
+  - military override codes available
   audience:
     kind: public
     player_visible: true
@@ -1286,19 +1275,28 @@ knowledge:
   - op: assert
     fact_id: behavioral_experiments_known
     value: true
+  - op: assert
+    fact_id: conditioned_release_plan_known
+    value: true
+  - op: assert
+    fact_id: military_override_codes_available
+    value: true
+  - op: assert
+    fact_id: charles_framed_officials_known
+    value: true
   source:
     kind: storylet_realization
     storylet_id: SL-3A-B
-    realization_id: SL-3A-B-R2
+    realization_id: SL-3A-B-R1
   relevance:
     entity_ids: []
     priority: 0
-- id: k_sl_3a_c_r1
-  statement: 'An imprisoned official gives Kristin military override codes that expire when Charles formally claims emergency authority.'
+- id: k_sl_3a_b_r2
+  statement: 'Michelle shows Kristin the medical level where prisoners were subjected to memory, compliance, and resistance experiments, and Kristin copies the imprisoned official''s usable override authorization.'
   entity_ids: []
   aliases:
+  - behavioral experiments known
   - military override codes available
-  - override codes deadline known
   audience:
     kind: public
     player_visible: true
@@ -1307,17 +1305,38 @@ knowledge:
   requires:
   - fact_id: michelle_reached
     equals: true
-  - fact_id: behavioral_experiments_known
-    equals: true
   establishes:
   - op: assert
-    fact_id: charles_framed_officials_known
+    fact_id: behavioral_experiments_known
     value: true
   - op: assert
     fact_id: military_override_codes_available
     value: true
+  source:
+    kind: storylet_realization
+    storylet_id: SL-3A-B
+    realization_id: SL-3A-B-R2
+  relevance:
+    entity_ids: []
+    priority: 0
+- id: k_sl_3a_c_r1
+  statement: 'Michelle triggers the coordinated uprising; prisoners seize checkpoints and open a fighting route toward the command and broadcast levels.'
+  entity_ids: []
+  aliases:
+  - detention uprising started
+  audience:
+    kind: public
+    player_visible: true
+  available_in_scenes:
+  - 3A
+  requires:
+  - fact_id: michelle_reached
+    equals: true
+  - fact_id: uprising_prepared
+    equals: true
+  establishes:
   - op: assert
-    fact_id: override_codes_deadline_known
+    fact_id: detention_uprising_started
     value: true
   source:
     kind: storylet_realization
@@ -1327,37 +1346,7 @@ knowledge:
     entity_ids: []
     priority: 0
 - id: k_sl_3a_c_r2
-  statement: 'Kristin learns Charles framed the captive official for the catastrophe, leaving the rescue tied to a vanishing deadline.'
-  entity_ids: []
-  aliases:
-  - military override codes available
-  - override codes deadline known
-  audience:
-    kind: public
-    player_visible: true
-  available_in_scenes:
-  - 3A
-  requires:
-  - fact_id: michelle_reached
-    equals: true
-  - fact_id: behavioral_experiments_known
-    equals: true
-  establishes:
-  - op: assert
-    fact_id: military_override_codes_available
-    value: true
-  - op: assert
-    fact_id: override_codes_deadline_known
-    value: true
-  source:
-    kind: storylet_realization
-    storylet_id: SL-3A-C
-    realization_id: SL-3A-C-R2
-  relevance:
-    entity_ids: []
-    priority: 0
-- id: k_sl_3a_c_r3
-  statement: 'Michelle triggers the uprising; prisoners seize checkpoints as Charles seals the exits and sends armed teams below.'
+  statement: 'With the override codes about to expire under Charles''s new authority, Michelle launches the prepared uprising rather than wait.'
   entity_ids: []
   aliases:
   - detention uprising started
@@ -1370,7 +1359,7 @@ knowledge:
   requires:
   - fact_id: michelle_reached
     equals: true
-  - fact_id: behavioral_experiments_known
+  - fact_id: uprising_prepared
     equals: true
   establishes:
   - op: assert
@@ -1382,7 +1371,7 @@ knowledge:
   source:
     kind: storylet_realization
     storylet_id: SL-3A-C
-    realization_id: SL-3A-C-R3
+    realization_id: SL-3A-C-R2
   relevance:
     entity_ids: []
     priority: 0
@@ -1507,8 +1496,8 @@ knowledge:
   - relay open
   - brandon confession available
   audience:
-    kind: world_only
-    player_visible: false
+    kind: public
+    player_visible: true
   available_in_scenes:
   - 3B
   requires:
@@ -1539,8 +1528,8 @@ knowledge:
   - relay open
   - brandon confession available
   audience:
-    kind: world_only
-    player_visible: false
+    kind: public
+    player_visible: true
   available_in_scenes:
   - 3B
   requires:

--- a/data/stories/continuity-initiative/pacing.yaml
+++ b/data/stories/continuity-initiative/pacing.yaml
@@ -68,7 +68,7 @@ transitions:
   triggers:
   - fact_id: michelle_lead_actionable
     equals: true
-  - fact_id: house_marked_for_return
+  - fact_id: patrol_return_pressure
     equals: true
   required_dependencies:
   - memory_card

--- a/data/stories/continuity-initiative/plot.md
+++ b/data/stories/continuity-initiative/plot.md
@@ -124,7 +124,7 @@ freytag_phase: rising_action
 objective: Follow Michelles lead and survive the park
 participant_ids: [kristin, brandon, michelle]
 item_ids: [memory_card, transit_card]
-entry_text: "Enter 1B"
+entry_text: "The park was quieter than the streets around it. Michelle's files pointed to an ordinary bench near the service path - the dead drop where she traded information with a source she never named. Kristin crossed the damaged grounds, keeping clear of the checkpoints, and knelt beside the bench.\n\n"
 transition_ids: [t_1b_1c]
 ---
 
@@ -186,7 +186,7 @@ freytag_phase: rising_action
 objective: Confirm the facility and its purpose
 participant_ids: [kristin, brandon, michelle]
 item_ids: [transit_card]
-entry_text: "Enter 1C"
+entry_text: "The transit card led to a freight terminal that was supposed to be abandoned. Fresh tire tracks, humming air vents, and unusually heavy electrical service said otherwise. Kristin and Brandon slipped into the service level beneath the loading docks, where an observation shaft overlooked something much larger below.\n\n"
 transition_ids: [t_1c_2a]
 ---
 
@@ -264,7 +264,7 @@ freytag_phase: rising_action
 objective: Enter the facility under false identities
 participant_ids: [kristin, brandon]
 item_ids: [transit_card]
-entry_text: "Enter 2A"
+entry_text: "Brandon's hideout was buried inside a dead communications center: servers, salvaged hardware, and years of leaked Continuity Initiative documents. Somewhere beneath the city the facility waited, and its overstressed cooling and support columns were exactly the kind of flaw a pair of outside inspectors might be sent to examine.\n\n"
 transition_ids: [t_2a_2b]
 ---
 
@@ -324,7 +324,7 @@ freytag_phase: crisis
 objective: Secure evidence while judging Brandons betrayal
 participant_ids: [kristin, brandon, michelle]
 item_ids: [memory_card]
-entry_text: "Enter 2B"
+entry_text: "The records archive hummed behind the restricted corridor. Rows of terminals held the Initiative's selection files - and, somewhere in them, the answers to why Michelle was taken and who helped build the system that chose her.\n\n"
 transition_ids: [t_2b_2c]
 ---
 
@@ -397,7 +397,7 @@ freytag_phase: crisis
 objective: Survive the purge clock and choose a combined mission
 participant_ids: [kristin, brandon]
 item_ids: [memory_card]
-entry_text: "Enter 2C"
+entry_text: "The command levels tightened around them. Somewhere above, orders were already moving - transfers, schedules, contingency plans measured in hours instead of days. Whatever Kristin and Brandon did next had to count.\n\n"
 transition_ids: [t_2c_3a]
 ---
 
@@ -474,7 +474,7 @@ freytag_phase: crisis
 objective: Reach Michelle and join the uprising
 participant_ids: [kristin, michelle, brandon]
 item_ids: [override_codes]
-entry_text: "Enter 3A"
+entry_text: "The detention sector doors opened onto rows of holding blocks. Coded announcements crackled through stolen radios, and the prisoners moved with a discipline no captor had taught them - someone inside had been organizing this long before rescue arrived.\n\n"
 transition_ids: [t_3a_3b]
 ---
 
@@ -534,7 +534,7 @@ freytag_phase: climax
 objective: Overload JANUS and seize the broadcast
 participant_ids: [kristin, brandon, rebecca]
 item_ids: [override_codes]
-entry_text: "Enter 3B"
+entry_text: "Alarms layered over alarms as the facility fought to predict its attackers. Above the fighting, Rebecca's executive office and the external broadcast relay waited at the end of corridors that JANUS watched move by move.\n\n"
 transition_ids: [t_3b_3c]
 ---
 
@@ -594,7 +594,7 @@ freytag_phase: resolution
 objective: Expose the network and escape
 participant_ids: [kristin, michelle, brandon, rebecca]
 item_ids: [memory_card]
-entry_text: "Enter 3C"
+entry_text: "The broadcast chamber lights steadied as Brandon's relay held open. Outside, the facility was beginning to fail; inside, the evidence was ready to leave for good.\n\n"
 transition_ids: []
 ---
 

--- a/data/stories/continuity-initiative/storylet-routes.yaml
+++ b/data/stories/continuity-initiative/storylet-routes.yaml
@@ -618,11 +618,14 @@ storylets:
     - janus_selection_system
     - phase_two
   - id: SL-1B-B-R2
-    dramatic_intent: Kristin confronts him with the photograph; Brandon admits prior Initiative work but withholds
-      the protected JANUS role.
+    dramatic_intent: Kristin confronts him with the photograph; Brandon admits prior Initiative work and that the
+      missing may still be alive, but withholds the protected JANUS role.
     operations:
     - op: assert
       fact_id: brandon_identified
+      value: true
+    - op: assert
+      fact_id: missing_may_be_alive
       value: true
     eligible_storylet_event_id: null
     helps_transition_triggers: []
@@ -676,11 +679,14 @@ storylets:
     - janus_selection_system
     - phase_two
   - id: SL-1B-C-R2
-    dramatic_intent: Kristin notices Brandon’s practiced system access during escape and carries that unresolved
-      suspicion forward.
+    dramatic_intent: Kristin notices Brandon’s practiced system access during the maintenance-route escape and carries
+      that unresolved suspicion forward while the transport route toward the freight terminal becomes clear.
     operations:
     - op: assert
       fact_id: brandon_retains_system_access
+      value: true
+    - op: assert
+      fact_id: transport_route_identified
       value: true
     - op: assert
       fact_id: park_pursuit_resolved
@@ -783,8 +789,12 @@ storylets:
     - brandon_history
     - phase_two
   - id: SL-1C-B-R2
-    dramatic_intent: Catch an obscured possible glimpse of Michelle without converting uncertainty into confirmed location.
+    dramatic_intent: Confirm the sedated captives are alive and catch an obscured possible glimpse of Michelle without
+      converting uncertainty into confirmed location.
     operations:
+    - op: assert
+      fact_id: captives_confirmed_alive
+      value: true
     - op: assert
       fact_id: michelle_possible_sighting
       value: true
@@ -1379,25 +1389,38 @@ storylets:
       latest_seconds: 900
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: When the player wants to rush upward, make the medical level evidence matter by showing why exposure
-    must include the conditioning program.
+    must include the conditioning program, and let the imprisoned official's expiring codes reward the documentation
+    detour.
   realization_options:
   - id: SL-3A-B-R1
-    dramatic_intent: Corroborate Michelle’s account with experiment records and establish that selected released captives
-      were being conditioned for Charles’s narrative.
+    dramatic_intent: Corroborate Michelle’s account with experiment records, establish that selected released captives
+      were being conditioned for Charles’s narrative, and secure the framed official’s emergency override codes.
     operations:
     - op: assert
+      fact_id: behavioral_experiments_known
+      value: true
+    - op: assert
       fact_id: conditioned_release_plan_known
+      value: true
+    - op: assert
+      fact_id: military_override_codes_available
+      value: true
+    - op: assert
+      fact_id: charles_framed_officials_known
       value: true
     eligible_storylet_event_id: null
     helps_transition_triggers: []
     protected_knowledge_boundaries:
     - phase_two
   - id: SL-3A-B-R2
-    dramatic_intent: Inspect treatment setup and establish the behavioral-experiment program without claiming guaranteed
-      mind control.
+    dramatic_intent: Inspect treatment setup, establish the behavioral-experiment program without claiming guaranteed
+      mind control, and copy the imprisoned official’s usable authorization codes.
     operations:
     - op: assert
       fact_id: behavioral_experiments_known
+      value: true
+    - op: assert
+      fact_id: military_override_codes_available
       value: true
     eligible_storylet_event_id: null
     helps_transition_triggers: []
@@ -1414,53 +1437,35 @@ storylets:
     as choices, commands, or required actions; equivalent player-authored approaches may validate the same operations.
 - id: SL-3A-C
   scene_id: 3A
-  title: The Override Codes Are Expiring
+  title: The Uprising Begins
   activation:
     scene_id: 3A
     conditions:
     - fact_id: michelle_reached
       equals: true
-    - fact_id: behavioral_experiments_known
+    - fact_id: uprising_prepared
       equals: true
     pacing:
       earliest_seconds: 780
       target_seconds: 840
       latest_seconds: 900
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
-  pressure_role: 'Add a second deadline when the player lingers: the imprisoned official’s codes lose value once
-    Charles activates the new authority.'
+  pressure_role: 'Convert the expiring authorization into forward motion: once the codes lose value with Charles’s
+    new authority, Michelle’s prepared disturbances become the only viable route upward.'
   realization_options:
   - id: SL-3A-C-R1
-    dramatic_intent: Secure the emergency override codes and understand their expiration condition.
+    dramatic_intent: Michelle triggers the coordinated disturbances across the detention sectors and the group turns
+      the freed checkpoints into a route toward the command levels.
     operations:
     - op: assert
-      fact_id: charles_framed_officials_known
-      value: true
-    - op: assert
-      fact_id: military_override_codes_available
-      value: true
-    - op: assert
-      fact_id: override_codes_deadline_known
+      fact_id: detention_uprising_started
       value: true
     eligible_storylet_event_id: null
-    helps_transition_triggers: []
+    helps_transition_triggers:
+    - t_3a_3b
     protected_knowledge_boundaries:
     - phase_two
   - id: SL-3A-C-R2
-    dramatic_intent: Relay/copy the codes rather than physically carry them, preserving free-form action while establishing
-      that the resistance has usable authorization.
-    operations:
-    - op: assert
-      fact_id: military_override_codes_available
-      value: true
-    - op: assert
-      fact_id: override_codes_deadline_known
-      value: true
-    eligible_storylet_event_id: null
-    helps_transition_triggers: []
-    protected_knowledge_boundaries:
-    - phase_two
-  - id: SL-3A-C-R3
     dramatic_intent: The expiring authorization window makes further delay untenable; Michelle launches the coordinated
       disturbances while the codes are still useful.
     operations:
@@ -1477,10 +1482,7 @@ storylets:
     - phase_two
   completion_or_abort:
     complete_when:
-    - any_fact_true:
-      - military_override_codes_available
-      - detention_uprising_started
-    - fact_id: override_codes_deadline_known
+    - fact_id: detention_uprising_started
       equals: true
     abort_when:
     - scene_id_not: 3A
@@ -2025,7 +2027,9 @@ canonical_transition_snapshot:
 canonical_bridge_events:
 - id: bridge_1a_actionable_lead
   scene_id: 1A
-  activation: {}
+  activation:
+    all_facts_true:
+    - continuity_initiative_known
   produces:
   - op: assert
     fact_id: michelle_lead_actionable
@@ -2058,8 +2062,6 @@ canonical_bridge_events:
     all_facts_true:
     - facility_proof
     - captives_confirmed_alive
-    - national_detention_network_known
-    - architects_strategy_known
   produces:
   - op: assert
     fact_id: facility_infiltration_needed
@@ -2075,6 +2077,7 @@ canonical_bridge_events:
   activation:
     all_facts_true:
     - false_identities_ready
+    - rebecca_observing_infiltrators
   produces:
   - op: assert
     fact_id: restricted_corridor_access
@@ -2088,7 +2091,6 @@ canonical_bridge_events:
   activation:
     all_facts_true:
     - janus_evidence
-    - kristin_deliberately_left_behind
     - brandon_janus_role_known
     - brandon_claimed_reform_motive
     - michelle_resistance_known
@@ -2107,6 +2109,7 @@ canonical_bridge_events:
   activation:
     all_facts_true:
     - purge_clock_started
+    - evidence_ready_to_transmit
   produces:
   - op: assert
     fact_id: combined_broadcast_rescue_plan_known
@@ -2120,8 +2123,6 @@ canonical_bridge_events:
   activation:
     all_facts_true:
     - michelle_reached
-    - behavioral_experiments_known
-    - override_codes_deadline_known
     - detention_uprising_started
   produces:
   - op: assert

--- a/data/stories/continuity-initiative/storylets.md
+++ b/data/stories/continuity-initiative/storylets.md
@@ -1043,7 +1043,7 @@ Each entry below is authoring data, not a player action menu.
 
 ### SL-3A-B — The “Rescued” Captives Were Being Prepared
 
-**Source beats:** [3A.2 — The Experiments](plot.md#scene-3a2--the-experiments)
+**Source beats:** [3A.2 — The Experiments](plot.md#scene-3a2--the-experiments), [3A.3 — The Unexpected Prisoner](plot.md#scene-3a3--the-unexpected-prisoner)
 
 **Allowed scene:** `3A`
 
@@ -1055,21 +1055,24 @@ Each entry below is authoring data, not a player action menu.
 **Participants / items**
 - Kristin Schweitzer
 - Dr. Michelle McGehee
-- Prisoners
+- Prisoners, including the imprisoned senior official
 - Medical/behavioral experiment records or equipment already present in the authored setting
+- Emergency military override authorization codes
 
 **Dramatic purpose**
 - Raise the moral and political stakes of Charles’s planned broadcast.
 - Show that simply releasing selected prisoners could strengthen the conspiracy.
+- Turn one prisoner into a time-sensitive strategic resource without making the NPC a permanent companion.
 
 **Possible realizations**
-- Michelle explains what she has observed while Kristin sees corroborating evidence.
-- A conditioned “rescue” plan becomes visible through records or treatment setup.
+- Michelle explains what she has observed while Kristin sees corroborating evidence, and the framed official hands over his expiring authorization.
+- A conditioned “rescue” plan becomes visible through records or treatment setup while the codes are secured or copied.
 - Kristin recognizes that public testimony itself has been engineered.
 
 **Effects**
 - May set `behavioral_experiments_known`.
 - May set `conditioned_release_plan_known`.
+- May set `military_override_codes_available` and `charles_framed_officials_known`.
 - May make the broadcast evidence more compelling.
 - May increase danger or moral urgency.
 
@@ -1081,6 +1084,7 @@ Each entry below is authoring data, not a player action menu.
 
 **Protected boundary**
 - Do not invent successful mind control beyond the specific authored methods and goals.
+- The codes do not automatically solve the facility fight or national conspiracy.
 
 **Pacing window**
 - earliest: `00:13:00`
@@ -1092,52 +1096,44 @@ Each entry below is authoring data, not a player action menu.
 
 ---
 
-### SL-3A-C — The Override Codes Are Expiring
+### SL-3A-C — The Uprising Begins
 
-**Source beats:** [3A.3 — The Unexpected Prisoner](plot.md#scene-3a3--the-unexpected-prisoner), [3A.4 — The Uprising Begins](plot.md#scene-3a4--the-uprising-begins)
+**Source beats:** [3A.4 — The Uprising Begins](plot.md#scene-3a4--the-uprising-begins)
 
 **Allowed scene:** `3A`
 
 **Available when**
 - Kristin has reached Michelle.
-- The behavioral-experiment stakes have been established.
-- The senior official prisoner is reachable.
+- Michelle’s uprising preparation is in place.
 - Charles’s planned authority activation remains pending.
 
 **Participants / items**
 - Kristin Schweitzer
 - Dr. Michelle McGehee
 - Brandon Corfman
-- Senior official prisoner
-- Emergency military override authorization codes
+- Organized prisoners across the detention sectors
 
 **Dramatic purpose**
-- Add a second deadline tied directly to the national political takeover.
-- Turn one prisoner into a time-sensitive strategic resource without making the NPC a permanent companion.
+- Convert the expiring authorization deadline into forward motion toward the command levels.
+- Commit the resistance to the coordinated assault that carries the story into Scene 3B.
 
 **Possible realizations**
-- The official explains that Charles framed and imprisoned members of his own government.
-- Michelle evaluates the codes as one more way to disrupt the takeover.
-- The uprising may begin before every implication can be discussed.
-- The expiring authorization window can itself force the resistance to launch coordinated disturbances.
-- The codes can be secured or relayed according to validated free-form action.
+- Michelle triggers coordinated disturbances and the freed checkpoints become a route upward.
+- The expiring authorization window itself forces the resistance to launch while the codes retain value.
 
 **Effects**
-- May set `charles_framed_officials_known`.
-- May set `military_override_codes_available`.
-- Starts/advances `override_codes_deadline_known`.
-- May set `detention_uprising_started` when the deadline forces Michelle to launch the resistance.
-- May help resistance efforts under declared package rules; securing the codes is not required for the Scene 3A → 3B transition.
+- Sets `detention_uprising_started`.
+- May advance `override_codes_deadline_known` when the deadline forces the launch.
+- Helps the Scene 3A → 3B transition under declared package rules.
 
 **Completion**
-- The codes and their expiration condition are understood/secured, or a declared alternate path makes them unnecessary.
+- The uprising is underway and the group is committed to fighting toward the command and broadcast levels.
 
 **Abort**
-- The codes expire after the relevant pacing deadline.
-- The NPC becomes unavailable; future satisfiability determines whether a warning is required.
+- Immediate security lockdown pins the resistance before the disturbances can begin.
 
 **Protected boundary**
-- The codes do not automatically solve the facility fight or national conspiracy.
+- The uprising does not by itself defeat JANUS, seize the broadcast, or resolve the national conspiracy.
 
 **Pacing window**
 - earliest: `00:13:00`

--- a/frontend/e2e/canon-journey.js
+++ b/frontend/e2e/canon-journey.js
@@ -1,74 +1,154 @@
+// One turn per authored knowledge selection: the runtime commits at most one
+// storylet realization per turn, so every scene needs as many turns as the
+// facts its outgoing bridge requires. Inputs steer the provider toward the
+// intended candidate without naming knowledge the player cannot have yet.
 export const canonJourney = [
   {
-    input: "I stay concealed in Michelle's house and watch the marked gate for the federal patrol's return without leaving or following a lead.",
+    input:
+      "I search the house for concrete signs Michelle was taken - the overturned chair, the forced back door - and I stay hidden while I watch the marked front gate for the patrol's return.",
     clock: { eventId: "pressure_1a" },
     expectedSceneId: "1A",
     expectedEventIds: ["pressure_1a"],
   },
   {
-    input: "I retrieve the hidden memory card from beneath the drawer, preserve it, and use Michelle's research to identify an actionable lead away from the house while noting the patrol mark.",
+    input:
+      "I retrieve the hidden memory card taped beneath the drawer, preserve Michelle's research, and use it to identify an actionable lead away from the house.",
     clock: { sceneId: "1B", point: "target" },
     expectedSceneId: "1B",
     expectedEventIds: ["pressure_1a"],
   },
   {
-    input: "I follow Michelle's park dead drop, take the transit card, identify Brandon from her photograph, and escape the ambush with him so we can depart for the freight terminal.",
+    input:
+      "At the park dead drop I take the transit card and the photograph, and when the stranger from the photo intervenes against the patrol I demand to know who he is and whether the missing are still alive.",
+    clock: { sceneId: "1B", point: "latest" },
+    expectedSceneId: "1B",
+    expectedEventIds: ["pressure_1a"],
+  },
+  {
+    input:
+      "I escape with him through the storm drains and watch closely as he unlocks the secured maintenance gate with a specialized code no civilian should have, following the route toward the freight terminal.",
     clock: { sceneId: "1C", point: "target" },
     expectedSceneId: "1C",
     expectedEventIds: ["pressure_1a"],
   },
   {
-    input: "I confirm living captives and the nationwide facility network, then conclude that Brandon and I need controlled deeper access rather than a reckless rescue attempt.",
+    input:
+      "I use the transit card at the freight terminal and slip into the service level to confirm the site is active beneath the abandoned surface.",
+    clock: { sceneId: "1C", point: "latest" },
+    expectedSceneId: "1C",
+    expectedEventIds: ["pressure_1a"],
+  },
+  {
+    input:
+      "From the observation shaft I document the rows of sedated prisoners being moved and match their identification numbers against the missing-person files, accepting that we need controlled deeper access rather than a reckless rescue.",
     clock: { sceneId: "2A", point: "target" },
     expectedSceneId: "2A",
     expectedEventIds: ["pressure_1a"],
   },
   {
-    input: "I prepare false inspector identities around the facility's real cooling risk, enter under that cover, and convince the supervisor to give us restricted infrastructure-corridor access.",
+    input:
+      "At the hideout I build false inspector identities around the facility's real cooling and support-column failure risk so we can enter as technical specialists.",
+    clock: { sceneId: "2A", point: "latest" },
+    expectedSceneId: "2A",
+    expectedEventIds: ["pressure_1a"],
+  },
+  {
+    input:
+      "We enter under the inspection cover and I convince the questioning supervisor that a progressive support-column collapse is imminent, gaining access to the restricted infrastructure corridors.",
     clock: { sceneId: "2B", point: "target" },
     expectedSceneId: "2B",
     expectedEventIds: ["pressure_1a"],
   },
   {
-    input: "I secure the JANUS archive evidence, learn that Kristin was deliberately left behind, confront Brandon about helping build JANUS and his claimed reform motive, and recognize Michelle's active resistance in the corrupted prisoner records.",
-    clock: { sceneId: "2C", point: "earliest" },
-    expectedSceneId: "2C",
+    input:
+      "In the records archive I open the selection files to learn why Michelle was taken and why I was left behind.",
+    clock: { sceneId: "2B", point: "latest" },
+    expectedSceneId: "2B",
     expectedEventIds: ["pressure_1a"],
   },
   {
-    input: "I read and verify Charles's purge and transfer order from the coordinated movement, treating the deadline as active while keeping the evidence and rescue mission together.",
-    clock: { eventId: "purge_2c" },
+    input:
+      "I confront my ally with his name in the original development records and demand the truth about his role and his motives.",
+    clock: { sceneId: "2B", point: "latest" },
+    expectedSceneId: "2B",
+    expectedEventIds: ["pressure_1a"],
+  },
+  {
+    input:
+      "I trace the corrupted prisoner files and equipment failures and recognize Michelle's phrasing in them - she has been resisting from inside.",
+    clock: { sceneId: "2C", point: "target" },
     expectedSceneId: "2C",
     expectedEventIds: ["pressure_1a", "purge_2c"],
   },
   {
-    input: "I follow Michelle's coded message and make the combined plan explicit: use Rebecca's secured office to broadcast the evidence while opening the detention sectors for the rescue.",
-    clock: { sceneId: "3A", point: "earliest" },
+    input:
+      "I stay close to Brandon as he fields the private executive channel and judge whether the architects are turning on each other.",
+    clock: { sceneId: "2C", point: "latest" },
+    expectedSceneId: "2C",
+    expectedEventIds: ["pressure_1a", "purge_2c"],
+  },
+  {
+    input:
+      "I follow Michelle's coded maintenance message and commit to the combined plan: broadcast the evidence from the secured executive office while opening the detention sectors for the rescue.",
+    clock: { sceneId: "3A", point: "target" },
     expectedSceneId: "3A",
     expectedEventIds: ["pressure_1a", "purge_2c"],
   },
   {
-    input: "I reunite with Michelle, document the behavioral experiments and conditioned-release plan, and secure the emergency military override codes while understanding that they expire with Charles's new authority.",
+    input:
+      "I descend into the detention block and reach Michelle where she is coordinating the prisoners through stolen radios and coded announcements.",
     clock: { eventId: "override_deadline_3a" },
     expectedSceneId: "3A",
     expectedEventIds: ["pressure_1a", "purge_2c", "override_deadline_3a"],
   },
   {
-    input: "I launch Michelle's coordinated detention uprising and lead the resistance upward toward the command and broadcast levels, using the override codes to keep the assault moving.",
+    input:
+      "Michelle leads me through the medical level; I document the behavioral experiments and copy the imprisoned official's emergency override authorization before it expires.",
+    clock: { sceneId: "3A", point: "latest" },
+    expectedSceneId: "3A",
+    expectedEventIds: ["pressure_1a", "purge_2c", "override_deadline_3a"],
+  },
+  {
+    input:
+      "With the override codes about to lose their value, Michelle triggers the coordinated uprising and we fight upward toward the command and broadcast levels.",
     clock: { sceneId: "3B", point: "target" },
     expectedSceneId: "3B",
     expectedEventIds: ["pressure_1a", "purge_2c", "override_deadline_3a"],
   },
   {
-    input: "I create conflicting infrastructure emergencies to overwhelm JANUS, reach Rebecca's office, secure her detention-site locations after Charles abandons her, and help Brandon open the relay and transmit his confession without starting the national broadcast yet.",
+    input:
+      "I create conflicting infrastructure emergencies - flooded corridors, structural alarms, power cuts - to overload the predictive security system until human operators take control.",
     clock: { eventId: "destruction_3b" },
     expectedSceneId: "3B",
     expectedEventIds: ["pressure_1a", "purge_2c", "override_deadline_3a", "destruction_3b"],
   },
   {
-    input: "I start Michelle's national broadcast through Brandon's open relay, transmit the JANUS evidence and detention locations, rescue the captives, and escape as the facility collapses.",
+    input:
+      "In Rebecca's office I confront her over the experiments she approved while Charles locks her out and abandons her, and I secure her record of the detention-site locations.",
+    clock: { sceneId: "3B", point: "latest" },
+    expectedSceneId: "3B",
+    expectedEventIds: ["pressure_1a", "purge_2c", "override_deadline_3a", "destruction_3b"],
+  },
+  {
+    input:
+      "Brandon reaches the relay chamber, disconnects it from the automated network, and transmits his confession while holding the relay open for us.",
     clock: { sceneId: "3C", point: "target" },
     expectedSceneId: "3C",
     expectedEventIds: ["pressure_1a", "purge_2c", "override_deadline_3a", "destruction_3b"],
   },
+  {
+    input:
+      "Michelle starts the national broadcast through the open relay - the captives, the selection records, the detention locations - until the truth can no longer be contained.",
+    clock: { sceneId: "3C", point: "latest" },
+    expectedSceneId: "3C",
+    expectedEventIds: ["pressure_1a", "purge_2c", "override_deadline_3a", "destruction_3b"],
+  },
+];
+
+// The unclocked spine run advances 60 authored seconds per turn, so it needs
+// one extra holding turn in Scene 1A before the 120-second storylet window.
+export const spineJourney = [
+  canonJourney[0].input,
+  "I keep watch from cover and reassess the physical evidence without leaving the house.",
+  ...canonJourney.slice(1).map((step) => step.input),
 ];

--- a/frontend/e2e/scene-runtime.spec.js
+++ b/frontend/e2e/scene-runtime.spec.js
@@ -9,18 +9,7 @@ import {
 } from "./helpers.js";
 import { loadPackagePacing } from "./package-clock.js";
 import { judgeRoleplayTurn, judgeSceneNarration } from "./roleplay-judge.js";
-import { canonJourney } from "./canon-journey.js";
-
-const spineActions = [
-  "I search for concrete evidence of Michelle's disappearance and follow the strongest lead.",
-  "I pursue the dead drop and ask Brandon for the evidence needed to move forward.",
-  "I prepare false identities and enter the facility without delaying the mission.",
-  "I secure proof of JANUS and act on the current objective.",
-  "I respond to the purge clock, reach Michelle, and preserve the rescue and evidence mission.",
-  "I use the relay and broadcast the evidence before the network can recover.",
-  "I finish the current objective and protect the route to the climax.",
-  "I bring the story to a responsible resolution.",
-];
+import { canonJourney, spineJourney } from "./canon-journey.js";
 
 function narrationText(payload) {
   const turnText = (payload.segments || [])
@@ -74,10 +63,10 @@ test("judges free-text roleplay quality with OpenAI @llm-judge", async ({ page }
 });
 
 test("drives the main spine and reports reachability and pressure @spine", async ({ page }) => {
-  test.setTimeout(12 * 60_000);
+  test.setTimeout(20 * 60_000);
   await startSceneSession(page);
   const turns = [];
-  for (const action of spineActions) {
+  for (const action of spineJourney) {
     const payload = await submitTurn(page, action);
     turns.push({ scene_id: payload.state?.scene_id, elapsed_seconds: payload.state?.story_elapsed_seconds });
     await resolveWarningIfPresent(page);
@@ -97,7 +86,7 @@ test("drives the main spine and reports reachability and pressure @spine", async
 test("judges every reached scene against the five-file narrative canon @llm-canon", async ({ page }) => {
   test.skip(!process.env.OPENAI_API_KEY, "requires OPENAI_API_KEY");
   test.skip(!process.env.E2E_PACKAGE_CLOCK, "requires the opt-in package E2E game clock");
-  test.setTimeout(5 * 60_000);
+  test.setTimeout(20 * 60_000);
   const pacing = loadPackagePacing({ storyId: "continuity_initiative" });
   const controller = await installPackageClock(page, {
     pacing,

--- a/storygame/runtime/engine.py
+++ b/storygame/runtime/engine.py
@@ -74,6 +74,12 @@ class RuntimeEngine:
         self._activate_pacing()
         self._apply_canonical_route_events()
         self._activate_pacing()
+        entry_text = self._apply_authored_transition()
+        self._activate_pacing()
+        if entry_text:
+            return proposal.model_copy(
+                update={"segments": (*proposal.segments, NarrationSegment(kind="narration", text=entry_text))}
+            )
         return proposal
 
     def _record_turn(self, proposal: ResolvedTurnProposal) -> None:
@@ -120,6 +126,38 @@ class RuntimeEngine:
         if decision == "proceed":
             self._apply_canonical_route_events()
             self._activate_pacing()
+            self._apply_authored_transition()
+            self._activate_pacing()
+
+    def _apply_authored_transition(self) -> str | None:
+        """Advance along the highest-priority authored transition once its declared triggers hold.
+
+        The target scene's earliest_seconds is a hard pacing floor so committed
+        triggers cannot rush the story ahead of its authored 20-minute budget.
+        Returns the entered scene's authored entry text so the turn can open the
+        new scene with the package's own words.
+        """
+
+        if self.state.has_pending_break:
+            return None
+        elapsed = self._elapsed_seconds()
+        windows = {window.scene_id: window for window in self.state.package.pacing.scenes}
+        for transition in self.validator.eligible_transitions(self.state):
+            if elapsed < windows[transition.target_scene_id].earliest_seconds:
+                continue
+            if not self.validator.transition_dependencies_available(transition, self.state.facts):
+                continue
+            scene = next(
+                item for item in self.state.package.scenes if item.metadata.scene_id == transition.target_scene_id
+            )
+            self.state.apply_proposal(
+                ResolvedTurnProposal(
+                    segments=(NarrationSegment(kind="narration", text=scene.metadata.entry_text),),
+                    transition={"transition_id": transition.id},
+                )
+            )
+            return scene.metadata.entry_text
+        return None
 
     def _activate_pacing(self) -> None:
         """Activate only package-declared, scene-bound optional storylets."""
@@ -128,7 +166,7 @@ class RuntimeEngine:
         for storylet in self.state.package.storylet_routes.storylets:
             if (
                 storylet.scene_id == self.state.current_scene_id
-                and storylet.earliest_seconds <= elapsed <= storylet.latest_seconds
+                and storylet.earliest_seconds <= elapsed
                 and all(self._predicate_matches(predicate) for predicate in storylet.activation_conditions)
                 and storylet.id not in self.state.fired_event_ids
             ):

--- a/storygame/runtime/validation.py
+++ b/storygame/runtime/validation.py
@@ -162,6 +162,18 @@ class ProgressionValidator:
         ]
         return tuple(sorted(eligible, key=lambda transition: transition.priority, reverse=True))
 
+    def transition_dependencies_available(self, transition: Transition, facts: FactStore) -> bool:
+        """Check the transition's declared dependencies, honoring declared fallbacks."""
+
+        unavailable = {fact.subject for fact in facts.matching("destroyed")} | {
+            fact.subject for fact in facts.matching("incapacitated")
+        }
+        return all(
+            dependency not in unavailable
+            or any(fallback not in unavailable for fallback in self._fallbacks(dependency))
+            for dependency in transition.required_dependencies
+        )
+
     def unsatisfied_dependencies(self, scene_id: str, facts: FactStore) -> tuple[str, ...]:
         """Find indispensable reachable entities, honoring declared fallbacks."""
 

--- a/tests/test_canon_journey.py
+++ b/tests/test_canon_journey.py
@@ -1,0 +1,144 @@
+"""Deterministic full-game canon journey: every authored transition is reachable.
+
+These tests drive the runtime with a scripted provider so CI proves the story
+package and engine support a complete 1A -> 3C playthrough without any model
+call. The clocked variant mirrors the hosted Playwright package-clock recipe;
+the unclocked variant mirrors default 60-second turns and lands exactly on the
+authored 1200-second (20-minute) budget.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from storygame.runtime.engine import RuntimeEngine
+from storygame.runtime.state import RuntimeState
+from storygame.story_package.loader import load_story_package
+
+PACKAGE = load_story_package(Path("data/stories/continuity-initiative"))
+
+# (selected knowledge id or None, armed elapsed target, expected scene at turn end)
+CLOCKED_JOURNEY = [
+    ("k_sl_1a_a_r1", 120, "1A"),
+    ("k_sl_1a_b_r1", 195, "1B"),
+    ("k_sl_1b_b_r1", 270, "1B"),
+    ("k_sl_1b_c_r1", 330, "1C"),
+    ("k_sl_1c_a_r2", 390, "1C"),
+    ("k_sl_1c_b_r1", 450, "2A"),
+    ("k_sl_2a_b_r1", 510, "2A"),
+    ("k_sl_2a_c_r2", 570, "2B"),
+    ("k_sl_2b_a_r2", 630, "2B"),
+    ("k_sl_2b_b_r1", 630, "2B"),
+    ("k_sl_2b_c_r1", 705, "2C"),
+    ("k_sl_2c_a_r2", 780, "2C"),
+    ("k_sl_2c_c_r1", 840, "3A"),
+    ("k_sl_3a_a_r1", 870, "3A"),
+    ("k_sl_3a_b_r2", 900, "3A"),
+    ("k_sl_3a_c_r1", 975, "3B"),
+    ("k_sl_3b_a_r1", 1020, "3B"),
+    ("k_sl_3b_b_r1", 1050, "3B"),
+    ("k_sl_3b_c_r1", 1140, "3C"),
+    ("k_sl_3c_a_r1", 1200, "3C"),
+]
+
+# Alternate-realization coverage at the default 60-second turn cadence.
+UNCLOCKED_JOURNEY = [
+    ("k_sl_1a_a_r1", "1A"),
+    (None, "1A"),
+    ("k_sl_1a_b_r1", "1B"),
+    ("k_sl_1b_b_r1", "1B"),
+    ("k_sl_1b_c_r1", "1C"),
+    ("k_sl_1c_a_r2", "1C"),
+    ("k_sl_1c_b_r2", "2A"),
+    ("k_sl_2a_b_r1", "2A"),
+    ("k_sl_2a_c_r2", "2B"),
+    ("k_sl_2b_a_r1", "2B"),
+    ("k_sl_2b_b_r2", "2B"),
+    ("k_sl_2b_c_r2", "2C"),
+    ("k_sl_2c_a_r2", "2C"),
+    ("k_sl_2c_c_r2", "3A"),
+    ("k_sl_3a_a_r2", "3A"),
+    ("k_sl_3a_b_r1", "3A"),
+    ("k_sl_3a_c_r2", "3B"),
+    ("k_sl_3b_a_r2", "3B"),
+    ("k_sl_3b_b_r2", "3B"),
+    ("k_sl_3b_c_r2", "3C"),
+    ("k_sl_3c_a_r2", "3C"),
+]
+
+
+class _ScriptedProvider:
+    """Return one pre-planned selection per turn without parsing prose."""
+
+    def __init__(self) -> None:
+        self.selected: list[str] = []
+
+    def __call__(self, _player_input: str) -> dict[str, object]:
+        return {
+            "segments": [{"kind": "narration", "text": "A concrete authored consequence lands."}],
+            "selected_knowledge_ids": list(self.selected),
+        }
+
+
+def _drive(engine: RuntimeEngine, provider: _ScriptedProvider, selection: str | None, **kwargs) -> None:
+    provider.selected = [selection] if selection else []
+    engine.turn("I act on the strongest available lead.", **kwargs)
+
+
+def test_clocked_canon_journey_reaches_the_resolution_scene() -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    provider = _ScriptedProvider()
+    engine = RuntimeEngine(state, provider)
+
+    elapsed = 0
+    for turn_index, (selection, target, expected_scene) in enumerate(CLOCKED_JOURNEY, start=1):
+        _drive(engine, provider, selection, clock_seconds=target - elapsed)
+        elapsed = target
+        assert state.current_scene_id == expected_scene, (
+            f"turn {turn_index} selecting {selection} at {target}s ended in "
+            f"{state.current_scene_id}, expected {expected_scene}"
+        )
+        assert not state.has_pending_break
+
+    assert "pressure_1a" in state.fired_event_ids
+    assert "purge_2c" in state.fired_event_ids
+    assert "override_deadline_3a" in state.fired_event_ids
+    assert "destruction_3b" in state.fired_event_ids
+    assert state.facts.has("resolution_complete", "story", value="true")
+
+
+def test_unclocked_canon_journey_fits_the_twenty_minute_budget() -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    provider = _ScriptedProvider()
+    engine = RuntimeEngine(state, provider)
+
+    for turn_index, (selection, expected_scene) in enumerate(UNCLOCKED_JOURNEY, start=1):
+        _drive(engine, provider, selection)
+        assert state.current_scene_id == expected_scene, (
+            f"turn {turn_index} selecting {selection} ended in {state.current_scene_id}, expected {expected_scene}"
+        )
+
+    assert state.facts.has("story_elapsed_seconds", "story", value=str(60 * len(UNCLOCKED_JOURNEY)))
+    assert state.facts.has("resolution_complete", "story", value="true")
+
+
+def test_committed_triggers_never_outrun_the_authored_pacing_floor() -> None:
+    """A committed transition trigger must wait for the target scene's earliest window."""
+
+    state = RuntimeState.bootstrap(PACKAGE)
+    provider = _ScriptedProvider()
+    engine = RuntimeEngine(state, provider)
+
+    _drive(engine, provider, "k_sl_1a_a_r1", clock_seconds=120)
+    _drive(engine, provider, "k_sl_1a_b_r1", clock_seconds=75)
+    assert state.current_scene_id == "1B"
+
+    # Commit every bridge_1b fact well before scene 1C's earliest window (270s).
+    _drive(engine, provider, "k_sl_1b_b_r1", clock_seconds=40)
+    _drive(engine, provider, "k_sl_1b_c_r1", clock_seconds=20)
+    assert state.facts.has("park_pursuit_resolved", "story", value="true")
+    assert state.current_scene_id == "1B", "the transition must wait for 1C's authored earliest window"
+
+    _drive(engine, provider, None, clock_seconds=15)
+    # At 270 seconds the authored window opens and the committed triggers carry Kristin out.
+    assert state.current_scene_id == "1C"

--- a/tests/test_markdown_story_package.py
+++ b/tests/test_markdown_story_package.py
@@ -291,7 +291,7 @@ def test_loader_rejects_ambiguous_transition_priority(tmp_path: Path) -> None:
         + (
             "- {id: t_tie, source_scene_id: 1A, target_scene_id: 1C, priority: 10, "
             "triggers: [{fact_id: michelle_lead_actionable, equals: true}, "
-            "{fact_id: house_marked_for_return, equals: true}]}\n"
+            "{fact_id: patrol_return_pressure, equals: true}]}\n"
         )
     )
     with pytest.raises(StoryPackageError, match="ambiguous priority"):

--- a/tests/test_scene_runtime_phase2.py
+++ b/tests/test_scene_runtime_phase2.py
@@ -228,7 +228,7 @@ def test_internal_dependency_analysis_honors_declared_fallbacks() -> None:
 def test_internal_validator_accepts_a_satisfied_transition_and_false_predicates() -> None:
     state = RuntimeState.bootstrap(PACKAGE)
     state.facts.assert_fact(Fact(predicate="michelle_lead_actionable", subject="story", value="true"))
-    state.facts.assert_fact(Fact(predicate="house_marked_for_return", subject="story", value="true"))
+    state.facts.assert_fact(Fact(predicate="patrol_return_pressure", subject="story", value="true"))
     validator = ProgressionValidator(PACKAGE)
     proposal = ResolvedTurnProposal(
         segments=(NarrationSegment(kind="narration", text="The route out is ready."),),

--- a/tests/test_web_demo.py
+++ b/tests/test_web_demo.py
@@ -208,7 +208,8 @@ def test_test_clock_is_opt_in_and_can_trigger_pacing_without_waiting(monkeypatch
     assert response.json()["state"]["story_elapsed_seconds"] == 120
 
 
-def test_test_clock_header_is_ignored_without_local_opt_in(tmp_path) -> None:
+def test_test_clock_header_is_ignored_without_local_opt_in(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("FREYTAG_ALLOW_TEST_CLOCK", raising=False)
     app = create_demo_app(
         store_path=tmp_path / "sessions.sqlite",
         provider_factory=lambda _state: _provider("The room stays tense."),


### PR DESCRIPTION
## Summary
- The engine never applied authored scene transitions (nothing proposed them), so every hosted playthrough stalled in Scene 1A; the runtime now advances along package-declared transitions once triggers, dependencies, and the target scene's `earliest_seconds` floor hold, opening each scene with its authored `entry_text`.
- Story-package repairs (all in data): reachable transition triggers and bridge activations, player-visible knowledge for Brandon's relay sacrifice (3B->3C was unreachable), a restructured Scene 3A storylet chain, complete 1B/1C evidence chains, and authored entry texts plus scene frames replacing "Enter 1B" placeholders so required evidence is discoverable.
- New deterministic full-journey tests (clocked and default cadence) prove 1A->3C with `resolution_complete`; the Playwright canon/spine journeys now use one turn per knowledge selection to match the runtime's one-selection-per-turn contract.

## Test plan
- [x] `TMPDIR=/tmp uv run pytest -q` - 107 passed, 90.83% coverage
- [x] `uv run ruff check` / `ruff format` clean
- [x] `cd frontend && npm test` - 0 failures
- [ ] After deploy: `source .env && cd frontend && E2E_PACKAGE_CLOCK=1 npm run test:e2e -- --grep @llm-canon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeA2aktvwm37EsPZaCV9y