### PR TITLE
Keep Scene 1A winnable when the recording is recovered before the files

### DIFF
--- a/data/stories/continuity-initiative/knowledge.yaml
+++ b/data/stories/continuity-initiative/knowledge.yaml
@@ -338,6 +338,61 @@ knowledge:
   relevance:
     entity_ids: []
     priority: 0
+- id: k_sl_1a_d_r1
+  statement: 'Taped beneath a drawer, Michelle''s memory card holds her research and names the place she used to trade information.'
+  entity_ids: [kristin, michelle, memory_card]
+  aliases:
+  - hidden memory card
+  - Michelle's research
+  audience:
+    kind: public
+    player_visible: true
+  available_in_scenes:
+  - 1A
+  requires: []
+  establishes:
+  - op: assert
+    fact_id: continuity_initiative_known
+    value: true
+  - op: assert
+    fact_id: michelle_abduction_suspicion
+    value: true
+  - op: assert
+    fact_id: michelle_lead_actionable
+    value: true
+  source:
+    kind: storylet_realization
+    storylet_id: SL-1A-D
+    realization_id: SL-1A-D-R1
+  relevance:
+    entity_ids: [memory_card]
+    priority: 10
+- id: k_sl_1a_d_r2
+  statement: 'Only fragments of Michelle''s files survive, but they still name the exchange point she was using.'
+  entity_ids: [kristin, michelle, memory_card]
+  aliases:
+  - recovered fragments
+  - exchange point
+  audience:
+    kind: public
+    player_visible: true
+  available_in_scenes:
+  - 1A
+  requires: []
+  establishes:
+  - op: assert
+    fact_id: continuity_initiative_known
+    value: true
+  - op: assert
+    fact_id: michelle_lead_actionable
+    value: true
+  source:
+    kind: storylet_realization
+    storylet_id: SL-1A-D
+    realization_id: SL-1A-D-R2
+  relevance:
+    entity_ids: [memory_card]
+    priority: 0
 - id: k_sl_1a_c_r1
   statement: 'The patrol’s interest in Michelle’s research makes Kristin doubt that its welfare check is innocent.'
   entity_ids: []

--- a/data/stories/continuity-initiative/storylet-routes.yaml
+++ b/data/stories/continuity-initiative/storylet-routes.yaml
@@ -531,6 +531,69 @@ storylets:
     - scene_id_not: 1A
   non_coercion_note: Offer as a consequence/opportunity inferred from free-text play. Do not present these realizations
     as choices, commands, or required actions; equivalent player-authored approaches may validate the same operations.
+- id: SL-1A-D
+  scene_id: 1A
+  title: The Memory Card Under the Drawer
+  activation:
+    scene_id: 1A
+    conditions:
+    - fact_id: continuity_initiative_known
+      equals: false
+    - fact_id: michelle_warning_known
+      equals: true
+    pacing:
+      earliest_seconds: 0
+      target_seconds: 120
+      latest_seconds: 300
+      pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
+  pressure_role: When Kristin reached the damaged recording before the files, the card is still under the drawer;
+    the warning tells her Michelle hid something deliberately, so keep searching for what it points to.
+  realization_options:
+  - id: SL-1A-D-R1
+    dramatic_intent: Kristin finds the card taped beneath the drawer and reads enough of the files to know where
+      Michelle was pointing her.
+    operations:
+    - op: assert
+      fact_id: continuity_initiative_known
+      value: true
+    - op: assert
+      fact_id: michelle_abduction_suspicion
+      value: true
+    - op: assert
+      fact_id: michelle_lead_actionable
+      value: true
+    eligible_storylet_event_id: null
+    helps_transition_triggers:
+    - t_1a_1b
+    protected_knowledge_boundaries:
+    - janus_selection_system
+    - brandon_history
+    - phase_two
+  - id: SL-1A-D-R2
+    dramatic_intent: Only fragments of the research survive recovery, but they still name the exchange point Michelle
+      used, which is enough to move on.
+    operations:
+    - op: assert
+      fact_id: continuity_initiative_known
+      value: true
+    - op: assert
+      fact_id: michelle_lead_actionable
+      value: true
+    eligible_storylet_event_id: null
+    helps_transition_triggers:
+    - t_1a_1b
+    protected_knowledge_boundaries:
+    - janus_selection_system
+    - brandon_history
+    - phase_two
+  completion_or_abort:
+    complete_when:
+    - fact_id: michelle_lead_actionable
+      equals: true
+    abort_when:
+    - scene_id_not: 1A
+  non_coercion_note: Offer as a consequence/opportunity inferred from free-text play. Do not present these realizations
+    as choices, commands, or required actions; equivalent player-authored approaches may validate the same operations.
 - id: SL-1B-A
   scene_id: 1B
   title: The Dead Drop Has More Than One Meaning
