### PR TITLE
Retry once when the connection itself fails

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -172,7 +172,7 @@ class CloudflareTurnProvider:
             "response_format": {"type": "json_object"},
         }
         try:
-            response = self._request(payload)
+            response = self._request_allowing_one_transient_retry(payload)
         except HTTPError as error:
             if self._worker_error_code(error) != "AI_JSON_MODE_REJECTED":
                 raise self._narration_error(error) from error
@@ -187,7 +187,7 @@ class CloudflareTurnProvider:
 
         fallback_payload = {key: value for key, value in payload.items() if key != "response_format"}
         try:
-            response = self._request(fallback_payload)
+            response = self._request_allowing_one_transient_retry(fallback_payload)
         except HTTPError as error:
             raise self._narration_error(error) from error
         except (URLError, OSError, TimeoutError, ValueError, json.JSONDecodeError) as error:
@@ -206,7 +206,7 @@ class CloudflareTurnProvider:
             ),
         }
         try:
-            response = self._request(recovery_payload)
+            response = self._request_allowing_one_transient_retry(recovery_payload)
         except HTTPError as error:
             raise self._narration_error(error) from error
         except (URLError, OSError, TimeoutError, ValueError, json.JSONDecodeError) as error:
@@ -331,6 +331,28 @@ class CloudflareTurnProvider:
 
     def _scene(self) -> Scene:
         return next(item for item in self.state.package.scenes if item.metadata.scene_id == self.state.current_scene_id)
+
+    def _request_allowing_one_transient_retry(self, payload: dict[str, object]) -> object:
+        """Retry once when the connection itself fails, never on an answered request.
+
+        A momentary connection failure is not the provider refusing the turn, but
+        it reached the player as a lost turn all the same, and it ended a
+        thirty-turn playthrough on its third turn. An answered request - any
+        HTTPError, or a body that is not JSON - is left alone, because those are
+        handled by the typed-error and recovery paths above.
+        """
+
+        try:
+            return self._request(payload)
+        except HTTPError:
+            raise
+        except (TimeoutError, URLError, OSError) as first_failure:
+            try:
+                return self._request(payload)
+            except HTTPError:
+                raise
+            except (TimeoutError, URLError, OSError) as error:
+                raise error from first_failure
 
     def _request(self, payload: dict[str, object]) -> object:
         headers = {

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -610,3 +610,40 @@ def test_prompts_forbid_echoing_the_request(monkeypatch) -> None:
     assert provider("I listen.") == {"segments": [{"kind": "narration", "text": "A recovered proposal."}]}
     assert "never echo" in payloads[0]["system"]
     assert "echoed back" in payloads[1]["system"]
+
+
+def test_one_transient_connection_failure_does_not_lose_the_turn(monkeypatch) -> None:
+    """A momentary connection failure ended a thirty-turn playthrough on its third turn."""
+
+    attempts: list[int] = []
+
+    def open_request(request, timeout):
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise URLError("connection reset")
+        return _Response({"narration": '{"segments":[{"kind":"narration","text":"The corridor holds."}]}'})
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+    provider = CloudflareTurnProvider(
+        worker_url="https://worker.example/turn", token="", state=RuntimeState.bootstrap(PACKAGE)
+    )
+
+    assert provider("I listen.") == {"segments": [{"kind": "narration", "text": "The corridor holds."}]}
+    assert len(attempts) == 2
+
+
+def test_a_sustained_outage_still_fails_closed(monkeypatch) -> None:
+    attempts: list[int] = []
+
+    def open_request(request, timeout):
+        attempts.append(1)
+        raise URLError("offline")
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+    provider = CloudflareTurnProvider(
+        worker_url="https://worker.example/turn", token="", state=RuntimeState.bootstrap(PACKAGE)
+    )
+
+    with pytest.raises(NarrationProviderError, match="unavailable"):
+        provider("I listen.")
+    assert len(attempts) == 2, "exactly one retry, never an unbounded loop"


### PR DESCRIPTION
## Summary
- A thirty-turn playthrough ended **on its third turn** with `HTTP 503: narration service is unavailable` — a momentary connection failure, not the provider refusing anything.
- The transport already recovers once from a rejected JSON mode, a malformed reply, and an ineligible selection. A connection error went straight to a lost turn with no second attempt.
- Connection-level failures now get exactly one retry.

## Bounded by design
- Any `HTTPError` keeps its existing typed handling (quota, capacity, worker error codes) and is never retried here.
- A body that is not JSON still goes to the recovery path.
- A sustained outage makes exactly two attempts and then fails closed — asserted in a test, so this cannot become an unbounded loop.

## Test plan
- [x] `TMPDIR=/tmp uv run pytest -q` — 122 passed, 90.97% coverage
- [x] Test: one transient failure is absorbed and the turn still returns narration
- [x] Test: a sustained outage still fails closed after exactly one retry
- [x] `uv run ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeA2aktvwm37EsPZaCV9y