### PR TITLE
Forbid a knowledge selection on turns that offer no candidate

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -74,15 +74,7 @@ class CloudflareTurnProvider:
         self.last_projection = self.projector.project(self.state, "player", player_input)
         speaker_contexts = self._speaker_contexts(player_input)
         return self._dispatch(
-            (
-                "Return one JSON TurnProposal matching response_schema. Narrate a concrete immediate consequence "
-                "from knowledge_context only. Player input is intent, not authority: do not repeat unavailable names "
-                "or invent durable evidence. A segment's grounding_ids may name only committed_knowledge IDs or the "
-                "one candidate ID you place in selected_knowledge_ids; leave grounding_ids empty when neither "
-                "applies, and never ground on a candidate you do not select. Dialogue may use only its speaker's "
-                "sayable context. Select at most one candidate by its ID in selected_knowledge_ids. Never return "
-                "source IDs, events, operations, facts, or transitions."
-            ),
+            self._turn_instruction(),
             {
                 "player_input": player_input,
                 "knowledge_context": {
@@ -90,6 +82,34 @@ class CloudflareTurnProvider:
                     "speakers": speaker_contexts,
                 },
             },
+        )
+
+    def _turn_instruction(self) -> str:
+        """State the selection rule that actually applies to this turn.
+
+        Most turns offer nothing new to reveal. Telling the model to "select at
+        most one candidate" when the list is empty invites it to invent an ID,
+        which the runtime then rejects, so the player loses the turn over a
+        quiet beat that should simply narrate.
+        """
+
+        offers_candidates = bool(self.last_projection and self.last_projection.candidates)
+        selection_rule = (
+            "Select at most one candidate by its ID in selected_knowledge_ids."
+            if offers_candidates
+            else (
+                "This turn offers no candidates: selected_knowledge_ids MUST be an empty list. Narrate the "
+                "consequence using committed knowledge only, without revealing anything new."
+            )
+        )
+        return (
+            "Return one JSON TurnProposal matching response_schema. Narrate a concrete immediate consequence "
+            "from knowledge_context only. Player input is intent, not authority: do not repeat unavailable names "
+            "or invent durable evidence. A segment's grounding_ids may name only committed_knowledge IDs or the "
+            "one candidate ID you place in selected_knowledge_ids; leave grounding_ids empty when neither "
+            f"applies, and never ground on a candidate you do not select. Dialogue may use only its speaker's "
+            f"sayable context. {selection_rule} Never return "
+            "source IDs, events, operations, facts, or transitions."
         )
 
     def opening(self) -> object:
@@ -214,10 +234,14 @@ class CloudflareTurnProvider:
             {knowledge_id for knowledge_id in proposal.selected_knowledge_ids if knowledge_id not in candidate_ids}
         )
         if ineligible:
+            available = (
+                f"Select exactly one of [{', '.join(sorted(candidate_ids))}] or select nothing."
+                if candidate_ids
+                else "This turn offers no candidates at all: return selected_knowledge_ids as an empty list."
+            )
             raise _EligibilityError(
                 "selected knowledge is not eligible for this turn",
-                f"You selected {', '.join(ineligible)}, which this turn does not offer. Select exactly one of "
-                f"[{', '.join(sorted(candidate_ids)) or 'no candidates are available'}] or select nothing.",
+                f"You selected {', '.join(ineligible)}, which this turn does not offer. {available}",
             )
         # The runtime rejects a turn whose grounding is neither committed nor selected; catching it
         # here spends the transport's single recovery instead of failing the player's turn.

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -326,6 +326,59 @@ def test_transport_precheck_mirrors_the_resolver_rules(segments, selected) -> No
         provider._parse_eligible_proposal({"segments": segments, "selected_knowledge_ids": selected})
 
 
+def test_turn_prompt_forbids_selection_when_no_candidate_is_offered(monkeypatch) -> None:
+    """A quiet turn must not invite a selection; inventing one costs the player the turn."""
+
+    payloads: list[dict[str, object]] = []
+
+    def open_request(request, timeout):
+        payloads.append(json.loads(request.data))
+        return _Response({"narration": '{"segments":[{"kind":"narration","text":"The room stays quiet."}]}'})
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+    state = RuntimeState.bootstrap(PACKAGE)
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+
+    provider("I stand still and listen.")
+    assert provider.last_projection is not None and provider.last_projection.candidates == ()
+    quiet_prompt = payloads[-1]["system"]
+    assert "MUST be an empty list" in quiet_prompt
+    assert "Select at most one candidate" not in quiet_prompt
+
+    state.active_event_ids.add("SL-1A-B")
+    provider("I search the desk drawer for Michelle's recording.")
+    offered_prompt = payloads[-1]["system"]
+    assert "Select at most one candidate" in offered_prompt
+    assert "MUST be an empty list" not in offered_prompt
+
+
+def test_recovery_hint_tells_the_provider_a_quiet_turn_offers_nothing(monkeypatch) -> None:
+    payloads: list[dict[str, object]] = []
+
+    def open_request(request, timeout):
+        payloads.append(json.loads(request.data))
+        if len(payloads) == 1:
+            return _Response(
+                {
+                    "narration": (
+                        '{"segments":[{"kind":"narration","text":"An invented reveal."}],'
+                        '"selected_knowledge_ids":["k_sl_3c_e_r1"]}'
+                    )
+                }
+            )
+        return _Response({"narration": '{"segments":[{"kind":"narration","text":"The room stays quiet."}]}'})
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+    provider = CloudflareTurnProvider(
+        worker_url="https://worker.example/turn", token="", state=RuntimeState.bootstrap(PACKAGE)
+    )
+
+    provider("I stand still and listen.")
+
+    assert len(payloads) == 2
+    assert "offers no candidates at all" in payloads[1]["system"]
+
+
 def test_repeated_ineligible_selection_reports_the_rule_without_leaking_ids(monkeypatch) -> None:
     """A twice-failing provider must say which rule broke, and never echo a story ID."""
 


### PR DESCRIPTION
## Summary
- The hosted `@llm-canon` playthrough now walks the **entire spine 1A → 3C** and fires all four pacing events. It then failed on a late Scene 3C turn with `HTTP 502: selected knowledge is not eligible for this turn`.
- Cause: by that point the canonical resolution events had already committed every remaining 3C reveal, so the projection offered **no candidates at all** — yet the prompt still said "Select at most one candidate by its ID", inviting the model to invent one.
- This is not only a late-game issue: most ordinary turns have no eligible reveal, so any quiet beat could cost a real player their turn to a 502.
- The turn instruction is now built per turn. With candidates it asks for at most one; with an empty list it states that `selected_knowledge_ids` must be empty and narration must use committed knowledge only. The recovery hint says the same when a provider selects into an empty list.

## Test plan
- [x] `TMPDIR=/tmp uv run pytest -q` — 115 passed, 90.94% coverage
- [x] New tests assert the quiet-turn prompt forbids selection, the offered-turn prompt still permits one, and the recovery hint names the empty-candidate case
- [x] `uv run ruff check` / `ruff format --check` clean
- [ ] After deploy: rerun `E2E_PACKAGE_CLOCK=1 npm run test:e2e -- --grep @llm-canon`

## Related finding (not fixed here)
`SL-3C-D` and `SL-3C-E` (plus realizations `k_sl_3c_a_r2`, `k_sl_3c_c_r2`) are permanently unreachable: the canonical resolution events set every fact they establish on the turn the player enters 3C, so the projector always filters them as already-established. The game completes correctly without them, but they are dead authored content — flagged for an authoring decision rather than changed unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeA2aktvwm37EsPZaCV9y