### PR TITLE
Steer provider recovery to the response that always validates

### DIFF
--- a/frontend/e2e/canon-journey.js
+++ b/frontend/e2e/canon-journey.js
@@ -59,13 +59,14 @@ export const scenePrompts = {
   ],
 };
 
-// A scene's prompts are exhausted only if the model needs more turns there than
-// authored; repeating the last prompt keeps the run moving without inventing
-// new player intent.
+// A scene may need more turns than it has authored prompts - a reveal can be
+// gated on a pacing event that only lands later in the scene. Cycling re-offers
+// the earlier intents once that gate opens, where clamping to the last prompt
+// would strand a beat the scene still needs.
 export function promptFor(sceneId, usedCount) {
   const prompts = scenePrompts[sceneId];
   if (!prompts) throw new Error(`No authored prompts for scene ${sceneId}.`);
-  return prompts[Math.min(usedCount, prompts.length - 1)];
+  return prompts[usedCount % prompts.length];
 }
 
 // The unclocked spine run advances 60 authored seconds per turn and cannot skip

--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -226,22 +226,27 @@ class CloudflareTurnProvider:
         if len(proposal.selected_knowledge_ids) > 1:
             raise _EligibilityError(
                 "at most one knowledge selection is allowed per turn",
-                f"You selected {', '.join(sorted(proposal.selected_knowledge_ids))}. Choose exactly one of those "
-                "IDs and drop the rest; a turn may reveal at most one candidate.",
+                f"You selected {', '.join(sorted(proposal.selected_knowledge_ids))}. Resend the same narration with "
+                "selected_knowledge_ids holding at most one of those IDs, or an empty list to reveal nothing.",
             )
         candidate_ids = {candidate.id for candidate in self.last_projection.candidates}
         ineligible = sorted(
             {knowledge_id for knowledge_id in proposal.selected_knowledge_ids if knowledge_id not in candidate_ids}
         )
         if ineligible:
-            available = (
-                f"Select exactly one of [{', '.join(sorted(candidate_ids))}] or select nothing."
+            # Steer to the one response that is always valid. Offering a menu invites the model to
+            # keep reaching for the reveal the player's intent implies, which fails the turn again.
+            alternative = (
+                f" Only if one of [{', '.join(sorted(candidate_ids))}] genuinely fits this moment may you select "
+                "exactly one of those instead."
                 if candidate_ids
-                else "This turn offers no candidates at all: return selected_knowledge_ids as an empty list."
+                else " This turn offers no candidates at all."
             )
             raise _EligibilityError(
                 "selected knowledge is not eligible for this turn",
-                f"You selected {', '.join(ineligible)}, which this turn does not offer. {available}",
+                f"You selected {', '.join(ineligible)}, which this turn does not offer. Resend the same narration "
+                "with selected_knowledge_ids as an empty list and no grounding_ids, revealing nothing new."
+                + alternative,
             )
         # The runtime rejects a turn whose grounding is neither committed nor selected; catching it
         # here spends the transport's single recovery instead of failing the player's turn.
@@ -260,8 +265,8 @@ class CloudflareTurnProvider:
             raise _EligibilityError(
                 "segment grounding is not committed or selected knowledge",
                 f"You grounded a segment on {', '.join(ungroundable)}, which is neither committed knowledge nor a "
-                "candidate you selected. Either put that ID in selected_knowledge_ids when it is one of this turn's "
-                "candidates, or return the segment with an empty grounding_ids list.",
+                "candidate you selected. Resend the same narration with an empty grounding_ids list; only if that ID "
+                "is one of this turn's candidates may you instead place it in selected_knowledge_ids.",
             )
         return proposal
 

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -217,6 +217,9 @@ def test_transport_recovers_once_when_provider_selects_unavailable_knowledge(mon
     assert len(payloads) == 2
     assert "previous response was invalid" in payloads[1]["system"]
     assert "k_future_unavailable" in payloads[1]["system"]
+    # The retry must lead with the response that always validates. Offering only a menu
+    # lets the model keep reaching for the reveal the player's intent implies.
+    assert "empty list" in payloads[1]["system"]
 
 
 def test_transport_recovers_once_when_provider_grounds_on_unselected_knowledge(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Turn 12 of the hosted playthrough failed twice in Scene 2C with `selected knowledge is not eligible for this turn`. The player intent was Michelle's combined broadcast-and-rescue plan, whose reveal is gated on `purge_clock_started` — a pacing event that lands **later in the same turn**, after the projection the provider was handed. The reveal was genuinely ineligible at that instant.
- The recovery hint offered a menu ("select one of [...] or select nothing"), so the model kept reaching for the reveal the player had asked for and failed the retry too.
- Recovery now leads with the response that always validates: resend the same narration with an empty `selected_knowledge_ids` and no `grounding_ids`, with eligible alternatives offered only as a secondary option. A player whose intent runs slightly ahead of a gate gets narration instead of a lost turn.
- The E2E scene prompts now cycle instead of clamping to the last, so a beat gated behind a mid-scene pacing event is re-offered once its gate opens.

## Test plan
- [x] `TMPDIR=/tmp uv run pytest -q` — 115 passed, 90.94% coverage
- [x] `cd frontend && npm test` — 32 passed
- [x] Test asserts the retry leads with the empty-list instruction, not just a menu
- [x] `uv run ruff check` / `ruff format --check` clean
- [ ] After deploy: rerun `E2E_PACKAGE_CLOCK=1 npm run test:e2e -- --grep @llm-canon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeA2aktvwm37EsPZaCV9y