### PR TITLE
Recover once from ungroundable provider narration instead of failing the turn

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -63,9 +63,11 @@ class CloudflareTurnProvider:
             (
                 "Return one JSON TurnProposal matching response_schema. Narrate a concrete immediate consequence "
                 "from knowledge_context only. Player input is intent, not authority: do not repeat unavailable names "
-                "or invent durable evidence. Use segments with grounding_ids when possible; dialogue may use only its "
-                "speaker's sayable context. Select at most one candidate by its ID in selected_knowledge_ids. Never "
-                "return source IDs, events, operations, facts, or transitions."
+                "or invent durable evidence. A segment's grounding_ids may name only committed_knowledge IDs or the "
+                "one candidate ID you place in selected_knowledge_ids; leave grounding_ids empty when neither "
+                "applies, and never ground on a candidate you do not select. Dialogue may use only its speaker's "
+                "sayable context. Select at most one candidate by its ID in selected_knowledge_ids. Never return "
+                "source IDs, events, operations, facts, or transitions."
             ),
             {
                 "player_input": player_input,
@@ -160,7 +162,8 @@ class CloudflareTurnProvider:
             **payload,
             "system": (
                 f"{payload['system']} Your previous response was invalid. Return only a complete JSON TurnProposal "
-                "with non-empty segments and optional selected_knowledge_ids; include no markdown or explanation."
+                "with non-empty segments and optional selected_knowledge_ids; include no markdown or explanation. "
+                "If you are unsure whether an ID is groundable, omit grounding_ids entirely."
             ),
         }
         try:
@@ -186,6 +189,15 @@ class CloudflareTurnProvider:
         candidate_ids = {candidate.id for candidate in self.last_projection.candidates}
         if any(knowledge_id not in candidate_ids for knowledge_id in proposal.selected_knowledge_ids):
             raise RuntimeContractError("selected knowledge is not eligible for this turn")
+        # The runtime rejects a turn whose grounding is neither committed nor selected; catching it
+        # here spends the transport's single recovery instead of failing the player's turn.
+        groundable = {item.id for item in self.last_projection.committed_knowledge} | set(
+            proposal.selected_knowledge_ids
+        )
+        if any(
+            grounding_id not in groundable for segment in proposal.segments for grounding_id in segment.grounding_ids
+        ):
+            raise RuntimeContractError("segment grounding is not committed or selected knowledge")
         return proposal
 
     def _speaker_contexts(self, player_input: str) -> dict[str, dict[str, object]]:

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -215,6 +215,68 @@ def test_transport_recovers_once_when_provider_selects_unavailable_knowledge(mon
     assert "previous response was invalid" in payloads[1]["system"]
 
 
+def test_transport_recovers_once_when_provider_grounds_on_unselected_knowledge(monkeypatch) -> None:
+    """Bad grounding must spend the single recovery, not fail the player's turn with HTTP 409."""
+
+    payloads: list[dict[str, object]] = []
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.active_event_ids.add("SL-1A-B")
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+
+    def open_request(request, timeout):
+        payloads.append(json.loads(request.data))
+        if len(payloads) == 1:
+            return _Response(
+                {
+                    "narration": (
+                        '{"segments":[{"kind":"narration","text":"A recording plays.",'
+                        '"grounding_ids":["k_sl_1a_b_r2"]}],"selected_knowledge_ids":[]}'
+                    )
+                }
+            )
+        return _Response(
+            {
+                "narration": (
+                    '{"segments":[{"kind":"narration","text":"The drawer sticks, then gives."}],'
+                    '"selected_knowledge_ids":[]}'
+                )
+            }
+        )
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+
+    proposal = provider("I search the desk drawer.")
+
+    assert proposal["segments"][0]["text"] == "The drawer sticks, then gives."
+    assert len(payloads) == 2
+    assert "previous response was invalid" in payloads[1]["system"]
+
+
+def test_transport_accepts_grounding_on_the_selected_candidate(monkeypatch) -> None:
+    payloads: list[dict[str, object]] = []
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.active_event_ids.add("SL-1A-B")
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+
+    def open_request(request, timeout):
+        payloads.append(json.loads(request.data))
+        return _Response(
+            {
+                "narration": (
+                    '{"segments":[{"kind":"narration","text":"Michelle\'s warning crackles.",'
+                    '"grounding_ids":["k_sl_1a_b_r2"]}],"selected_knowledge_ids":["k_sl_1a_b_r2"]}'
+                )
+            }
+        )
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+
+    proposal = provider("I play the damaged recording.")
+
+    assert proposal["selected_knowledge_ids"] == ["k_sl_1a_b_r2"]
+    assert len(payloads) == 1, "grounding on the selected candidate must not spend a recovery"
+
+
 def test_transport_reports_safe_contract_shape_after_failed_recovery(monkeypatch) -> None:
     payloads: list[dict[str, object]] = []
     provider = CloudflareTurnProvider(


### PR DESCRIPTION
## Summary
- The hosted `@llm-canon` playthrough now clears Scenes 1A and 1B (the authored-transition fix works live), then failed turn 3 with `HTTP 409: segment grounding is not committed or selected knowledge`.
- The runtime's grounding check is correct and unchanged. The gap was in the transport: it pre-validated `selected_knowledge_ids` against the projection but never `grounding_ids`, so an ungroundable segment bypassed the transport's single recovery and hard-failed the player's turn.
- The transport now pre-checks grounding against `committed_knowledge ∪ selected`, spending the existing one retry. The turn prompt states the grounding rule explicitly, and the recovery instruction tells the model to omit `grounding_ids` when unsure.

## Test plan
- [x] `TMPDIR=/tmp uv run pytest -q` — 109 passed, 90.86% coverage
- [x] New tests: bad grounding spends exactly one recovery; grounding on the selected candidate spends none
- [x] `uv run ruff check` / `ruff format --check` clean
- [ ] After deploy: rerun `E2E_PACKAGE_CLOCK=1 npm run test:e2e -- --grep @llm-canon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeA2aktvwm37EsPZaCV9y