### PR TITLE
Drive the canon E2E journey by observed scene, not a fixed turn script

### DIFF
--- a/frontend/e2e/canon-journey.js
+++ b/frontend/e2e/canon-journey.js
@@ -1,154 +1,77 @@
-// One turn per authored knowledge selection: the runtime commits at most one
-// storylet realization per turn, so every scene needs as many turns as the
-// facts its outgoing bridge requires. Inputs steer the provider toward the
-// intended candidate without naming knowledge the player cannot have yet.
-export const canonJourney = [
-  {
-    input:
-      "I search the house for concrete signs Michelle was taken - the overturned chair, the forced back door - and I stay hidden while I watch the marked front gate for the patrol's return.",
-    clock: { eventId: "pressure_1a" },
-    expectedSceneId: "1A",
-    expectedEventIds: ["pressure_1a"],
-  },
-  {
-    input:
-      "I retrieve the hidden memory card taped beneath the drawer, preserve Michelle's research, and use it to identify an actionable lead away from the house.",
-    clock: { sceneId: "1B", point: "target" },
-    expectedSceneId: "1B",
-    expectedEventIds: ["pressure_1a"],
-  },
-  {
-    input:
-      "At the park dead drop I take the transit card and the photograph, and when the stranger from the photo intervenes against the patrol I demand to know who he is and whether the missing are still alive.",
-    clock: { sceneId: "1B", point: "latest" },
-    expectedSceneId: "1B",
-    expectedEventIds: ["pressure_1a"],
-  },
-  {
-    input:
-      "I escape with him through the storm drains and watch closely as he unlocks the secured maintenance gate with a specialized code no civilian should have, following the route toward the freight terminal.",
-    clock: { sceneId: "1C", point: "target" },
-    expectedSceneId: "1C",
-    expectedEventIds: ["pressure_1a"],
-  },
-  {
-    input:
-      "I use the transit card at the freight terminal and slip into the service level to confirm the site is active beneath the abandoned surface.",
-    clock: { sceneId: "1C", point: "latest" },
-    expectedSceneId: "1C",
-    expectedEventIds: ["pressure_1a"],
-  },
-  {
-    input:
-      "From the observation shaft I document the rows of sedated prisoners being moved and match their identification numbers against the missing-person files, accepting that we need controlled deeper access rather than a reckless rescue.",
-    clock: { sceneId: "2A", point: "target" },
-    expectedSceneId: "2A",
-    expectedEventIds: ["pressure_1a"],
-  },
-  {
-    input:
-      "At the hideout I build false inspector identities around the facility's real cooling and support-column failure risk so we can enter as technical specialists.",
-    clock: { sceneId: "2A", point: "latest" },
-    expectedSceneId: "2A",
-    expectedEventIds: ["pressure_1a"],
-  },
-  {
-    input:
-      "We enter under the inspection cover and I convince the questioning supervisor that a progressive support-column collapse is imminent, gaining access to the restricted infrastructure corridors.",
-    clock: { sceneId: "2B", point: "target" },
-    expectedSceneId: "2B",
-    expectedEventIds: ["pressure_1a"],
-  },
-  {
-    input:
-      "In the records archive I open the selection files to learn why Michelle was taken and why I was left behind.",
-    clock: { sceneId: "2B", point: "latest" },
-    expectedSceneId: "2B",
-    expectedEventIds: ["pressure_1a"],
-  },
-  {
-    input:
-      "I confront my ally with his name in the original development records and demand the truth about his role and his motives.",
-    clock: { sceneId: "2B", point: "latest" },
-    expectedSceneId: "2B",
-    expectedEventIds: ["pressure_1a"],
-  },
-  {
-    input:
-      "I trace the corrupted prisoner files and equipment failures and recognize Michelle's phrasing in them - she has been resisting from inside.",
-    clock: { sceneId: "2C", point: "target" },
-    expectedSceneId: "2C",
-    expectedEventIds: ["pressure_1a", "purge_2c"],
-  },
-  {
-    input:
-      "I stay close to Brandon as he fields the private executive channel and judge whether the architects are turning on each other.",
-    clock: { sceneId: "2C", point: "latest" },
-    expectedSceneId: "2C",
-    expectedEventIds: ["pressure_1a", "purge_2c"],
-  },
-  {
-    input:
-      "I follow Michelle's coded maintenance message and commit to the combined plan: broadcast the evidence from the secured executive office while opening the detention sectors for the rescue.",
-    clock: { sceneId: "3A", point: "target" },
-    expectedSceneId: "3A",
-    expectedEventIds: ["pressure_1a", "purge_2c"],
-  },
-  {
-    input:
-      "I descend into the detention block and reach Michelle where she is coordinating the prisoners through stolen radios and coded announcements.",
-    clock: { eventId: "override_deadline_3a" },
-    expectedSceneId: "3A",
-    expectedEventIds: ["pressure_1a", "purge_2c", "override_deadline_3a"],
-  },
-  {
-    input:
-      "Michelle leads me through the medical level; I document the behavioral experiments and copy the imprisoned official's emergency override authorization before it expires.",
-    clock: { sceneId: "3A", point: "latest" },
-    expectedSceneId: "3A",
-    expectedEventIds: ["pressure_1a", "purge_2c", "override_deadline_3a"],
-  },
-  {
-    input:
-      "With the override codes about to lose their value, Michelle triggers the coordinated uprising and we fight upward toward the command and broadcast levels.",
-    clock: { sceneId: "3B", point: "target" },
-    expectedSceneId: "3B",
-    expectedEventIds: ["pressure_1a", "purge_2c", "override_deadline_3a"],
-  },
-  {
-    input:
-      "I create conflicting infrastructure emergencies - flooded corridors, structural alarms, power cuts - to overload the predictive security system until human operators take control.",
-    clock: { eventId: "destruction_3b" },
-    expectedSceneId: "3B",
-    expectedEventIds: ["pressure_1a", "purge_2c", "override_deadline_3a", "destruction_3b"],
-  },
-  {
-    input:
-      "In Rebecca's office I confront her over the experiments she approved while Charles locks her out and abandons her, and I secure her record of the detention-site locations.",
-    clock: { sceneId: "3B", point: "latest" },
-    expectedSceneId: "3B",
-    expectedEventIds: ["pressure_1a", "purge_2c", "override_deadline_3a", "destruction_3b"],
-  },
-  {
-    input:
-      "Brandon reaches the relay chamber, disconnects it from the automated network, and transmits his confession while holding the relay open for us.",
-    clock: { sceneId: "3C", point: "target" },
-    expectedSceneId: "3C",
-    expectedEventIds: ["pressure_1a", "purge_2c", "override_deadline_3a", "destruction_3b"],
-  },
-  {
-    input:
-      "Michelle starts the national broadcast through the open relay - the captives, the selection records, the detention locations - until the truth can no longer be contained.",
-    clock: { sceneId: "3C", point: "latest" },
-    expectedSceneId: "3C",
-    expectedEventIds: ["pressure_1a", "purge_2c", "override_deadline_3a", "destruction_3b"],
-  },
-];
+// Prompts are grouped by scene, not by turn number. The narration model may
+// legitimately satisfy a scene's outgoing bridge in fewer turns than the
+// authored maximum, so a fixed turn-indexed script produces false failures the
+// moment a valid faster ordering is chosen. The harness reads the scene the
+// runtime reports and sends that scene's next prompt, asserting the invariants
+// that actually matter: the spine never regresses, never skips a scene, and
+// ends at the authored resolution.
+//
+// Each scene lists prompts in authored beat order. They name only evidence the
+// player can already have in that scene, so the run never smuggles in a future
+// reveal.
+export const scenePrompts = {
+  "1A": [
+    "I search the house for concrete signs Michelle was taken - the overturned chair, the forced back door - and I stay hidden while I watch the marked front gate for the patrol's return.",
+    "I retrieve the hidden memory card taped beneath the drawer, preserve Michelle's research, and use it to identify an actionable lead away from the house.",
+    "I go back over the kitchen and her work area for anything I have not yet accounted for.",
+  ],
+  "1B": [
+    "At the park dead drop I take the transit card and the photograph, and when the stranger from the photo intervenes against the patrol I demand to know who he is and whether the missing are still alive.",
+    "I escape with him through the storm drains and watch closely as he unlocks the secured maintenance gate with a specialized code no civilian should have, following the route toward the freight terminal.",
+    "I press him on the handwritten sequence and the dates until the route it points to is unambiguous.",
+  ],
+  "1C": [
+    "I use the transit card at the freight terminal and slip into the service level to confirm the site is active beneath the abandoned surface.",
+    "From the observation shaft I document the rows of sedated prisoners being moved and match their identification numbers against the missing-person files.",
+    "I read the logistics terminal and the recorded conference to understand how far this network reaches and who is directing it.",
+  ],
+  "2A": [
+    "At the hideout I take stock of how long he has been preparing for this and what he has been hoarding against it.",
+    "I build false inspector identities around the facility's real cooling and support-column failure risk so we can enter as technical specialists.",
+    "We enter under the inspection cover and I convince the questioning supervisor that a progressive support-column collapse is imminent, gaining access to the restricted infrastructure corridors.",
+  ],
+  "2B": [
+    "In the records archive I open the selection files to learn why Michelle was taken and why I was left behind.",
+    "I confront my ally with his name in the original development records and demand the truth about his role and his motives.",
+    "I trace the corrupted prisoner files and equipment failures and recognize Michelle's phrasing in them - she has been resisting from inside.",
+  ],
+  "2C": [
+    "I stay close to Brandon as he fields the private executive channel and judge whether the architects are turning on each other.",
+    "I follow Michelle's coded maintenance message and commit to the combined plan: broadcast the evidence from the secured executive office while opening the detention sectors for the rescue.",
+    "I take stock of exactly what evidence we are carrying and what transmitting it will cost us.",
+  ],
+  "3A": [
+    "I descend into the detention block and reach Michelle where she is coordinating the prisoners through stolen radios and coded announcements.",
+    "Michelle leads me through the medical level; I document the behavioral experiments and copy the imprisoned official's emergency override authorization before it expires.",
+    "With the override codes about to lose their value, Michelle triggers the coordinated uprising and we fight upward toward the command and broadcast levels.",
+  ],
+  "3B": [
+    "I create conflicting infrastructure emergencies - flooded corridors, structural alarms, power cuts - to overload the predictive security system until human operators take control.",
+    "In Rebecca's office I confront her over the experiments she approved while Charles locks her out and abandons her, and I secure her record of the detention-site locations.",
+    "Brandon reaches the relay chamber, disconnects it from the automated network, and transmits his confession while holding the relay open for us.",
+  ],
+  "3C": [
+    "Michelle starts the national broadcast through the open relay - the captives, the selection records, the detention locations - until the truth can no longer be contained.",
+    "I stop Rebecca from leaving with the portable archive, and rather than destroy it we copy it out to independent networks.",
+    "I hold the emergency supports while Michelle leads the captives up through the maintenance tunnels to the surface.",
+    "I take account of what this has changed across the country and what it has not.",
+    "I read the recovered fragment describing what was planned to follow all of this.",
+  ],
+};
 