@@ -1936,6 +1999,7 @@ coverage_matrix:
   trigger_fact_id: michelle_lead_actionable
   storylets_helping_in_source_scene:
   - SL-1A-B
+  - SL-1A-D
   status: covered_by_gated_canonical_bridge
   canonical_fallback_event: bridge_1a_actionable_lead
 - scene_id: 1B
@@ -2036,6 +2100,7 @@ canonical_bridge_events:
     value: true
   realization_storylets:
   - SL-1A-B
+  - SL-1A-D
   fallback_realization: Validated free-text recovery of Michelle’s memory-card files may establish the concrete park/dead-drop
     lead; the warning alone is not sufficient.
 - id: bridge_1b_departure

--- a/data/stories/continuity-initiative/storylets.md
+++ b/data/stories/continuity-initiative/storylets.md
@@ -132,6 +132,54 @@ Each entry below is authoring data, not a player action menu.
 
 ---
 
+### SL-1A-D — The Memory Card Under the Drawer
+
+**Source beats:** [1A.2 — Michelle’s Last Investigation](plot.md#scene-1a2--michelles-last-investigation)
+
+**Allowed scene:** `1A`
+
+**Available when**
+- Kristin has recovered Michelle’s damaged warning but not yet her research files.
+- Kristin remains able to search Michelle’s work area.
+- The memory card has not been destroyed or permanently lost.
+
+**Participants / items**
+- Kristin Schweitzer
+- Dr. Michelle McGehee through her research notes
+- Hidden memory card
+
+**Dramatic purpose**
+- Guarantee that the concrete lead away from the house stays earnable when Kristin reached the damaged recording before the research files.
+- Keep the memory card, not the damaged recording, as the thing that names where Michelle was working.
+
+**Possible realizations**
+- Kristin finds the card taped beneath the drawer and reads enough of the files to know where Michelle was pointing.
+- Kristin recovers only fragments of the research, but they still name the exchange point Michelle used.
+
+**Effects**
+- Sets `continuity_initiative_known`.
+- Sets `michelle_lead_actionable` once Kristin has a concrete lead she can follow away from the house.
+- May set `michelle_abduction_suspicion`.
+
+**Completion**
+- Kristin holds or has copied Michelle’s research and knows where to go next.
+
+**Abort**
+- The card becomes inaccessible through a player-caused destructive proposal; if it is a required future dependency with no fallback, normal game-break handling applies.
+
+**Protected boundary**
+- “Continuity Initiative” may be known as Michelle’s suspicious emergency program, but its actual national purpose remains protected.
+
+**Pacing window**
+- earliest: `00:00:00`
+- target: `00:02:00`
+- latest: `00:05:00`
+
+**Pacing impact**
+`brief_delay`
+
+---
+
 ### SL-1A-C — The Welfare Check Feels Like a Search
 
 **Source beats:** [1A.4 — The First Threat](plot.md#scene-1a4--the-first-threat)
@@ -1575,7 +1623,7 @@ These do **not** create a new playable scene after `3C`. The storylets themselve
 
 | Playable scene | Storylets | Primary function |
 |---|---|---|
-| [1A](plot.md#scene-1a--michelles-disappearance) | `SL-1A-A` … `SL-1A-C` | Crime-scene inference, Michelle’s evidence, first authority pressure |
+| [1A](plot.md#scene-1a--michelles-disappearance) | `SL-1A-A` … `SL-1A-D` | Crime-scene inference, Michelle’s evidence, first authority pressure |
 | [1B](plot.md#scene-1b--the-lead-in-the-park) | `SL-1B-A` … `SL-1B-C` | Dead-drop clues, Brandon trust, pursuit |
 | [1C](plot.md#scene-1c--discovery-of-the-facility) | `SL-1C-A` … `SL-1C-C` | Facility discovery, living captives, national scale |
 | [2A](plot.md#scene-2a--false-identities) | `SL-2A-A` … `SL-2A-C` | Brandon context, infiltration preparation, entry complication |

--- a/tests/test_canon_journey.py
+++ b/tests/test_canon_journey.py
@@ -142,3 +142,59 @@ def test_committed_triggers_never_outrun_the_authored_pacing_floor() -> None:
     _drive(engine, provider, None, clock_seconds=15)
     # At 270 seconds the authored window opens and the committed triggers carry Kristin out.
     assert state.current_scene_id == "1C"
+
+
+def _reachable_facts(package, seed_facts: set[str], fired_storylets: set[str]) -> set[str]:
+    """Every fact still committable from this state, ignoring turn order."""
+
+    pacing_facts = {effect.fact_id for event in package.pacing.events for effect in event.effects}
+    facts = set(seed_facts) | pacing_facts
+    changed = True
+    while changed:
+        changed = False
+        for route in package.storylet_routes.storylets:
+            if route.id in fired_storylets:
+                continue
+            eligible = all(
+                (predicate.fact_id in facts) if predicate.equals is not False else (predicate.fact_id not in seed_facts)
+                for predicate in route.activation_conditions
+            )
+            if not eligible:
+                continue
+            for realization in route.realizations:
+                for operation in realization.operations:
+                    if operation.op == "assert" and operation.fact_id not in facts:
+                        facts.add(operation.fact_id)
+                        changed = True
+        for event in package.storylet_routes.bridge_events:
+            if all(predicate.fact_id in facts for predicate in event.activation_conditions):
+                for operation in event.operations:
+                    if operation.op == "assert" and operation.fact_id not in facts:
+                        facts.add(operation.fact_id)
+                        changed = True
+    return facts
+
+
+def test_no_single_reveal_can_strand_a_scene_exit() -> None:
+    """No realization may consume the only route to its own scene's exit.
+
+    A storylet fires once. When two authored beats share a storylet and only one
+    of them establishes the outgoing trigger, choosing the other permanently
+    strands the player: recovering Michelle's damaged recording used to consume
+    Scene 1A's only source of `michelle_lead_actionable`, leaving the game
+    unwinnable in the opening scene.
+    """
+
+    stranded = []
+    for transition in PACKAGE.pacing.transitions:
+        required = {trigger.fact_id for trigger in transition.triggers}
+        for route in PACKAGE.storylet_routes.storylets:
+            if route.scene_id != transition.source_scene_id:
+                continue
+            for realization in route.realizations:
+                committed = {op.fact_id for op in realization.operations if op.op == "assert"}
+                missing = required - _reachable_facts(PACKAGE, committed, {route.id})
+                if missing:
+                    stranded.append(f"{route.id}/{realization.id} strands {sorted(missing)} needed by {transition.id}")
+
+    assert not stranded, "a single reveal made a scene exit unreachable:\n" + "\n".join(stranded)

--- a/tests/test_knowledge_projection.py
+++ b/tests/test_knowledge_projection.py
@@ -148,7 +148,10 @@ def test_scene_1a_route_windows_preserve_the_recording_timeline() -> None:
         {"k_sl_1a_a_r1", "k_sl_1a_a_r2"},
         set(),
         {"k_sl_1a_b_r1", "k_sl_1a_b_r2"},
-        {"k_sl_1a_c_r1", "k_sl_1a_c_r2"},
+        # This run took the damaged recording before Michelle's files, which used to
+        # consume Scene 1A's only source of the actionable lead. The memory card
+        # recovery now appears alongside the patrol beat so the scene stays winnable.
+        {"k_sl_1a_c_r1", "k_sl_1a_c_r2", "k_sl_1a_d_r1", "k_sl_1a_d_r2"},
     )
     for player_input, expected in zip(
         (

--- a/tests/test_markdown_story_package.py
+++ b/tests/test_markdown_story_package.py
@@ -30,7 +30,7 @@ def test_continuity_package_loads_all_scene_headings_and_storylets() -> None:
         "3B",
         "3C",
     ]
-    assert len(package.storylets) == 29
+    assert len(package.storylets) == 30
     assert all(storylet.source_links and storylet.sections["Protected boundary"] for storylet in package.storylets)
     assert package.knowledge.schema_version == "2.0"
     assert set(package.knowledge_indexes.facts_to_knowledge) == set(package.world.facts)


### PR DESCRIPTION
## Summary
The hosted playthrough reached the canon judge, then **stalled permanently in Scene 1A** — an unwinnable state in the opening scene.

- Recovering Michelle's damaged recording fires `SL-1A-B` with realization **R2**, which establishes her warning but not the actionable lead.
- A storylet fires once, and `michelle_lead_actionable` had only two sources: that storylet's *other* realization (R1), and `bridge_1a_actionable_lead`, which is gated on `continuity_initiative_known` — also only from R1.
- So playing the recording before finding the memory card consumed the scene's only route forward. Observed live: turns 5–9 committed nothing and the story could never leave 1A.

## Scope of the problem
A reachability audit over the whole package found this is the **single** instance of the shape — every other scene exit survives any one realization choice. That audit is now a test, so a future beat sharing a storylet with the only source of its scene's trigger fails in CI instead of in a playthrough.

## Fix
The authored bridge note is explicit that Michelle's warning alone is *not* sufficient to produce the lead, so R2 is not changed to grant it. Instead `SL-1A-D` offers the memory card as a recovery, activating only in the stranded state — warning recovered, files not yet found. It therefore neither competes for candidate slots on an ordinary turn nor alters the intended order when the files are found first.

## Test plan
- [x] `TMPDIR=/tmp uv run pytest -q` — 119 passed, 90.96% coverage
- [x] New `test_no_single_reveal_can_strand_a_scene_exit` audits every transition against every realization
- [x] Existing Scene 1A timeline test updated to show the recovery appearing on the recording-first path
- [x] `uv run ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeA2aktvwm37EsPZaCV9y