### PR TITLE
Tell the turn prompt not to echo the request back

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -119,7 +119,8 @@ class CloudflareTurnProvider:
             "one candidate ID you place in selected_knowledge_ids; leave grounding_ids empty when neither "
             f"applies, and never ground on a candidate you do not select. Dialogue may use only its speaker's "
             f"sayable context. {selection_rule} Never return "
-            "source IDs, events, operations, facts, or transitions."
+            "source IDs, events, operations, facts, or transitions. Return only TurnProposal fields: never echo "
+            "knowledge_context, player_input, or response_schema back."
         )
 
     def opening(self) -> object:
@@ -199,8 +200,9 @@ class CloudflareTurnProvider:
             **payload,
             "system": (
                 f"{payload['system']} Your previous response was invalid.{correction} Return only a complete JSON "
-                "TurnProposal with non-empty segments and optional selected_knowledge_ids; include no markdown or "
-                "explanation. If you are unsure whether an ID is groundable, omit grounding_ids entirely."
+                "TurnProposal with non-empty segments and optional selected_knowledge_ids; include no markdown, no "
+                "explanation, and none of the request's own fields echoed back. If you are unsure whether an ID is "
+                "groundable, omit grounding_ids entirely."
             ),
         }
         try:

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -585,3 +585,28 @@ def test_request_size_stays_flat_as_the_story_accumulates(monkeypatch) -> None:
     context = json.loads(captured[-1]["user"])["knowledge_context"]
     assert "sayable_knowledge" not in context["player"]
     assert all(set(speaker) == {"sayable_knowledge"} for speaker in context["speakers"].values())
+
+
+def test_prompts_forbid_echoing_the_request(monkeypatch) -> None:
+    """A provider that echoed the request back cost the player a turn with HTTP 502.
+
+    The reply carried knowledge_context, player_input and response_schema instead of
+    a proposal, which is unparseable and so cannot be salvaged after the fact.
+    """
+
+    payloads: list[dict[str, object]] = []
+
+    def open_request(request, timeout):
+        payloads.append(json.loads(request.data))
+        if len(payloads) == 1:
+            return _Response({"narration": '{"player_input":"x","knowledge_context":{},"response_schema":{}}'})
+        return _Response({"narration": '{"segments":[{"kind":"narration","text":"A recovered proposal."}]}'})
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+    provider = CloudflareTurnProvider(
+        worker_url="https://worker.example/turn", token="", state=RuntimeState.bootstrap(PACKAGE)
+    )
+
+    assert provider("I listen.") == {"segments": [{"kind": "narration", "text": "A recovered proposal."}]}
+    assert "never echo" in payloads[0]["system"]
+    assert "echoed back" in payloads[1]["system"]


### PR DESCRIPTION
## Summary
- A hosted turn failed with `HTTP 502` and validation paths `segments:missing, knowledge_context:extra_forbidden, player_input:extra_forbidden, response_schema:extra_forbidden` — the provider returned the **request payload** instead of a proposal, and repeated it on the recovery attempt.
- An echoed request is unparseable, so unlike an ineligible selection it cannot be salvaged into narration after the fact: the player simply loses the turn.
- The **opening** prompt has carried an explicit no-echo instruction since the truncated-JSON work; the ordinary **turn** prompt never did. Both it and the recovery instruction now say to return only TurnProposal fields and never echo `knowledge_context`, `player_input`, or `response_schema`.

## Test plan
- [x] `TMPDIR=/tmp uv run pytest -q` — 120 passed, 90.96% coverage
- [x] New test drives an echoed reply, asserts the guided recovery succeeds, and pins the no-echo wording in both prompts
- [x] `uv run ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeA2aktvwm37EsPZaCV9y