-// The unclocked spine run advances 60 authored seconds per turn, so it needs
-// one extra holding turn in Scene 1A before the 120-second storylet window.
+// A scene's prompts are exhausted only if the model needs more turns there than
+// authored; repeating the last prompt keeps the run moving without inventing
+// new player intent.
+export function promptFor(sceneId, usedCount) {
+  const prompts = scenePrompts[sceneId];
+  if (!prompts) throw new Error(`No authored prompts for scene ${sceneId}.`);
+  return prompts[Math.min(usedCount, prompts.length - 1)];
+}
+
+// The unclocked spine run advances 60 authored seconds per turn and cannot skip
+// ahead, so it walks the same prompts in authored scene order.
 export const spineJourney = [
-  canonJourney[0].input,
+  scenePrompts["1A"][0],
   "I keep watch from cover and reassess the physical evidence without leaving the house.",
-  ...canonJourney.slice(1).map((step) => step.input),
+  ...Object.values(scenePrompts).flat(),
 ];

--- a/frontend/e2e/package-clock.js
+++ b/frontend/e2e/package-clock.js
@@ -210,9 +210,25 @@ export function loadPackagePacing({ storyId, repoRoot, pacingPath } = {}) {
     ]),
   );
 
+  // One ascending ladder of every authored instant a turn may need to land on. Pacing events win
+  // ties so the evidence names the event rather than a scene boundary that shares its timestamp.
+  const ladder = [...eventMilestones.values(), ...[...sceneMilestones.values()].flatMap((points) => [...points.values()])]
+    // "latest" is a deadline, not a place to stop; 0 is the story's start, already reached.
+    .filter((milestone) => milestone.point !== "latest" && milestone.target_seconds > 0)
+    .sort((left, right) => left.target_seconds - right.target_seconds || (left.kind === "pacing_event" ? -1 : 1));
+  const dedupedLadder = Object.freeze(
+    ladder.filter(
+      (milestone, index) => index === 0 || milestone.target_seconds !== ladder[index - 1].target_seconds,
+    ),
+  );
+
   const projection = {
     storyId,
     sceneOrder: frozenSceneOrder,
+    eventOrder: Object.freeze([...eventRecords.keys()]),
+    milestoneLadder() {
+      return dedupedLadder;
+    },
     scenePoint(sceneId, point) {
       if (!sceneMilestones.has(sceneId)) {
         throw pacingError(storyId, resolvedPacingPath, sceneId, `scene "${sceneId}" is not declared`);

--- a/frontend/e2e/package-clock.test.js
+++ b/frontend/e2e/package-clock.test.js
@@ -82,7 +82,16 @@ test("loads the real package and resolves irregular scene and event milestones",
   assert.equal(Object.isFrozen(projection.sceneOrder), true);
   assert.equal(Object.isFrozen(projection.scenePoint("1B", "target")), true);
   assert.equal(Object.isFrozen(projection.eventPoint("purge_2c")), true);
-  assert.deepEqual(Object.keys(projection), ["storyId", "sceneOrder", "scenePoint", "eventPoint"]);
+  assert.deepEqual(Object.keys(projection), [
+    "storyId",
+    "sceneOrder",
+    "eventOrder",
+    "milestoneLadder",
+    "scenePoint",
+    "eventPoint",
+  ]);
+  assert.equal(Object.isFrozen(projection.eventOrder), true);
+  assert.equal(Object.isFrozen(projection.milestoneLadder()), true);
 });
 
 test("reports unknown story, scene, event, and point identifiers", () => {
@@ -249,5 +258,31 @@ events:
 `,
     "event_missing_scene",
     "undeclared scene",
+  );
+});
+
+test("milestoneLadder walks every authored instant once, ascending", () => {
+  const pacing = loadPackagePacing({ storyId: "continuity_initiative" });
+  const ladder = pacing.milestoneLadder();
+  const seconds = ladder.map((milestone) => milestone.target_seconds);
+
+  assert.deepEqual(seconds, [...seconds].sort((left, right) => left - right), "ladder must ascend");
+  assert.equal(new Set(seconds).size, seconds.length, "ladder must not repeat an instant");
+
+  // Every pacing event and every scene entry window must be landable.
+  for (const eventId of pacing.eventOrder) {
+    assert.ok(seconds.includes(pacing.eventPoint(eventId).target_seconds), `missing event ${eventId}`);
+  }
+  // Every scene the story must still transition into needs a landable entry window.
+  // The first scene's window is the story's start, which no turn can land on.
+  for (const sceneId of pacing.sceneOrder.slice(1)) {
+    assert.ok(
+      seconds.includes(pacing.scenePoint(sceneId, "earliest").target_seconds),
+      `missing earliest window for ${sceneId}`,
+    );
+  }
+  assert.ok(
+    seconds.every((value) => value > 0),
+    "the ladder must not offer the already-reached story start",
   );
 });

--- a/frontend/e2e/scene-runtime.spec.js
+++ b/frontend/e2e/scene-runtime.spec.js
@@ -9,7 +9,7 @@ import {
 } from "./helpers.js";
 import { loadPackagePacing } from "./package-clock.js";
 import { judgeRoleplayTurn, judgeSceneNarration } from "./roleplay-judge.js";
-import { canonJourney, spineJourney } from "./canon-journey.js";
+import { promptFor, scenePrompts, spineJourney } from "./canon-journey.js";
 
 function narrationText(payload) {
   const turnText = (payload.segments || [])
@@ -95,44 +95,56 @@ test("judges every reached scene against the five-file narrative canon @llm-cano
   await startSceneSession(page);
   const opening = (await page.locator(".entry-output").first().textContent())?.trim() || "";
   const byScene = new Map([["1A", { opening, turns: [] }]]);
+  const sceneOrder = pacing.sceneOrder;
+  const ladder = pacing.milestoneLadder();
   let sceneId = "1A";
+  const promptsUsed = new Map();
   const progress = [];
-  for (const [index, step] of canonJourney.entries()) {
-    await test.step(`turn ${index + 1}: scene ${sceneId} to ${step.expectedSceneId}`, async () => {
-      const milestone = step.clock.eventId
-        ? pacing.eventPoint(step.clock.eventId)
-        : pacing.scenePoint(step.clock.sceneId, step.clock.point);
+
+  for (const [index, milestone] of ladder.entries()) {
+    if (sceneId === sceneOrder.at(-1) && promptsUsed.get(sceneId) >= scenePrompts[sceneId].length) break;
+    const sourceSceneId = sceneId;
+    const used = promptsUsed.get(sourceSceneId) || 0;
+    const input = promptFor(sourceSceneId, used);
+    await test.step(`turn ${index + 1}: scene ${sourceSceneId} at ${milestone.target_seconds}s`, async () => {
       controller.arm(milestone);
-      const sourceSceneId = sceneId;
-      const payload = await submitTurn(page, step.input);
+      const payload = await submitTurn(page, input);
       const warningResolved = await resolveWarningIfPresent(page);
       const timing = controller.history().at(-1);
       const observedElapsed = payload.state?.story_elapsed_seconds;
       if (!timing?.reached) {
         throw new Error(
-          `Package clock missed ${milestone.kind} ${milestone.event_id || `${milestone.scene_id} ${step.clock.point || "event"}`}; observed elapsed ${String(observedElapsed)} (pending game break: ${String(payload.state?.pending_game_break === true)}, warning resolved: ${String(warningResolved)}).`,
+          `Package clock missed ${milestone.kind} ${milestone.event_id || `${milestone.scene_id} ${milestone.point}`}; observed elapsed ${String(observedElapsed)} (pending game break: ${String(payload.state?.pending_game_break === true)}, warning resolved: ${String(warningResolved)}).`,
         );
       }
 
       const narration = narrationText(payload);
-      expect(payload.state?.scene_id, `Turn ${index + 1} did not end in the authored scene.`).toBe(step.expectedSceneId);
+      const reachedSceneId = payload.state?.scene_id;
+      promptsUsed.set(sourceSceneId, used + 1);
       expect(payload.state?.story_elapsed_seconds, `Turn ${index + 1} missed its package milestone.`).toBe(
         milestone.target_seconds,
       );
-      for (const eventId of step.expectedEventIds) {
+
+      // The spine may pause in a scene or step forward exactly one scene, never
+      // backward and never skipping an authored scene.
+      const from = sceneOrder.indexOf(sourceSceneId);
+      const to = sceneOrder.indexOf(reachedSceneId);
+      expect(to, `Turn ${index + 1} left the authored spine at ${String(reachedSceneId)}.`).toBeGreaterThanOrEqual(0);
+      expect(to - from, `Turn ${index + 1} regressed from ${sourceSceneId} to ${String(reachedSceneId)}.`).toBeGreaterThanOrEqual(0);
+      expect(to - from, `Turn ${index + 1} skipped past a scene from ${sourceSceneId} to ${String(reachedSceneId)}.`).toBeLessThanOrEqual(1);
+
+      // Any pacing event whose authored instant has passed must have fired.
+      for (const eventId of pacing.eventOrder) {
+        if (pacing.eventPoint(eventId).target_seconds > milestone.target_seconds) continue;
         expect(payload.state?.fired_pacing_event_ids, `Turn ${index + 1} is missing pacing event ${eventId}.`).toContain(eventId);
       }
 
-      if (!byScene.has(step.expectedSceneId)) byScene.set(step.expectedSceneId, { opening: "", turns: [] });
-      byScene.get(step.expectedSceneId).turns.push({
-        player_input: step.input,
-        narration,
-        source_scene_id: sourceSceneId,
-      });
-      sceneId = step.expectedSceneId;
+      if (!byScene.has(reachedSceneId)) byScene.set(reachedSceneId, { opening: "", turns: [] });
+      byScene.get(reachedSceneId).turns.push({ player_input: input, narration, source_scene_id: sourceSceneId });
+      sceneId = reachedSceneId;
       progress.push({
         turn: index + 1,
-        input: step.input,
+        input,
         requested_milestone: milestone,
         observed_timing: timing,
         state: payload.state,
@@ -145,6 +157,10 @@ test("judges every reached scene against the five-file narrative canon @llm-cano
       });
     });
   }
+
+  expect([...byScene.keys()], "the playthrough must visit every authored scene in order").toEqual([...sceneOrder]);
+  expect(sceneId, "the playthrough must end in the authored resolution scene").toBe(sceneOrder.at(-1));
+
   const judgments = [];
   for (const [id, scene] of byScene) {
     const judgment = await judgeSceneNarration({ sceneId: id, ...scene });


### PR DESCRIPTION
## Summary
- The hosted playthrough failed at turn 12 with `Expected: "2C", Received: "3A"`. This was a **test defect, not a runtime defect**: the model selected a different-but-valid Scene 2C candidate, which satisfied the combined-plan bridge one turn earlier, and the runtime transitioned correctly at 3A's authored 780s floor.
- A turn-indexed script asserts one specific ordering out of several valid ones, so it reports a false failure whenever the model legitimately advances faster.
- The journey is now adaptive: prompts are grouped by scene and the harness sends the next prompt for whichever scene the runtime reports, while walking a package-derived milestone ladder (every pacing event plus every scene entry window, ascending) so each authored instant is still hit exactly.

## Invariants now asserted
- The spine never regresses and never advances more than one scene per turn, so no scene can be skipped.
- Every pacing event has fired once its authored instant has passed.
- All nine scenes are visited in authored order and the run ends in `3C`.

## Test plan
- [x] `cd frontend && npm test` — 33 passed (includes new milestone-ladder coverage)
- [x] Ladder verified: 20 milestones, 120s → 1140s, covering all four pacing events and all eight entry windows
- [ ] After deploy: rerun `E2E_PACKAGE_CLOCK=1 npm run test:e2e -- --grep @llm-canon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeA2aktvwm37EsPZaCV9y