### PR TITLE
Let the E2E clock follow the story instead of advancing every turn

### DIFF
--- a/frontend/e2e/package-clock.js
+++ b/frontend/e2e/package-clock.js
@@ -210,25 +210,10 @@ export function loadPackagePacing({ storyId, repoRoot, pacingPath } = {}) {
     ]),
   );
 
-  // One ascending ladder of every authored instant a turn may need to land on. Pacing events win
-  // ties so the evidence names the event rather than a scene boundary that shares its timestamp.
-  const ladder = [...eventMilestones.values(), ...[...sceneMilestones.values()].flatMap((points) => [...points.values()])]
-    // "latest" is a deadline, not a place to stop; 0 is the story's start, already reached.
-    .filter((milestone) => milestone.point !== "latest" && milestone.target_seconds > 0)
-    .sort((left, right) => left.target_seconds - right.target_seconds || (left.kind === "pacing_event" ? -1 : 1));
-  const dedupedLadder = Object.freeze(
-    ladder.filter(
-      (milestone, index) => index === 0 || milestone.target_seconds !== ladder[index - 1].target_seconds,
-    ),
-  );
-
   const projection = {
     storyId,
     sceneOrder: frozenSceneOrder,
     eventOrder: Object.freeze([...eventRecords.keys()]),
-    milestoneLadder() {
-      return dedupedLadder;
-    },
     scenePoint(sceneId, point) {
       if (!sceneMilestones.has(sceneId)) {
         throw pacingError(storyId, resolvedPacingPath, sceneId, `scene "${sceneId}" is not declared`);

--- a/frontend/e2e/package-clock.test.js
+++ b/frontend/e2e/package-clock.test.js
@@ -86,12 +86,11 @@ test("loads the real package and resolves irregular scene and event milestones",
     "storyId",
     "sceneOrder",
     "eventOrder",
-    "milestoneLadder",
     "scenePoint",
     "eventPoint",
   ]);
   assert.equal(Object.isFrozen(projection.eventOrder), true);
-  assert.equal(Object.isFrozen(projection.milestoneLadder()), true);
+  assert.deepEqual([...projection.eventOrder], ["pressure_1a", "purge_2c", "override_deadline_3a", "destruction_3b"]);
 });
 
 test("reports unknown story, scene, event, and point identifiers", () => {
@@ -258,31 +257,5 @@ events:
 `,
     "event_missing_scene",
     "undeclared scene",
-  );
-});
-
-test("milestoneLadder walks every authored instant once, ascending", () => {
-  const pacing = loadPackagePacing({ storyId: "continuity_initiative" });
-  const ladder = pacing.milestoneLadder();
-  const seconds = ladder.map((milestone) => milestone.target_seconds);
-
-  assert.deepEqual(seconds, [...seconds].sort((left, right) => left - right), "ladder must ascend");
-  assert.equal(new Set(seconds).size, seconds.length, "ladder must not repeat an instant");
-
-  // Every pacing event and every scene entry window must be landable.
-  for (const eventId of pacing.eventOrder) {
-    assert.ok(seconds.includes(pacing.eventPoint(eventId).target_seconds), `missing event ${eventId}`);
-  }
-  // Every scene the story must still transition into needs a landable entry window.
-  // The first scene's window is the story's start, which no turn can land on.
-  for (const sceneId of pacing.sceneOrder.slice(1)) {
-    assert.ok(
-      seconds.includes(pacing.scenePoint(sceneId, "earliest").target_seconds),
-      `missing earliest window for ${sceneId}`,
-    );
-  }
-  assert.ok(
-    seconds.every((value) => value > 0),
-    "the ladder must not offer the already-reached story start",
   );
 });

--- a/frontend/e2e/scene-runtime.spec.js
+++ b/frontend/e2e/scene-runtime.spec.js
@@ -11,6 +11,10 @@ import { loadPackagePacing } from "./package-clock.js";
 import { judgeRoleplayTurn, judgeSceneNarration } from "./roleplay-judge.js";
 import { promptFor, scenePrompts, spineJourney } from "./canon-journey.js";
 
+// Nine scenes needing up to three earned reveals each, with headroom for a turn
+// the model spends on a non-progressing but valid candidate.
+const MAX_CANON_TURNS = 36;
+
 function narrationText(payload) {
   const turnText = (payload.segments || [])
     .filter((segment) => ["narration", "action", "dialogue"].includes(segment.kind))
@@ -96,16 +100,31 @@ test("judges every reached scene against the five-file narrative canon @llm-cano
   const opening = (await page.locator(".entry-output").first().textContent())?.trim() || "";
   const byScene = new Map([["1A", { opening, turns: [] }]]);
   const sceneOrder = pacing.sceneOrder;
-  const ladder = pacing.milestoneLadder();
   let sceneId = "1A";
+  let elapsed = 0;
   const promptsUsed = new Map();
   const progress = [];
 
-  for (const [index, milestone] of ladder.entries()) {
-    if (sceneId === sceneOrder.at(-1) && promptsUsed.get(sceneId) >= scenePrompts[sceneId].length) break;
+  // The clock follows the story, never the other way round. A scene needs
+  // several turns to earn its outgoing bridge, so time advances only as far as
+  // the next scene's authored entry window and then holds until the story is
+  // ready. Advancing on every turn instead lets the clock outrun the spine and
+  // strands scene-bound pacing events in a scene the story has not reached.
+  const clockTargetFor = (currentSceneId, currentElapsed) => {
+    const next = sceneOrder[sceneOrder.indexOf(currentSceneId) + 1];
+    const goal = next
+      ? pacing.scenePoint(next, "earliest")
+      : pacing.scenePoint(currentSceneId, "target");
+    if (goal.target_seconds > currentElapsed) return goal;
+    return { kind: "scene_point", scene_id: currentSceneId, point: "hold", target_seconds: currentElapsed };
+  };
+
+  for (let index = 0; index < MAX_CANON_TURNS; index += 1) {
+    if (sceneId === sceneOrder.at(-1) && (promptsUsed.get(sceneId) || 0) >= scenePrompts[sceneId].length) break;
     const sourceSceneId = sceneId;
     const used = promptsUsed.get(sourceSceneId) || 0;
     const input = promptFor(sourceSceneId, used);
+    const milestone = clockTargetFor(sourceSceneId, elapsed);
     await test.step(`turn ${index + 1}: scene ${sourceSceneId} at ${milestone.target_seconds}s`, async () => {
       controller.arm(milestone);
       const payload = await submitTurn(page, input);
@@ -133,15 +152,21 @@ test("judges every reached scene against the five-file narrative canon @llm-cano
       expect(to - from, `Turn ${index + 1} regressed from ${sourceSceneId} to ${String(reachedSceneId)}.`).toBeGreaterThanOrEqual(0);
       expect(to - from, `Turn ${index + 1} skipped past a scene from ${sourceSceneId} to ${String(reachedSceneId)}.`).toBeLessThanOrEqual(1);
 
-      // Any pacing event whose authored instant has passed must have fired.
+      // A pacing event is bound to its own scene, so it is due only once the
+      // story is in that scene at or past its instant - or has left the scene
+      // behind, in which case a beat that never landed is a real defect.
       for (const eventId of pacing.eventOrder) {
-        if (pacing.eventPoint(eventId).target_seconds > milestone.target_seconds) continue;
+        const event = pacing.eventPoint(eventId);
+        const eventScene = sceneOrder.indexOf(event.scene_id);
+        const inScenePastDue = eventScene === to && observedElapsed >= event.target_seconds;
+        if (!inScenePastDue && eventScene >= to) continue;
         expect(payload.state?.fired_pacing_event_ids, `Turn ${index + 1} is missing pacing event ${eventId}.`).toContain(eventId);
       }
 
       if (!byScene.has(reachedSceneId)) byScene.set(reachedSceneId, { opening: "", turns: [] });
       byScene.get(reachedSceneId).turns.push({ player_input: input, narration, source_scene_id: sourceSceneId });
       sceneId = reachedSceneId;
+      elapsed = observedElapsed;
       progress.push({
         turn: index + 1,
         input,


### PR DESCRIPTION
## Summary
- The adaptive journey advanced one authored milestone per turn, but a scene needs two or three turns to earn its outgoing bridge, so the clock outran the spine.
- Observed live: by turn 11 the story was still in Scene 2B while the clock had reached 690s, and `purge_2c` — which is bound to Scene 2C — could not fire in a scene the story had not yet reached.
- The clock now advances only as far as the next scene's authored entry window, then holds at the current instant until the story is ready to move. A scene may take as many turns as it needs without consuming the 20-minute budget, and every pacing event still lands because each event's instant falls before its scene's outgoing window (120 < 120, 690 < 780, 870 < 900, 1020 < 1050).
- The pacing-event assertion is scene-aware to match: an event is due once the story is in its scene at or past its instant, or has left that scene behind — the case where a beat that never landed is a genuine defect.
- Drops the now-unused `milestoneLadder()` accessor rather than leaving dead API behind.

## Test plan
- [x] `cd frontend && npm test` — 32 passed
- [x] `npx playwright test --list` discovers `@spine` and `@llm-canon`
- [ ] Rerun `E2E_PACKAGE_CLOCK=1 npm run test:e2e -- --grep @llm-canon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeA2aktvwm37EsPZaCV9y