### PR TITLE
Make the provider recovery retry actionable instead of blind

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -28,6 +28,20 @@ class NarrationProviderError(RuntimeError):
     worker_revision: str = ""
 
 
+class _EligibilityError(RuntimeContractError):
+    """A proposal that parsed cleanly but named knowledge this turn may not use.
+
+    ``summary`` is safe to return to the client: it names the rule, never a
+    story ID. ``hint`` is for the recovery prompt only, where the offending IDs
+    are already part of the Worker's own context.
+    """
+
+    def __init__(self, summary: str, hint: str) -> None:
+        super().__init__(summary)
+        self.summary = summary
+        self.hint = hint
+
+
 class CloudflareTurnProvider:
     """Send only bounded, scene-safe context to the configured Worker."""
 
@@ -136,8 +150,8 @@ class CloudflareTurnProvider:
         else:
             try:
                 self._parse_eligible_proposal(response)
-            except RuntimeContractError:
-                return self._recover_malformed_response(payload)
+            except RuntimeContractError as error:
+                return self._recover_malformed_response(payload, getattr(error, "hint", ""))
             return response
 
         fallback_payload = {key: value for key, value in payload.items() if key != "response_format"}
@@ -148,7 +162,7 @@ class CloudflareTurnProvider:
         except HTTPError as error:
             raise self._narration_error(error) from error
         except RuntimeContractError as error:
