### PR TITLE
Keep the narration when a provider will not correct an ineligible selection

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -177,19 +177,11 @@ class CloudflareTurnProvider:
         fallback_payload = {key: value for key, value in payload.items() if key != "response_format"}
         try:
             response = self._request(fallback_payload)
-            self._parse_eligible_proposal(response)
-            return response
         except HTTPError as error:
             raise self._narration_error(error) from error
-        except RuntimeContractError as error:
-            summary = contract_error_summary(error) or getattr(error, "summary", "") or "invalid proposal"
-            raise NarrationProviderError(
-                f"narration service returned an invalid proposal ({summary})",
-                502,
-                "INVALID_PROPOSAL",
-            ) from error
         except (URLError, OSError, TimeoutError, ValueError, json.JSONDecodeError) as error:
             raise NarrationProviderError("narration service is unavailable") from error
+        return self._eligible_or_narration_only(response)
 
     def _recover_malformed_response(self, payload: dict[str, object], hint: str = "") -> object:
         correction = f" {hint}" if hint else ""
@@ -203,19 +195,46 @@ class CloudflareTurnProvider:
         }
         try:
             response = self._request(recovery_payload)
-            self._parse_eligible_proposal(response)
-            return response
         except HTTPError as error:
             raise self._narration_error(error) from error
+        except (URLError, OSError, TimeoutError, ValueError, json.JSONDecodeError) as error:
+            raise NarrationProviderError("narration service is unavailable") from error
+        return self._eligible_or_narration_only(response)
+
+    def _eligible_or_narration_only(self, response: object) -> object:
+        """Accept the reply, or keep only its narration when it still names knowledge it may not use.
+
+        A provider that will not correct its selection after one guided retry
+        would otherwise cost the player the turn. Returning the narration with
+        no selection and no grounding cannot commit an unearned fact: the
+        runtime only ever commits through an eligible package route, and the
+        projection never showed this provider the ineligible unit's statement.
+        A reply that cannot be parsed at all is still refused.
+        """
+
+        try:
+            self._parse_eligible_proposal(response)
+        except _EligibilityError:
+            proposal = parse_turn_proposal(response)
+            return {
+                "segments": [
+                    {
+                        "kind": segment.kind,
+                        "text": segment.text,
+                        **({"speaker_id": segment.speaker_id} if segment.speaker_id else {}),
+                    }
+                    for segment in proposal.segments
+                ],
+                "selected_knowledge_ids": [],
+            }
         except RuntimeContractError as error:
-            summary = contract_error_summary(error) or getattr(error, "summary", "") or "invalid proposal"
+            summary = contract_error_summary(error) or "invalid proposal"
             raise NarrationProviderError(
                 f"narration service returned an invalid proposal ({summary})",
                 502,
                 "INVALID_PROPOSAL",
             ) from error
