### PR TITLE
Give Scene 1A its authored crime-scene detail and credit each scene's opening

### DIFF
--- a/data/stories/continuity-initiative/knowledge.yaml
+++ b/data/stories/continuity-initiative/knowledge.yaml
@@ -207,8 +207,7 @@ facts:
   purpose: The safe opening frame for scene 3C has been established.
 scene_frames:
 - scene_id: 1A
-  situation: The house is too quiet. Michelle's phone lies facedown on the kitchen floor
-    beside an overturned chair, while her laptop and work bag are gone.
+  situation: 'The house is too quiet. Michelle''s phone lies facedown on the kitchen floor beside an overturned chair, her laptop and work bag are gone, and the back door frame is splintered where someone forced the lock. Her work area - the desk, the drawers, the places she kept her research - has not been searched yet.'
   pressure: Find evidence of Michelle's disappearance
 - scene_id: 1B
   situation: 'A damaged public park holding Michelle''s dead drop: an ordinary bench with a transit access card, a handwritten number sequence, a photograph of Michelle with an unidentified man, and a list of earlier disappearance dates hidden beneath it. A watcher lingers across the park while emergency patrols sweep the paths.'

--- a/frontend/e2e/scene-runtime.spec.js
+++ b/frontend/e2e/scene-runtime.spec.js
@@ -180,7 +180,17 @@ test("judges every reached scene against the five-file narrative canon @llm-cano
         `Scene ${sourceSceneId} committed nothing for ${stalledTurns} turns running; its outgoing reveals are not landing.`,
       ).toBeLessThan(MAX_STALLED_TURNS);
 
-      if (!byScene.has(reachedSceneId)) byScene.set(reachedSceneId, { opening: "", turns: [] });
+      if (!byScene.has(reachedSceneId)) {
+        // Entering a scene emits its authored entry_text as the turn's final segment.
+        // Recording it as that scene's opening stops the judge from grading every scene
+        // after 1A as though it had established itself from nothing.
+        const entered = reachedSceneId !== sourceSceneId;
+        const segments = (payload.segments || []).filter((segment) => segment.kind === "narration");
+        byScene.set(reachedSceneId, {
+          opening: entered && segments.length ? segments.at(-1).text.trim() : "",
+          turns: [],
+        });
+      }
       byScene.get(reachedSceneId).turns.push({ player_input: input, narration, source_scene_id: sourceSceneId });
       sceneId = reachedSceneId;
       elapsed = observedElapsed;


### PR DESCRIPTION
## Summary
The playthrough now runs **all nine scenes and every one reaches the canon judge**. All nine failed; two of the judge's recurring complaints have concrete, fixable causes.

**1. Scene 1A's frame omitted the forced back door.**
> "The canon explicitly states the back door shows signs of forced entry. Ignoring that inspected evidence breaks responsiveness on an ordinary turn."

The frame named the phone, the chair, and the missing bag — but not the forced lock. The one piece of evidence the player was inspecting was the one the narrator could not see. It now carries the forced door and the fact that her work area is still unsearched.

**2. The judge graded scenes 1B–3C as though each established itself from nothing.**
> "…especially given the supplied opening is empty and the scene must establish itself strongly."

Entering a scene *does* emit its authored `entry_text` as the turn's final segment, but the harness recorded an empty opening for every scene after 1A. It now records that text, so the judge sees what a player actually reads.

## Remaining gap (not addressed here)
The deeper cause of the richness and beat-faithfulness failures is that an ordinary turn's context carries only a one-sentence scene frame and terse knowledge statements — never the scene's authored beat prose. The narration model therefore cannot draw on authored detail mid-scene. Widening that context is a real design decision (it trades against the unearned-reveal protections and the context budget), so it is written up rather than pushed through unilaterally.

## Test plan
- [x] `TMPDIR=/tmp uv run pytest -q` — 122 passed, 90.97% coverage
- [x] Playwright still discovers the suite
- [ ] Rerun `@llm-canon` for updated nine-scene verdicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeA2aktvwm37EsPZaCV9y