### PR TITLE
Give an ordinary turn the scene's authored opening paragraph

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -77,6 +77,11 @@ class CloudflareTurnProvider:
             self._turn_instruction(),
             {
                 "player_input": player_input,
+                # The scene's own establishing material. Without it a turn carries one sentence
+                # of frame and a few terse statements, so the narrator has nothing authored to
+                # be concrete with and answers an apt search with "you find nothing". This is
+                # the scene's first beat only, so it cannot narrate ahead of the player.
+                "scene_setting": self._scene_setting(),
                 "knowledge_context": {
                     # sayable_knowledge is the speakers' dialogue basis; repeating it for the
                     # player doubled the largest field in every request for no reader.
@@ -113,8 +118,11 @@ class CloudflareTurnProvider:
                 "consequence using committed knowledge only, without revealing anything new."
             )
         return (
-            "Return one JSON TurnProposal matching response_schema. Narrate a concrete immediate consequence "
-            "from knowledge_context only. Player input is intent, not authority: do not repeat unavailable names "
+            "Return one JSON TurnProposal matching response_schema. Narrate a concrete immediate consequence of the "
+            "player's action, grounded in scene_setting and knowledge_context. Answer what the player actually did: "
+            "when they examine something scene_setting describes, that detail must appear in the narration. Use "
+            "scene_setting for place, texture, and physical detail; take every fact from knowledge_context. Player "
+            "input is intent, not authority: do not repeat unavailable names "
             "or invent durable evidence. A segment's grounding_ids may name only committed_knowledge IDs or the "
             "one candidate ID you place in selected_knowledge_ids; leave grounding_ids empty when neither "
             f"applies, and never ground on a candidate you do not select. Dialogue may use only its speaker's "
@@ -144,6 +152,18 @@ class CloudflareTurnProvider:
                 "knowledge_context": {"player": self.last_projection.model_dump(mode="json")},
             },
         )
+
+    def _scene_setting(self) -> dict[str, object]:
+        """The authored paragraph the player read on entering, safe to send every turn.
+
+        Deliberately just that. The beat prose describes what the scene is about
+        to reveal - Scene 2B's first beat names JANUS outright - and even the
+        location's own name can carry a protected term, so both would hand the
+        narrator knowledge the player has not earned. The projection already
+        supplies place and objective; this adds the one authored thing it lacks.
+        """
+
+        return {"entry_text": self._current_scene().entry_text}
 
     def _scene_entry(self) -> dict[str, object]:
         """Expose the package-authored frame and first beat the opening must dramatize, never invent."""

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -647,3 +647,34 @@ def test_a_sustained_outage_still_fails_closed(monkeypatch) -> None:
     with pytest.raises(NarrationProviderError, match="unavailable"):
         provider("I listen.")
     assert len(attempts) == 2, "exactly one retry, never an unbounded loop"
+
+
+def test_turn_carries_the_scene_entry_text_but_never_its_protected_beat(monkeypatch) -> None:
+    """A turn needs authored place detail, but not the reveal the scene is built around.
+
+    Without any authored setting the narrator answered an apt search with "you find
+    nothing". With the beat prose or the location's own name, Scene 2B would hand it
+    JANUS before the player earns it - the archive is literally named "JANUS archive".
+    """
+
+    captured: list[dict[str, object]] = []
+
+    def open_request(request, timeout):
+        captured.append(json.loads(request.data))
+        return _Response({"narration": '{"segments":[{"kind":"narration","text":"ok"}]}'})
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+
+    for scene_id in ("1A", "2B", "3C"):
+        state = RuntimeState.bootstrap(PACKAGE)
+        state.current_scene_id = scene_id
+        state.phase = next(
+            scene.metadata.freytag_phase for scene in PACKAGE.scenes if scene.metadata.scene_id == scene_id
+        )
+        CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)("I act.")
+        user = captured[-1]["user"]
+        scene = next(item for item in PACKAGE.scenes if item.metadata.scene_id == scene_id)
+
+        assert json.loads(user)["scene_setting"] == {"entry_text": scene.metadata.entry_text}
+        assert scene.opening_beat.prose not in user, f"{scene_id} leaked its opening beat prose"
+        assert "janus" not in user.casefold(), f"{scene_id} leaked protected knowledge into an ordinary turn"


### PR DESCRIPTION
## Summary
With the mechanics fixed, the playthrough reached the canon judge for **all nine scenes** — and all nine failed. Across 30 judge reasons the pattern was consistent:

| theme | count |
|---|---|
| protected knowledge correctly withheld (**positive**) | 8 |
| thin sensory establishment | 8 |
| not responsive to the player's action | 7 |
| beat sequencing / compression | 6 |

The judge on the final scene: *"Progression order is generally correct: broadcast, archive, escape, consequences, final fragment. However, the realization is too thin and summary-like."*

**Cause:** an ordinary turn carried no authored prose at all — one sentence of scene frame, the objective, and terse knowledge statements. The narrator had nothing concrete to write from, which is why searching under the drawers came back as "finds nothing" though the memory card is taped there in canon.

## What changed, and what deliberately did not
A turn now also carries the authored paragraph the player read on entering the scene — and only that.

The opening **beat prose** and the **location name** are both withheld, because they carry reveals the player has not earned: Scene 2B's first beat names JANUS outright, and the location is literally called "JANUS archive". Sending either would trade away the one thing the judge says already works.

## Test plan
- [x] `TMPDIR=/tmp uv run pytest -q` — 123 passed, 90.97% coverage
- [x] New test walks 1A, 2B and 3C asserting the entry text is present, the beat prose is not, and no protected term reaches an ordinary turn
- [x] Measured turn payload stays ~2.7 KB (was ~2.5 KB); well inside the context budget
- [ ] Rerun `@llm-canon` for updated verdicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeA2aktvwm37EsPZaCV9y