-        except (URLError, OSError, TimeoutError, ValueError, json.JSONDecodeError) as error:
-            raise NarrationProviderError("narration service is unavailable") from error
+        return response
 
     def _parse_eligible_proposal(self, response: object) -> TurnProposal:
         proposal = parse_turn_proposal(response)

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -382,18 +382,25 @@ def test_recovery_hint_tells_the_provider_a_quiet_turn_offers_nothing(monkeypatc
     assert "offers no candidates at all" in payloads[1]["system"]
 
 
-def test_repeated_ineligible_selection_reports_the_rule_without_leaking_ids(monkeypatch) -> None:
-    """A twice-failing provider must say which rule broke, and never echo a story ID."""
+def test_persistently_ineligible_selection_keeps_the_narration_and_commits_nothing(monkeypatch) -> None:
+    """A provider that will not correct itself must not cost the player the turn.
 
+    The narration is kept, the selection and grounding are dropped, so the runtime
+    can commit nothing unearned and the player still gets a story beat.
+    """
+
+    payloads: list[dict[str, object]] = []
     state = RuntimeState.bootstrap(PACKAGE)
     state.active_event_ids.add("SL-1A-B")
     provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
 
     def open_request(request, timeout):
+        payloads.append(json.loads(request.data))
         return _Response(
             {
                 "narration": (
-                    '{"segments":[{"kind":"narration","text":"An invalid reveal."}],'
+                    '{"segments":[{"kind":"narration","text":"The drawer scrapes open.",'
+                    '"grounding_ids":["k_future_unavailable"]}],'
                     '"selected_knowledge_ids":["k_future_unavailable"]}'
                 )
             }
@@ -401,12 +408,35 @@ def test_repeated_ineligible_selection_reports_the_rule_without_leaking_ids(monk
 
     monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
 
-    with pytest.raises(NarrationProviderError) as error:
-        provider("I reach for something I have not earned.")
+    proposal = provider("I reach for something I have not earned.")
 
-    assert "selected knowledge is not eligible for this turn" in error.value.message
-    assert "k_future_unavailable" not in error.value.message
-    assert error.value.status_code == 502
+    assert len(payloads) == 2, "the provider still gets exactly one guided recovery"
+    assert proposal["selected_knowledge_ids"] == []
+    assert proposal["segments"] == [{"kind": "narration", "text": "The drawer scrapes open."}]
+
+    # The sanitized shape must satisfy the runtime rule that rejected it.
+    projector = KnowledgeProjector()
+    projection = projector.project(state, "player", "I reach for something I have not earned.")
+    resolved, _ = SelectedRevealResolver(PACKAGE).resolve(
+        state, projection, parse_turn_proposal(proposal), projector, "I reach for something I have not earned."
+    )
+    assert resolved.selected_knowledge_ids == ()
+    assert resolved.events == ()
+
+
+def test_unparseable_reply_is_still_refused(monkeypatch) -> None:
+    """Sanitizing an ineligible selection must not soften a reply we cannot read at all."""
+
+    provider = CloudflareTurnProvider(
+        worker_url="https://worker.example/turn", token="", state=RuntimeState.bootstrap(PACKAGE)
+    )
+    monkeypatch.setattr(
+        "storygame.runtime.cloudflare.urlopen",
+        lambda *_args, **_kwargs: _Response({"narration": '{"segments":[]}'}),
+    )
+
+    with pytest.raises(NarrationProviderError, match="invalid proposal"):
+        provider("I listen.")
 
 
 def test_transport_reports_safe_contract_shape_after_failed_recovery(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Four hosted runs have now died on `HTTP 502: selected knowledge is not eligible for this turn`, in Scenes 2B, 2C and 3C.
- I probed the deployed Worker directly at the exact failing state (Scene 2B, elapsed 510, only `SL-2B-A` eligible) and it selected a valid candidate on both attempts. So this is a **stochastic provider slip, not a promptable defect** — occasionally the model names an ID the turn does not offer, and repeats it on the guided retry.
- The transport is the untrusted-provider boundary, so it now guarantees the runtime an acceptable proposal: after the one guided recovery, a still-ineligible reply keeps its narration and loses its selection and grounding.

## Why this is safe
- No unearned fact can commit: the runtime only commits through an eligible package route, and a dropped selection produces no event.
- The provider was never shown the ineligible unit's statement — the projector filters it out — so the prose cannot faithfully carry its content.
- The runtime's fail-closed contract is **unchanged**; it simply stops being handed input that trips it.
- A reply that cannot be parsed at all is still refused with 502.

## Test plan
- [x] `TMPDIR=/tmp uv run pytest -q` — 116 passed, 91.05% coverage
- [x] New test drives the sanitized proposal through the real `SelectedRevealResolver` and asserts it resolves with no selection and no events
- [x] New test asserts an unparseable reply is still refused
- [x] `uv run ruff check` / `ruff format --check` clean
- [ ] After deploy: rerun `E2E_PACKAGE_CLOCK=1 npm run test:e2e -- --grep @llm-canon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeA2aktvwm37EsPZaCV9y