### PR TITLE
Mirror every provider-facing resolver rule in the transport pre-check

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -201,6 +201,14 @@ class CloudflareTurnProvider:
         proposal = parse_turn_proposal(response)
         if self.last_projection is None:
             raise RuntimeContractError("knowledge projection is unavailable")
+        # This pre-check must mirror every provider-facing rule in SelectedRevealResolver.resolve;
+        # a rule missing here becomes a hard turn failure in the browser instead of one recovery.
+        if len(proposal.selected_knowledge_ids) > 1:
+            raise _EligibilityError(
+                "at most one knowledge selection is allowed per turn",
+                f"You selected {', '.join(sorted(proposal.selected_knowledge_ids))}. Choose exactly one of those "
+                "IDs and drop the rest; a turn may reveal at most one candidate.",
+            )
         candidate_ids = {candidate.id for candidate in self.last_projection.candidates}
         ineligible = sorted(
             {knowledge_id for knowledge_id in proposal.selected_knowledge_ids if knowledge_id not in candidate_ids}

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -10,7 +10,10 @@ from urllib.error import HTTPError, URLError
 import pytest
 
 from storygame.runtime.cloudflare import CloudflareTurnProvider, NarrationProviderError
+from storygame.runtime.contracts import RuntimeContractError, parse_turn_proposal
+from storygame.runtime.knowledge import KnowledgeProjector
 from storygame.runtime.state import RuntimeState
+from storygame.runtime.validation import ProposalValidationError, SelectedRevealResolver
 from storygame.story_package.loader import load_story_package
 
 PACKAGE = load_story_package(Path("data/stories/continuity-initiative"))
@@ -279,6 +282,48 @@ def test_transport_accepts_grounding_on_the_selected_candidate(monkeypatch) -> N
 
     assert proposal["selected_knowledge_ids"] == ["k_sl_1a_b_r2"]
     assert len(payloads) == 1, "grounding on the selected candidate must not spend a recovery"
+
+
+@pytest.mark.parametrize(
+    ("segments", "selected"),
+    [
+        pytest.param(
+            [{"kind": "narration", "text": "Two reveals at once."}],
+            ["k_sl_1a_b_r1", "k_sl_1a_b_r2"],
+            id="more than one selection",
+        ),
+        pytest.param(
+            [{"kind": "narration", "text": "An unearned reveal."}],
+            ["k_future_unavailable"],
+            id="selection outside this turn's candidates",
+        ),
+        pytest.param(
+            [{"kind": "narration", "text": "A grounded claim.", "grounding_ids": ["k_sl_1a_b_r2"]}],
+            [],
+            id="grounding that is neither committed nor selected",
+        ),
+    ],
+)
+def test_transport_precheck_mirrors_the_resolver_rules(segments, selected) -> None:
+    """Every provider-facing rule the resolver enforces must also fail the transport pre-check.
+
+    A rule the resolver rejects but the transport accepts reaches the player as a
+    hard turn failure instead of spending the transport's one recovery attempt.
+    """
+
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.active_event_ids.add("SL-1A-B")
+    projector = KnowledgeProjector()
+    projection = projector.project(state, "player", "I search the drawer.")
+    provider_proposal = parse_turn_proposal({"segments": segments, "selected_knowledge_ids": selected})
+
+    with pytest.raises(ProposalValidationError):
+        SelectedRevealResolver(PACKAGE).resolve(state, projection, provider_proposal, projector, "I search the drawer.")
+
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+    provider.last_projection = projection
+    with pytest.raises(RuntimeContractError):
+        provider._parse_eligible_proposal({"segments": segments, "selected_knowledge_ids": selected})
 
 
 def test_repeated_ineligible_selection_reports_the_rule_without_leaking_ids(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- The hosted `@llm-canon` playthrough now reaches **Scene 3B and the final 3B → 3C transition** (turn 19 of 20; it could not leave Scene 1A before this work). It failed there with `HTTP 409: at most one knowledge selection is allowed per turn`.
- This was the third failure of a single structural gap: `SelectedRevealResolver` enforces a provider-facing rule that the transport's pre-check did not know, so the rejection bypassed the transport's one recovery attempt and hard-failed the player's turn.
- Rather than keep discovering these one deploy at a time, the pre-check now mirrors **all three** provider-facing resolver rules — selection arity, candidate eligibility, and grounding — each with an actionable recovery hint.
- A parametrized contract test feeds the same malformed proposals to both the resolver and the transport pre-check and requires both to reject them, so a rule added to one side can't silently regress into a browser-facing failure again.

## Test plan
- [x] `TMPDIR=/tmp uv run pytest -q` — 113 passed, 90.91% coverage
- [x] Mirror test covers multi-selection, ineligible selection, and ungroundable grounding
- [x] `uv run ruff check` / `ruff format --check` clean
- [ ] After deploy: rerun `E2E_PACKAGE_CLOCK=1 npm run test:e2e -- --grep @llm-canon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeA2aktvwm37EsPZaCV9y