-            summary = contract_error_summary(error) or "invalid proposal"
+            summary = contract_error_summary(error) or getattr(error, "summary", "") or "invalid proposal"
             raise NarrationProviderError(
                 f"narration service returned an invalid proposal ({summary})",
                 502,
@@ -157,13 +171,14 @@ class CloudflareTurnProvider:
         except (URLError, OSError, TimeoutError, ValueError, json.JSONDecodeError) as error:
             raise NarrationProviderError("narration service is unavailable") from error
 
-    def _recover_malformed_response(self, payload: dict[str, object]) -> object:
+    def _recover_malformed_response(self, payload: dict[str, object], hint: str = "") -> object:
+        correction = f" {hint}" if hint else ""
         recovery_payload = {
             **payload,
             "system": (
-                f"{payload['system']} Your previous response was invalid. Return only a complete JSON TurnProposal "
-                "with non-empty segments and optional selected_knowledge_ids; include no markdown or explanation. "
-                "If you are unsure whether an ID is groundable, omit grounding_ids entirely."
+                f"{payload['system']} Your previous response was invalid.{correction} Return only a complete JSON "
+                "TurnProposal with non-empty segments and optional selected_knowledge_ids; include no markdown or "
+                "explanation. If you are unsure whether an ID is groundable, omit grounding_ids entirely."
             ),
         }
         try:
@@ -173,7 +188,7 @@ class CloudflareTurnProvider:
         except HTTPError as error:
             raise self._narration_error(error) from error
         except RuntimeContractError as error:
-            summary = contract_error_summary(error) or "invalid proposal"
+            summary = contract_error_summary(error) or getattr(error, "summary", "") or "invalid proposal"
             raise NarrationProviderError(
                 f"narration service returned an invalid proposal ({summary})",
                 502,
@@ -187,17 +202,35 @@ class CloudflareTurnProvider:
         if self.last_projection is None:
             raise RuntimeContractError("knowledge projection is unavailable")
         candidate_ids = {candidate.id for candidate in self.last_projection.candidates}
-        if any(knowledge_id not in candidate_ids for knowledge_id in proposal.selected_knowledge_ids):
-            raise RuntimeContractError("selected knowledge is not eligible for this turn")
+        ineligible = sorted(
+            {knowledge_id for knowledge_id in proposal.selected_knowledge_ids if knowledge_id not in candidate_ids}
+        )
+        if ineligible:
+            raise _EligibilityError(
+                "selected knowledge is not eligible for this turn",
+                f"You selected {', '.join(ineligible)}, which this turn does not offer. Select exactly one of "
+                f"[{', '.join(sorted(candidate_ids)) or 'no candidates are available'}] or select nothing.",
+            )
         # The runtime rejects a turn whose grounding is neither committed nor selected; catching it
         # here spends the transport's single recovery instead of failing the player's turn.
         groundable = {item.id for item in self.last_projection.committed_knowledge} | set(
             proposal.selected_knowledge_ids
         )
-        if any(
-            grounding_id not in groundable for segment in proposal.segments for grounding_id in segment.grounding_ids
-        ):
-            raise RuntimeContractError("segment grounding is not committed or selected knowledge")
+        ungroundable = sorted(
+            {
+                grounding_id
+                for segment in proposal.segments
+                for grounding_id in segment.grounding_ids
+                if grounding_id not in groundable
+            }
+        )
+        if ungroundable:
+            raise _EligibilityError(
+                "segment grounding is not committed or selected knowledge",
+                f"You grounded a segment on {', '.join(ungroundable)}, which is neither committed knowledge nor a "
+                "candidate you selected. Either put that ID in selected_knowledge_ids when it is one of this turn's "
+                "candidates, or return the segment with an empty grounding_ids list.",
+            )
         return proposal
 
     def _speaker_contexts(self, player_input: str) -> dict[str, dict[str, object]]:

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -213,6 +213,7 @@ def test_transport_recovers_once_when_provider_selects_unavailable_knowledge(mon
     assert proposal["selected_knowledge_ids"] == ["k_sl_1a_b_r2"]
     assert len(payloads) == 2
     assert "previous response was invalid" in payloads[1]["system"]
+    assert "k_future_unavailable" in payloads[1]["system"]
 
 
 def test_transport_recovers_once_when_provider_grounds_on_unselected_knowledge(monkeypatch) -> None:
@@ -250,6 +251,9 @@ def test_transport_recovers_once_when_provider_grounds_on_unselected_knowledge(m
     assert proposal["segments"][0]["text"] == "The drawer sticks, then gives."
     assert len(payloads) == 2
     assert "previous response was invalid" in payloads[1]["system"]
+    # The retry must name the offending ID; a blind retry repeats the same mistake.
+    assert "k_sl_1a_b_r2" in payloads[1]["system"]
+    assert "grounding_ids" in payloads[1]["system"]
 
 
 def test_transport_accepts_grounding_on_the_selected_candidate(monkeypatch) -> None:
@@ -275,6 +279,33 @@ def test_transport_accepts_grounding_on_the_selected_candidate(monkeypatch) -> N
 
     assert proposal["selected_knowledge_ids"] == ["k_sl_1a_b_r2"]
     assert len(payloads) == 1, "grounding on the selected candidate must not spend a recovery"
+
+
+def test_repeated_ineligible_selection_reports_the_rule_without_leaking_ids(monkeypatch) -> None:
+    """A twice-failing provider must say which rule broke, and never echo a story ID."""
+
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.active_event_ids.add("SL-1A-B")
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+
+    def open_request(request, timeout):
+        return _Response(
+            {
+                "narration": (
+                    '{"segments":[{"kind":"narration","text":"An invalid reveal."}],'
+                    '"selected_knowledge_ids":["k_future_unavailable"]}'
+                )
+            }
+        )
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+
+    with pytest.raises(NarrationProviderError) as error:
+        provider("I reach for something I have not earned.")
+
+    assert "selected knowledge is not eligible for this turn" in error.value.message
+    assert "k_future_unavailable" not in error.value.message
+    assert error.value.status_code == 502
 
 
 def test_transport_reports_safe_contract_shape_after_failed_recovery(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- With the previous two fixes deployed, the hosted `@llm-canon` playthrough now clears Scenes 1A → 2C (six scenes; it could not leave 1A before this work). Turn 12 then failed `HTTP 502: narration service returned an invalid proposal (invalid proposal)`.
- Cause: the provider named ineligible knowledge on both the first attempt and the recovery. The recovery prompt only said "your previous response was invalid" — it never named the rejected ID or the valid candidates, so the retry had nothing to correct against.
- Eligibility errors now carry a `hint` (recovery prompt only; names the rejected IDs and this turn's real candidate IDs, which are already in the Worker's context) and a `summary` (client-facing; names the violated rule and no story IDs).

## Test plan
- [x] `TMPDIR=/tmp uv run pytest -q` — 110 passed, 90.89% coverage
- [x] New/updated tests assert the retry names the offending ID, and that a twice-failing provider reports the rule without echoing any story ID
- [x] `uv run ruff check` / `ruff format --check` clean
- [ ] After deploy: rerun `E2E_PACKAGE_CLOCK=1 npm run test:e2e -- --grep @llm-canon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeA2aktvwm37EsPZaCV9y