### PR TITLE
Legible, recoverable scene transitions on a scene-relative clock

### DIFF
--- a/data/stories/continuity-initiative/handoffs.yaml
+++ b/data/stories/continuity-initiative/handoffs.yaml
@@ -1,0 +1,214 @@
+deliveries:
+- fact_id: continuity_initiative_known
+  scene_id: 1A
+  source_kind: message
+  source_entity_id: michelle
+  must_convey:
+  - [Michelle's memory card, Michelle's files, Michelle's notes]
+  - [Continuity Initiative, federal emergency program]
+  fallback_text: >-
+    Michelle's memory card identifies the federal emergency program as the Continuity Initiative. The files say the
+    Continuity Initiative was preparing to choose who remains.
+- fact_id: park_pursuit_resolved
+  scene_id: 1B
+  source_kind: observation
+  source_entity_id: kristin
+  must_convey:
+  - [escaped through the storm-drain system, storm-drain system, secured maintenance gate]
+  - [park pursuit ended, tactical team lost their trail, pursuit ended]
+  fallback_text: >-
+    Kristin and Brandon escaped through the storm-drain system, and Brandon unlocked the secured maintenance gate.
+    The park pursuit ended behind them when the tactical team lost their trail.
+- fact_id: transport_route_identified
+  scene_id: 1B
+  source_kind: observation
+  source_entity_id: kristin
+  must_convey:
+  - [transit card, handwritten sequence, Michelle's dead drop]
+  - [freight terminal, transport route, evacuation tunnels]
+  fallback_text: >-
+    The transit card and handwritten sequence from Michelle's dead drop identify the transport route. They point Kristin
+    toward the supposedly abandoned freight terminal and its evacuation tunnels.
+- fact_id: brandon_identified
+  scene_id: 1B
+  source_kind: npc
+  source_entity_id: brandon
+  must_convey:
+  - [Brandon Corfman, Brandon, Michelle's photograph]
+  - [identified himself, person in Michelle's photograph, source in the photograph]
+  costs:
+  - {op: retract, fact_id: trust_brandon, value: true}
+  fallback_text: >-
+    The man identified himself as Brandon Corfman, the person in Michelle's photograph. Kristin finally knew the source
+    in the photograph had found her in the park.
+- fact_id: missing_may_be_alive
+  scene_id: 1B
+  source_kind: message
+  source_entity_id: brandon
+  must_convey:
+  - [Brandon claims, Brandon says, Brandon's warning]
+  - [missing are still alive, missing people are alive, captives are alive]
+  fallback_text: >-
+    Brandon claims that the missing are still alive, though he refuses to explain how he knows. His warning gives Kristin
+    reason to believe the disappeared people are captives rather than casualties.
+- fact_id: facility_proof
+  scene_id: 1C
+  source_kind: observation
+  source_entity_id: kristin
+  must_convey:
+  - [fresh tire tracks, humming air vents, heavy electrical service]
+  - [active facility, underground complex, site remains active]
+  fallback_text: >-
+    Fresh tire tracks, humming air vents, and heavy electrical service prove that the supposedly abandoned terminal hides
+    an active facility. The signs point to an underground complex beneath the loading docks.
+- fact_id: captives_confirmed_alive
+  scene_id: 1C
+  source_kind: observation
+  source_entity_id: kristin
+  must_convey:
+  - [observation shaft, Kristin sees, processing area]
+  - [sedated prisoners, captives are alive, prisoners alive]
+  fallback_text: >-
+    From the observation shaft, Kristin sees sedated prisoners moving through the processing area. The captives are alive,
+    even if the view is too brief to confirm whether Michelle is among them.
+- fact_id: false_identities_ready
+  scene_id: 2A
+  source_kind: npc
+  source_entity_id: brandon
+  must_convey:
+  - [Brandon creates false credentials, false credentials, technical inspectors]
+  - [false identities, inspection cover, inspectors' cover]
+  fallback_text: >-
+    Brandon creates false credentials presenting them as technical inspectors. Their inspection cover gives Kristin and
+    Brandon the false identities they need to enter the facility.
+- fact_id: janus_evidence
+  scene_id: 2B
+  source_kind: observation
+  source_entity_id: kristin
+  must_convey:
+  - [JANUS files, JANUS records, selection algorithm]
+  - [ranked every American, classification system, selected people]
+  fallback_text: >-
+    Kristin opens the JANUS files in the records archive. The JANUS selection algorithm ranked every American for
+    detention, leverage, or control.
+- fact_id: brandon_janus_role_known
+  scene_id: 2B
+  source_kind: message
+  source_entity_id: brandon
+  must_convey:
+  - [Brandon admits, Brandon's confession, Brandon says]
+  - [helped write JANUS, wrote the JANUS software, helped develop the AI]
+  costs:
+  - {op: retract, fact_id: trust_brandon, value: true}
+  fallback_text: >-
+    Brandon admits that he helped write JANUS, the software that selected people for detention. His confession confirms
+    that he helped develop the AI before learning what it would become.
+- fact_id: brandon_claimed_reform_motive
+  scene_id: 2B
+  source_kind: message
+  source_entity_id: brandon
+  must_convey:
+  - [Brandon says, Brandon's explanation, Brandon claims]
+  - [tried to destroy the project, expose the program, stop JANUS]
+  fallback_text: >-
+    Brandon says he tried to destroy the project after he learned its purpose. His explanation is that he meant to expose
+    the program and stop JANUS from becoming a tool of political control.
+- fact_id: michelle_resistance_known
+  scene_id: 2B
+  source_kind: message
+  source_entity_id: michelle
+  must_convey:
+  - [Michelle's coded messages, Michelle's private notes, Michelle's resistance]
+  - [organized prisoners, altering classifications, preparing an uprising]
+  fallback_text: >-
+    Michelle's coded messages and private notes show that she has organized prisoners inside the facility. Her resistance
+    is altering classifications and preparing an uprising.
+- fact_id: purge_clock_started
+  scene_id: 2C
+  source_kind: broadcast
+  must_convey:
+  - [Charles's purge order, Charles orders, command orders]
+  - [purge begins within hours, purge deadline, captives face destruction]
+  fallback_text: >-
+    Charles's purge order moves the transfers and destruction onto a deadline. Command orders make clear that the purge
+    begins within hours, before the captives can be safely moved.
+- fact_id: evidence_ready_to_transmit
+  scene_id: 2C
+  source_kind: observation
+  source_entity_id: kristin
+  must_convey:
+  - [Kristin and Brandon obtain evidence, evidence in hand, Kristin's evidence]
+  - [ready to transmit, transmit the evidence, send proof]
+  fallback_text: >-
+    Kristin and Brandon obtain enough evidence to expose the conspiracy, leaving the evidence in hand. It is ready to
+    transmit, but sending proof will reveal their position.
+- fact_id: michelle_reached
+  scene_id: 3A
+  source_kind: observation
+  source_entity_id: kristin
+  must_convey:
+  - [Kristin reaches Michelle, reunion with Michelle, Michelle is reached]
+  - [detention sector, holding blocks, Michelle's cell]
+  fallback_text: >-
+    Kristin reaches Michelle among the holding blocks in the detention sector. Their reunion is brief, but Michelle is
+    alive and ready to direct the rescue.
+- fact_id: detention_uprising_started
+  scene_id: 3A
+  source_kind: message
+  source_entity_id: michelle
+  must_convey:
+  - [Michelle triggers, Michelle organizes prisoners, coded announcements]
+  - [uprising begins, prisoners rise, detention uprising]
+  fallback_text: >-
+    Michelle triggers coordinated disturbances through coded announcements while she organizes prisoners across the
+    detention sectors. The uprising begins as prisoners rise, disable cameras, and seize internal checkpoints.
+- fact_id: relay_open
+  scene_id: 3B
+  source_kind: observation
+  source_entity_id: brandon
+  must_convey:
+  - [Brandon holds the relay open, Brandon's relay, external communications relay]
+  - [relay is open, relay open, broadcast connection]
+  fallback_text: >-
+    Brandon reaches the external communications relay and disconnects it from JANUS. Brandon holds the relay open so the
+    broadcast connection can carry Michelle's evidence.
+- fact_id: human_security_control
+  scene_id: 3B
+  source_kind: observation
+  source_entity_id: kristin
+  must_convey:
+  - [Kristin overloads JANUS, conflicting emergencies, human operators]
+  - [human operators take control, human security control, people control security]
+  fallback_text: >-
+    Kristin overloads JANUS with conflicting emergencies until human operators take control. Human security control
+    replaces the system's predictions in the corridors.
+- fact_id: charles_abandoned_rebecca
+  scene_id: 3B
+  source_kind: message
+  source_entity_id: rebecca
+  must_convey:
+  - [Charles locks down Rebecca's office, Charles abandons Rebecca, Rebecca understands]
+  - [was expendable, Rebecca is expendable, Charles left Rebecca, Rebecca was abandoned]
+  fallback_text: >-
+    Charles locks down Rebecca's office and abandons Rebecca while he transfers control of the national network. Rebecca
+    finally understands that she was expendable to him.
+- fact_id: detention_locations_secured
+  scene_id: 3B
+  source_kind: message
+  source_entity_id: rebecca
+  must_convey:
+  - [Rebecca offers, Rebecca's location data, Rebecca offers the locations]
+  - [detention locations, every detention site, locations of every detention site]
+  fallback_text: >-
+    Rebecca offers the locations of every detention site in exchange for a chance to save herself. Her location data
+    gives Kristin and Michelle the detention locations they need for the broadcast.
+- fact_id: brandon_confession_available
+  scene_id: 3B
+  source_kind: message
+  source_entity_id: brandon
+  must_convey:
+  - [Brandon's confession, Brandon admits, Brandon transmits]
+  - [helped create JANUS, role in creating JANUS, authenticate Michelle's evidence]
+  fallback_text: >-
+    Brandon transmits a confession before the electrical surge takes the relay. He admits his role in creating JANUS,
+    and the statement helps authenticate Michelle's evidence.

--- a/data/stories/continuity-initiative/handoffs.yaml
+++ b/data/stories/continuity-initiative/handoffs.yaml
@@ -4,8 +4,8 @@ deliveries:
   source_kind: message
   source_entity_id: michelle
   must_convey:
-  - [Michelle's memory card, Michelle's files, Michelle's notes]
-  - [Continuity Initiative, federal emergency program]
+  - [Michelle's memory card, Michelle's files, Michelle's notes, Michelle's card, memory card, research files]
+  - [Continuity Initiative, federal emergency program, Continuity program, federal Continuity program, Continuity project, population-selection program]
   fallback_text: >-
     Michelle's memory card identifies the federal emergency program as the Continuity Initiative. The files say the
     Continuity Initiative was preparing to choose who remains.
@@ -14,8 +14,8 @@ deliveries:
   source_kind: observation
   source_entity_id: kristin
   must_convey:
-  - [escaped through the storm-drain system, storm-drain system, secured maintenance gate]
-  - [park pursuit ended, tactical team lost their trail, pursuit ended]
+  - [escaped through the storm-drain system, storm-drain system, secured maintenance gate, escaped through the storm drains, storm drains, maintenance gate]
+  - [park pursuit ended, tactical team lost their trail, pursuit ended, the pursuit was over, they lost the tactical team, the ambush was behind them]
   fallback_text: >-
     Kristin and Brandon escaped through the storm-drain system, and Brandon unlocked the secured maintenance gate.
     The park pursuit ended behind them when the tactical team lost their trail.
@@ -24,8 +24,8 @@ deliveries:
   source_kind: observation
   source_entity_id: kristin
   must_convey:
-  - [transit card, handwritten sequence, Michelle's dead drop]
-  - [freight terminal, transport route, evacuation tunnels]
+  - [transit card, handwritten sequence, Michelle's dead drop, the card, number sequence, Michelle's drop]
+  - [freight terminal, transport route, evacuation tunnels, freight yard, old freight yard, yard route]
   fallback_text: >-
     The transit card and handwritten sequence from Michelle's dead drop identify the transport route. They point Kristin
     toward the supposedly abandoned freight terminal and its evacuation tunnels.
@@ -34,8 +34,8 @@ deliveries:
   source_kind: npc
   source_entity_id: brandon
   must_convey:
-  - [Brandon Corfman, Brandon, Michelle's photograph]
-  - [identified himself, person in Michelle's photograph, source in the photograph]
+  - [Brandon Corfman, Brandon, Michelle's photograph, Michelle's photo, photo of Michelle, picture of Michelle]
+  - [identified himself, person in Michelle's photograph, source in the photograph, Brandon introduced himself, the man in Michelle's photo, identified the man in the photo, admitted he was the one in Michelle's photo]
   costs:
   - {op: retract, fact_id: trust_brandon, value: true}
   fallback_text: >-
@@ -46,8 +46,8 @@ deliveries:
   source_kind: message
   source_entity_id: brandon
   must_convey:
-  - [Brandon claims, Brandon says, Brandon's warning]
-  - [missing are still alive, missing people are alive, captives are alive]
+  - [Brandon claims, Brandon says, Brandon's warning, Brandon's claim, Brandon maintains, Brandon's account]
+  - [missing are still alive, missing people are alive, captives are alive, the disappeared are alive, people were taken alive, living survivors]
   fallback_text: >-
     Brandon claims that the missing are still alive, though he refuses to explain how he knows. His warning gives Kristin
     reason to believe the disappeared people are captives rather than casualties.
@@ -56,8 +56,8 @@ deliveries:
   source_kind: observation
   source_entity_id: kristin
   must_convey:
-  - [fresh tire tracks, humming air vents, heavy electrical service]
-  - [active facility, underground complex, site remains active]
+  - [fresh tire tracks, humming air vents, heavy electrical service, recent tire tracks, working air vents, electrical load]
+  - [active facility, underground complex, site remains active, the terminal is operating, working facility, operation beneath the terminal]
   fallback_text: >-
     Fresh tire tracks, humming air vents, and heavy electrical service prove that the supposedly abandoned terminal hides
     an active facility. The signs point to an underground complex beneath the loading docks.
@@ -66,8 +66,8 @@ deliveries:
   source_kind: observation
   source_entity_id: kristin
   must_convey:
-  - [observation shaft, Kristin sees, processing area]
-  - [sedated prisoners, captives are alive, prisoners alive]
+  - [observation shaft, Kristin sees, processing area, the observation shaft, saw the processing line, prisoner processing area]
+  - [sedated prisoners, captives are alive, prisoners alive, living prisoners, prisoners are alive, living captives]
   fallback_text: >-
     From the observation shaft, Kristin sees sedated prisoners moving through the processing area. The captives are alive,
     even if the view is too brief to confirm whether Michelle is among them.
@@ -76,8 +76,8 @@ deliveries:
   source_kind: npc
   source_entity_id: brandon
   must_convey:
-  - [Brandon creates false credentials, false credentials, technical inspectors]
-  - [false identities, inspection cover, inspectors' cover]
+  - [Brandon creates false credentials, false credentials, technical inspectors, Brandon builds their credentials, inspector credentials, fake credentials]
+  - [false identities, inspection cover, inspectors' cover, technical-inspection cover, fake identities, inspector cover]
   fallback_text: >-
     Brandon creates false credentials presenting them as technical inspectors. Their inspection cover gives Kristin and
     Brandon the false identities they need to enter the facility.
@@ -86,8 +86,8 @@ deliveries:
   source_kind: observation
   source_entity_id: kristin
   must_convey:
-  - [JANUS files, JANUS records, selection algorithm]
-  - [ranked every American, classification system, selected people]
+  - [JANUS files, JANUS records, selection algorithm, JANUS archive, JANUS selection records, the selection files]
+  - [ranked every American, classification system, selected people, everyone was ranked, Americans were classified, the ranking system]
   fallback_text: >-
     Kristin opens the JANUS files in the records archive. The JANUS selection algorithm ranked every American for
     detention, leverage, or control.
@@ -96,8 +96,8 @@ deliveries:
   source_kind: message
   source_entity_id: brandon
   must_convey:
-  - [Brandon admits, Brandon's confession, Brandon says]
-  - [helped write JANUS, wrote the JANUS software, helped develop the AI]
+  - [Brandon admits, Brandon's confession, Brandon says, Brandon confessed, Brandon acknowledges it, Brandon's admission]
+  - [helped write JANUS, wrote the JANUS software, helped develop the AI, helped build JANUS, created the JANUS system, wrote part of JANUS]
   costs:
   - {op: retract, fact_id: trust_brandon, value: true}
   fallback_text: >-
@@ -108,8 +108,8 @@ deliveries:
   source_kind: message
   source_entity_id: brandon
   must_convey:
-  - [Brandon says, Brandon's explanation, Brandon claims]
-  - [tried to destroy the project, expose the program, stop JANUS]
+  - [Brandon says, Brandon's explanation, Brandon claims, Brandon's claim, Brandon explains, Brandon's account]
+  - [tried to destroy the project, expose the program, stop JANUS, wanted to bring down JANUS, tried to expose JANUS, break up the project]
   fallback_text: >-
     Brandon says he tried to destroy the project after he learned its purpose. His explanation is that he meant to expose
     the program and stop JANUS from becoming a tool of political control.
@@ -118,8 +118,8 @@ deliveries:
   source_kind: message
   source_entity_id: michelle
   must_convey:
-  - [Michelle's coded messages, Michelle's private notes, Michelle's resistance]
-  - [organized prisoners, altering classifications, preparing an uprising]
+  - [Michelle's coded messages, Michelle's private notes, Michelle's resistance, Michelle's coded notes, her private messages, the resistance notes]
+  - [organized prisoners, altering classifications, preparing an uprising, prisoners organized, reclassified prisoners, planned an uprising]
   fallback_text: >-
     Michelle's coded messages and private notes show that she has organized prisoners inside the facility. Her resistance
     is altering classifications and preparing an uprising.
@@ -127,8 +127,8 @@ deliveries:
   scene_id: 2C
   source_kind: broadcast
   must_convey:
-  - [Charles's purge order, Charles orders, command orders]
-  - [purge begins within hours, purge deadline, captives face destruction]
+  - [Charles's purge order, Charles orders, command orders, Charles's order, the purge command, Charles's command]
+  - [purge begins within hours, purge deadline, captives face destruction, destruction is due within hours, hours remain before destruction, the purge is imminent]
   fallback_text: >-
     Charles's purge order moves the transfers and destruction onto a deadline. Command orders make clear that the purge
     begins within hours, before the captives can be safely moved.
@@ -137,8 +137,8 @@ deliveries:
   source_kind: observation
   source_entity_id: kristin
   must_convey:
-  - [Kristin and Brandon obtain evidence, evidence in hand, Kristin's evidence]
-  - [ready to transmit, transmit the evidence, send proof]
+  - [Kristin and Brandon obtain evidence, evidence in hand, Kristin's evidence, they have the evidence, proof in hand, the gathered evidence]
+  - [ready to transmit, transmit the evidence, send proof, ready for broadcast, send the evidence, broadcast the proof]
   fallback_text: >-
     Kristin and Brandon obtain enough evidence to expose the conspiracy, leaving the evidence in hand. It is ready to
     transmit, but sending proof will reveal their position.
@@ -147,8 +147,8 @@ deliveries:
   source_kind: observation
   source_entity_id: kristin
   must_convey:
-  - [Kristin reaches Michelle, reunion with Michelle, Michelle is reached]
-  - [detention sector, holding blocks, Michelle's cell]
+  - [Kristin reaches Michelle, reunion with Michelle, Michelle is reached, Kristin finds Michelle, they are reunited, Kristin reaches her]
+  - [detention sector, holding blocks, Michelle's cell, prisoner block, detention holding block, the cell block]
   fallback_text: >-
     Kristin reaches Michelle among the holding blocks in the detention sector. Their reunion is brief, but Michelle is
     alive and ready to direct the rescue.
@@ -157,8 +157,8 @@ deliveries:
   source_kind: message
   source_entity_id: michelle
   must_convey:
-  - [Michelle triggers, Michelle organizes prisoners, coded announcements]
-  - [uprising begins, prisoners rise, detention uprising]
+  - [Michelle triggers, Michelle organizes prisoners, coded announcements, Michelle sets it off, Michelle starts the disturbances, her coded announcements]
+  - [uprising begins, prisoners rise, detention uprising, the prisoners revolt, the uprising is underway, prisoners seize checkpoints]
   fallback_text: >-
     Michelle triggers coordinated disturbances through coded announcements while she organizes prisoners across the
     detention sectors. The uprising begins as prisoners rise, disable cameras, and seize internal checkpoints.
@@ -167,8 +167,8 @@ deliveries:
   source_kind: observation
   source_entity_id: brandon
   must_convey:
-  - [Brandon holds the relay open, Brandon's relay, external communications relay]
-  - [relay is open, relay open, broadcast connection]
+  - [Brandon holds the relay open, Brandon's relay, external communications relay, Brandon kept the relay open, Brandon held the relay open, Brandon leaves the relay open]
+  - [relay is open, relay open, broadcast connection, open communications relay, the connection stays open, relay remains open]
   fallback_text: >-
     Brandon reaches the external communications relay and disconnects it from JANUS. Brandon holds the relay open so the
     broadcast connection can carry Michelle's evidence.
@@ -177,8 +177,8 @@ deliveries:
   source_kind: observation
   source_entity_id: kristin
   must_convey:
-  - [Kristin overloads JANUS, conflicting emergencies, human operators]
-  - [human operators take control, human security control, people control security]
+  - [Kristin overloads JANUS, conflicting emergencies, human operators, JANUS is overloaded, too many emergencies, security emergencies conflict]
+  - [human operators take control, human security control, people control security, humans take over security, operators control the corridors, manual security takes over]
   fallback_text: >-
     Kristin overloads JANUS with conflicting emergencies until human operators take control. Human security control
     replaces the system's predictions in the corridors.
@@ -187,8 +187,8 @@ deliveries:
   source_kind: message
   source_entity_id: rebecca
   must_convey:
-  - [Charles locks down Rebecca's office, Charles abandons Rebecca, Rebecca understands]
-  - [was expendable, Rebecca is expendable, Charles left Rebecca, Rebecca was abandoned]
+  - [Charles locks down Rebecca's office, Charles abandons Rebecca, Rebecca understands, Charles cuts Rebecca off, Rebecca learns he abandoned her, Charles seals her office]
+  - [was expendable, Rebecca is expendable, Charles left Rebecca, Rebecca was abandoned, Charles discarded Rebecca, he left her to die]
   fallback_text: >-
     Charles locks down Rebecca's office and abandons Rebecca while he transfers control of the national network. Rebecca
     finally understands that she was expendable to him.
@@ -197,8 +197,8 @@ deliveries:
   source_kind: message
   source_entity_id: rebecca
   must_convey:
-  - [Rebecca offers, Rebecca's location data, Rebecca offers the locations]
-  - [detention locations, every detention site, locations of every detention site]
+  - [Rebecca offers, Rebecca's location data, Rebecca offers the locations, Rebecca gives, Rebecca's site list, the locations Rebecca offers]
+  - [detention locations, every detention site, locations of every detention site, detention-site locations, the prison sites, all detention facilities]
   fallback_text: >-
     Rebecca offers the locations of every detention site in exchange for a chance to save herself. Her location data
     gives Kristin and Michelle the detention locations they need for the broadcast.
@@ -207,8 +207,8 @@ deliveries:
   source_kind: message
   source_entity_id: brandon
   must_convey:
-  - [Brandon's confession, Brandon admits, Brandon transmits]
-  - [helped create JANUS, role in creating JANUS, authenticate Michelle's evidence]
+  - [Brandon's confession, Brandon admits, Brandon transmits, Brandon's admission, Brandon confesses, Brandon sends his confession]
+  - [helped create JANUS, role in creating JANUS, authenticate Michelle's evidence, helped build the AI, JANUS development role, his part in JANUS]
   fallback_text: >-
     Brandon transmits a confession before the electrical surge takes the relay. He admits his role in creating JANUS,
     and the statement helps authenticate Michelle's evidence.

--- a/data/stories/continuity-initiative/knowledge.yaml
+++ b/data/stories/continuity-initiative/knowledge.yaml
@@ -312,11 +312,11 @@ knowledge:
     entity_ids: []
     priority: 0
   must_convey:
-  - [memory card, hidden card, card]
-  - [damaged recording, voice recording, recording]
-  - [Michelle, Michelle's, Dr. McGehee]
-  - [dead drop, exchange point, place to trade information]
-  - [bench in the park, park bench, bench, park]
+  - [memory card, hidden card, card, Michelle's card, hidden memory card, the card]
+  - [damaged recording, voice recording, recording, damaged voice recording, recording from Michelle, broken recording]
+  - [Michelle, Michelle's, Dr. McGehee, Michelle McGehee, Dr. Michelle, Shelly]
+  - [dead drop, exchange point, place to trade information, the dead-drop, park exchange, drop at the bench]
+  - [bench in the park, park bench, bench, park, the park bench, bench near the park]
 - id: k_sl_1a_b_r2
   statement: "Kristin recovers Michelle's damaged recording: do not trust emergency broadcasts."
   entity_ids: []
@@ -373,10 +373,10 @@ knowledge:
     entity_ids: [memory_card]
     priority: 10
   must_convey:
-  - [memory card, hidden card, card]
-  - [research, research files, files]
-  - [Michelle, Michelle's, Dr. McGehee]
-  - [place she used to trade information, exchange point, place to trade]
+  - [memory card, hidden card, card, the memory card, Michelle's card, card beneath the drawer]
+  - [research, research files, files, research material, Michelle's files, work files]
+  - [Michelle, Michelle's, Dr. McGehee, Michelle McGehee, Dr. Michelle, Shelly]
+  - [place she used to trade information, exchange point, place to trade, the exchange point, her information drop, where she traded information]
 - id: k_sl_1a_d_r2
   statement: 'Only fragments of Michelle''s files survive, but they still name the exchange point she was using.'
   entity_ids: [kristin, michelle, memory_card]
@@ -404,9 +404,9 @@ knowledge:
     entity_ids: [memory_card]
     priority: 0
   must_convey:
-  - [fragments, files, research files]
-  - [exchange point, place she was using, place to trade information]
-  - [Michelle, Michelle's, Dr. McGehee]
+  - [fragments, files, research files, research fragments, file fragments, partial files]
+  - [exchange point, place she was using, place to trade information, the exchange point, her information drop, where she traded information]
+  - [Michelle, Michelle's, Dr. McGehee, Michelle McGehee, Dr. Michelle, Shelly]
 - id: k_sl_1a_c_r1
   statement: 'The patrol’s interest in Michelle’s research makes Kristin doubt that its welfare check is innocent.'
   entity_ids: []
@@ -464,9 +464,9 @@ knowledge:
     entity_ids: []
     priority: 0
   must_convey:
-  - [reflective tape, gate marker, marker]
-  - [gate, house, home]
-  - [patrol, officers, federal emergency patrol]
+  - [reflective tape, gate marker, marker, reflective gate tape, tape marker, strip of reflective tape]
+  - [gate, house, home, front gate, the house gate, marked home]
+  - [patrol, officers, federal emergency patrol, welfare patrol, emergency officers, federal patrol]
 - id: k_sl_1b_a_r1
   statement: 'Kristin matches the transit card and number sequence to a freight route leading out of the city.'
   entity_ids: []
@@ -910,10 +910,10 @@ knowledge:
     entity_ids: []
     priority: 0
   must_convey:
-  - [support-column failure, cooling-system risk, structural failure]
-  - [collapse the facility, facility collapse, facility]
-  - [corridor access, restricted corridor, access]
-  - [supervisor, security supervisor, facility supervisor]
+  - [support-column failure, cooling-system risk, structural failure, support column problem, cooling failure, structural risk]
+  - [collapse the facility, facility collapse, facility, bring down the facility, underground collapse, collapse below]
+  - [corridor access, restricted corridor, access, restricted access, infrastructure access, corridor entrance]
+  - [supervisor, security supervisor, facility supervisor, the supervisor, security officer, inspection supervisor]
 - id: k_sl_2a_c_r2
   statement: Kristin and Brandon have opened a restricted infrastructure corridor.
   entity_ids: [kristin, brandon, regional_facility]
@@ -940,9 +940,9 @@ knowledge:
     entity_ids: [regional_facility]
     priority: 10
   must_convey:
-  - [opened, open, access]
-  - [restricted infrastructure corridor, restricted corridor, infrastructure corridor]
-  - [Kristin and Brandon, Kristin, Brandon]
+  - [opened, open, access, gained access, opened access, corridor opened]
+  - [restricted infrastructure corridor, restricted corridor, infrastructure corridor, service corridor, access corridor, restricted passage]
+  - [Kristin and Brandon, Kristin, Brandon, the pair, both inspectors, the inspectors]
 - id: k_sl_2a_c_r2_rebecca_observes
   statement: Rebecca has ordered the infiltrators watched.
   entity_ids: [rebecca, kristin, brandon, regional_facility]
@@ -1260,10 +1260,10 @@ knowledge:
     entity_ids: []
     priority: 0
   must_convey:
-  - [evidence, proof, evidence transmission]
-  - [open the detention cells, open the cells, rescue the prisoners]
-  - [Rebecca's secured office, Rebecca's office, secured office]
-  - [Michelle's message, coded message, message]
+  - [evidence, proof, evidence transmission, transmit proof, evidence for broadcast, the proof]
+  - [open the detention cells, open the cells, rescue the prisoners, free the cells, release the prisoners, open detention blocks]
+  - [Rebecca's secured office, Rebecca's office, secured office, Rebecca's locked office, office under Rebecca's control, secured room]
+  - [Michelle's message, coded message, message, Michelle's coded note, her message, message from Michelle]
 - id: k_sl_2c_c_r2
   statement: 'Michelle’s coded message reveals that Rebecca’s office can open the cells and broadcast the evidence at once.'
   entity_ids: []
@@ -1293,10 +1293,10 @@ knowledge:
     entity_ids: []
     priority: 0
   must_convey:
-  - [coded message, Michelle's message, message]
-  - [Rebecca's office, secured office, office]
-  - [open the cells, open detention cells, cells]
-  - [broadcast the evidence, transmit the evidence, broadcast]
+  - [coded message, Michelle's message, message, coded note, message from Michelle, Michelle's note]
+  - [Rebecca's office, secured office, office, Rebecca's locked office, office under Rebecca's control, Rebecca's room]
+  - [open the cells, open detention cells, cells, free the cells, release the captives, open detention blocks]
+  - [broadcast the evidence, transmit the evidence, broadcast, send the evidence, evidence broadcast, broadcast proof]
 - id: k_sl_3a_a_r1
   statement: 'Kristin reaches Michelle alive, only to find her directing prisoners through stolen radios and coded announcements.'
   entity_ids: []

--- a/data/stories/continuity-initiative/knowledge.yaml
+++ b/data/stories/continuity-initiative/knowledge.yaml
@@ -279,7 +279,7 @@ knowledge:
     entity_ids: []
     priority: 0
 - id: k_sl_1a_b_r1
-  statement: 'Kristin finds Michelle’s hidden card and damaged recording, learning that Michelle feared the emergency broadcasts.'
+  statement: "Kristin finds Michelle's hidden memory card and damaged recording; the card points to a dead drop at a bench in the park."
   entity_ids: []
   aliases:
   - continuity initiative known
@@ -311,6 +311,12 @@ knowledge:
   relevance:
     entity_ids: []
     priority: 0
+  must_convey:
+  - [memory card, hidden card, card]
+  - [damaged recording, voice recording, recording]
+  - [Michelle, Michelle's, Dr. McGehee]
+  - [dead drop, exchange point, place to trade information]
+  - [bench in the park, park bench, bench, park]
 - id: k_sl_1a_b_r2
   statement: "Kristin recovers Michelle's damaged recording: do not trust emergency broadcasts."
   entity_ids: []
@@ -366,6 +372,11 @@ knowledge:
   relevance:
     entity_ids: [memory_card]
     priority: 10
+  must_convey:
+  - [memory card, hidden card, card]
+  - [research, research files, files]
+  - [Michelle, Michelle's, Dr. McGehee]
+  - [place she used to trade information, exchange point, place to trade]
 - id: k_sl_1a_d_r2
   statement: 'Only fragments of Michelle''s files survive, but they still name the exchange point she was using.'
   entity_ids: [kristin, michelle, memory_card]
@@ -392,6 +403,10 @@ knowledge:
   relevance:
     entity_ids: [memory_card]
     priority: 0
+  must_convey:
+  - [fragments, files, research files]
+  - [exchange point, place she was using, place to trade information]
+  - [Michelle, Michelle's, Dr. McGehee]
 - id: k_sl_1a_c_r1
   statement: 'The patrol’s interest in Michelle’s research makes Kristin doubt that its welfare check is innocent.'
   entity_ids: []
@@ -448,6 +463,10 @@ knowledge:
   relevance:
     entity_ids: []
     priority: 0
+  must_convey:
+  - [reflective tape, gate marker, marker]
+  - [gate, house, home]
+  - [patrol, officers, federal emergency patrol]
 - id: k_sl_1b_a_r1
   statement: 'Kristin matches the transit card and number sequence to a freight route leading out of the city.'
   entity_ids: []
@@ -890,6 +909,11 @@ knowledge:
   relevance:
     entity_ids: []
     priority: 0
+  must_convey:
+  - [support-column failure, cooling-system risk, structural failure]
+  - [collapse the facility, facility collapse, facility]
+  - [corridor access, restricted corridor, access]
+  - [supervisor, security supervisor, facility supervisor]
 - id: k_sl_2a_c_r2
   statement: Kristin and Brandon have opened a restricted infrastructure corridor.
   entity_ids: [kristin, brandon, regional_facility]
@@ -915,6 +939,10 @@ knowledge:
   relevance:
     entity_ids: [regional_facility]
     priority: 10
+  must_convey:
+  - [opened, open, access]
+  - [restricted infrastructure corridor, restricted corridor, infrastructure corridor]
+  - [Kristin and Brandon, Kristin, Brandon]
 - id: k_sl_2a_c_r2_rebecca_observes
   statement: Rebecca has ordered the infiltrators watched.
   entity_ids: [rebecca, kristin, brandon, regional_facility]
@@ -1198,7 +1226,7 @@ knowledge:
     entity_ids: []
     priority: 0
 - id: k_sl_2c_c_r1
-  statement: 'Kristin refuses to choose evidence over the prisoners when Michelle’s message offers a way to do both.'
+  statement: "Michelle's message offers a way to transmit the evidence and open the detention cells through Rebecca's secured office."
   entity_ids: []
   aliases:
   - combined broadcast rescue plan known
@@ -1231,6 +1259,11 @@ knowledge:
   relevance:
     entity_ids: []
     priority: 0
+  must_convey:
+  - [evidence, proof, evidence transmission]
+  - [open the detention cells, open the cells, rescue the prisoners]
+  - [Rebecca's secured office, Rebecca's office, secured office]
+  - [Michelle's message, coded message, message]
 - id: k_sl_2c_c_r2
   statement: 'Michelle’s coded message reveals that Rebecca’s office can open the cells and broadcast the evidence at once.'
   entity_ids: []
@@ -1259,6 +1292,11 @@ knowledge:
   relevance:
     entity_ids: []
     priority: 0
+  must_convey:
+  - [coded message, Michelle's message, message]
+  - [Rebecca's office, secured office, office]
+  - [open the cells, open detention cells, cells]
+  - [broadcast the evidence, transmit the evidence, broadcast]
 - id: k_sl_3a_a_r1
   statement: 'Kristin reaches Michelle alive, only to find her directing prisoners through stolen radios and coded announcements.'
   entity_ids: []

--- a/data/stories/continuity-initiative/pacing.yaml
+++ b/data/stories/continuity-initiative/pacing.yaml
@@ -1,65 +1,66 @@
+budget_seconds: 1800
 events:
 - id: pressure_1a
   scene_id: 1A
-  at_seconds: 120
+  at_turn: 2
   effects:
   - fact_id: patrol_return_pressure
     equals: true
 - id: purge_2c
   scene_id: 2C
-  at_seconds: 690
+  at_turn: 2
   effects:
   - fact_id: purge_clock_started
     equals: true
 - id: override_deadline_3a
   scene_id: 3A
-  at_seconds: 870
+  at_turn: 3
   effects:
   - fact_id: override_codes_deadline_known
     equals: true
 - id: destruction_3b
   scene_id: 3B
-  at_seconds: 1020
+  at_turn: 4
   effects:
   - fact_id: facility_destruction_threat
     equals: true
 scenes:
 - scene_id: 1A
-  earliest_seconds: 0
-  target_seconds: 180
-  latest_seconds: 300
+  min_turns: 2
+  nudge_after_turns: 2
+  handoff_after_turns: 3
 - scene_id: 1B
-  earliest_seconds: 120
-  target_seconds: 195
-  latest_seconds: 270
+  min_turns: 2
+  nudge_after_turns: 3
+  handoff_after_turns: 4
 - scene_id: 1C
-  earliest_seconds: 270
-  target_seconds: 330
-  latest_seconds: 390
+  min_turns: 1
+  nudge_after_turns: 2
+  handoff_after_turns: 3
 - scene_id: 2A
-  earliest_seconds: 390
-  target_seconds: 450
-  latest_seconds: 510
+  min_turns: 1
+  nudge_after_turns: 2
+  handoff_after_turns: 3
 - scene_id: 2B
-  earliest_seconds: 510
-  target_seconds: 570
-  latest_seconds: 630
+  min_turns: 2
+  nudge_after_turns: 3
+  handoff_after_turns: 4
 - scene_id: 2C
-  earliest_seconds: 630
-  target_seconds: 705
-  latest_seconds: 780
+  min_turns: 1
+  nudge_after_turns: 2
+  handoff_after_turns: 3
 - scene_id: 3A
-  earliest_seconds: 780
-  target_seconds: 840
-  latest_seconds: 900
+  min_turns: 1
+  nudge_after_turns: 2
+  handoff_after_turns: 3
 - scene_id: 3B
-  earliest_seconds: 900
-  target_seconds: 975
-  latest_seconds: 1050
+  min_turns: 2
+  nudge_after_turns: 4
+  handoff_after_turns: 5
 - scene_id: 3C
-  earliest_seconds: 1050
-  target_seconds: 1140
-  latest_seconds: 1200
+  min_turns: 1
+  nudge_after_turns: 2
+  handoff_after_turns: 2
 transitions:
 - id: t_1a_1b
   source_scene_id: 1A

--- a/data/stories/continuity-initiative/plot.md
+++ b/data/stories/continuity-initiative/plot.md
@@ -68,6 +68,10 @@ participant_ids: [kristin, michelle]
 item_ids: [memory_card, michelle_phone]
 entry_text: "Michelle's text came in a little after 4:00am. It came in during all the other emergency alerts, and Kristin had missed it by minutes. Trying to call Michelle back was hopeless - calls stopped going through. Kristin jumped in her truck with the idea of getting to her best friend's house quickly, but that proved impossible. Police cars, ambulances, and fire trucks were deployed everywhere, causing traffic jams that made her drive take forever.\n\n"
 transition_ids: [t_1a_1b]
+bridge_text:
+  t_1a_1b: >-
+    Michelle's files reference an ordinary park bench where she exchanged information with a confidential source.
+    Kristin travels there while avoiding checkpoints and emergency patrols.
 ---
 
 **Setting:** Michelle’s home 
@@ -130,6 +134,11 @@ participant_ids: [kristin, brandon, michelle]
 item_ids: [memory_card, transit_card]
 entry_text: "The park was quieter than the streets around it. Michelle's files pointed to an ordinary bench near the service path - the dead drop where she traded information with a source she never named. Kristin crossed the damaged grounds, keeping clear of the checkpoints, and knelt beside the bench.\n\n"
 transition_ids: [t_1b_1c]
+bridge_text:
+  t_1b_1c: >-
+    The transit card from Michelle's dead drop granted access to a supposedly abandoned freight terminal. Fresh tire
+    tracks, air vents, and unusually heavy electrical service said the site remained active, so Kristin and Brandon
+    followed the transport route beneath the loading docks.
 ---
 
 **Setting:** Kristin’s neighborhood and a damaged public park in Los Angeles
@@ -192,6 +201,11 @@ participant_ids: [kristin, brandon, michelle]
 item_ids: [transit_card]
 entry_text: "The transit card led to a freight terminal that was supposed to be abandoned. Fresh tire tracks, humming air vents, and unusually heavy electrical service said otherwise. Kristin and Brandon slipped into the service level beneath the loading docks, where an observation shaft overlooked something much larger below.\n\n"
 transition_ids: [t_1c_2a]
+bridge_text:
+  t_1c_2a: >-
+    The observation shaft showed them living captives in an active regional command center, but the main facility could
+    not be reached from the service level without triggering security. Kristin and Brandon withdrew to prepare a way
+    inside.
 ---
 
 **Setting:** Industrial outskirts of Los Angeles and an underground Continuity Initiative installation
@@ -270,6 +284,11 @@ participant_ids: [kristin, brandon]
 item_ids: [transit_card]
 entry_text: "Brandon's hideout was buried inside a dead communications center: servers, salvaged hardware, and years of leaked Continuity Initiative documents. Somewhere beneath the city the facility waited, and its overstressed cooling and support columns were exactly the kind of flaw a pair of outside inspectors might be sent to examine.\n\n"
 transition_ids: [t_2a_2b]
+bridge_text:
+  t_2a_2b: >-
+    Their false credentials survived the initial checks, and Kristin's warning about a progressive underground collapse
+    won them access to restricted infrastructure corridors. Beyond those corridors, the records archive waited behind
+    another layer of security.
 ---
 
 **Setting:** Brandon’s hidden operations base and the secret facility
@@ -330,6 +349,11 @@ participant_ids: [kristin, brandon, michelle]
 item_ids: [memory_card]
 entry_text: "The records archive hummed behind the restricted corridor. Rows of terminals held the Initiative's selection files - and, somewhere in them, the answers to why Michelle was taken and who helped build the system that chose her.\n\n"
 transition_ids: [t_2b_2c]
+bridge_text:
+  t_2b_2c: >-
+    JANUS had chosen Michelle, left Kristin behind as bait, and carried Brandon's name in its original development
+    records. With Michelle's coded resistance already corrupting prisoner files, Kristin and Brandon understood that the
+    archive held both the proof and the betrayal.
 ---
 
 **Setting:** The facility’s records archive, medical levels, and Brandon’s hideout through a remote connection
@@ -403,6 +427,11 @@ participant_ids: [kristin, brandon]
 item_ids: [memory_card]
 entry_text: "The command levels tightened around them. Somewhere above, orders were already moving - transfers, schedules, contingency plans measured in hours instead of days. Whatever Kristin and Brandon did next had to count.\n\n"
 transition_ids: [t_2c_3a]
+bridge_text:
+  t_2c_3a: >-
+    Michelle's coded message offered a way to transmit the evidence while opening the detention sectors, but the
+    broadcast could only be activated from Rebecca's secured office. The combined mission was the only chance left
+    before Charles's purge began.
 ---
 
 **Setting:** The facility’s command levels and detention sectors
@@ -480,6 +509,10 @@ participant_ids: [kristin, michelle, brandon]
 item_ids: [override_codes]
 entry_text: "The detention sector doors opened onto rows of holding blocks. Coded announcements crackled through stolen radios, and the prisoners moved with a discipline no captor had taught them - someone inside had been organizing this long before rescue arrived.\n\n"
 transition_ids: [t_3a_3b]
+bridge_text:
+  t_3a_3b: >-
+    Michelle's uprising disabled cameras and seized checkpoints, while Charles sealed the primary exits and sent armed
+    teams downward. Kristin, Michelle, and Brandon fought upward toward Rebecca's office and the broadcast levels.
 ---
 
 **Setting:** Detention sectors and experimental laboratories within the facility
@@ -540,6 +573,10 @@ participant_ids: [kristin, brandon, rebecca]
 item_ids: [override_codes]
 entry_text: "Alarms layered over alarms as the facility fought to predict its attackers. Above the fighting, Rebecca's executive office and the external broadcast relay waited at the end of corridors that JANUS watched move by move.\n\n"
 transition_ids: [t_3b_3c]
+bridge_text:
+  t_3b_3c: >-
+    Brandon disconnected the relay from JANUS and held it open through the electrical surge while Kristin and Michelle
+    began the broadcast. The evidence was moving beyond Charles's control as the facility started to fail.
 ---
 
 **Setting:** Security corridors, command center, and Rebecca Jenkins’s executive office

--- a/data/stories/continuity-initiative/storylet-routes.yaml
+++ b/data/stories/continuity-initiative/storylet-routes.yaml
@@ -428,7 +428,7 @@ storylets:
     her disappearance to a deliberate threat rather than require a specific search command.
   realization_options:
   - id: SL-1A-B-R1
-    dramatic_intent: Discover or securely recover Michelle’s research and infer that she expected targeted danger.
+    dramatic_intent: Recover Michelle's hidden memory card and damaged recording; the card points to a dead drop at a bench in the park, giving Kristin a concrete lead away from the house.
     operations:
     - op: assert
       fact_id: continuity_initiative_known
@@ -1352,8 +1352,8 @@ storylets:
     combined mission and focuses urgency.
   realization_options:
   - id: SL-2C-C-R1
-    dramatic_intent: Michelle’s coded message establishes that broadcast and detention access can be combined through
-      Rebecca’s secured office.
+    dramatic_intent: Michelle's coded message establishes that evidence can be broadcast and detention cells opened
+      through Rebecca's secured office.
     operations:
     - op: assert
       fact_id: evidence_ready_to_transmit

--- a/data/stories/continuity-initiative/storylet-routes.yaml
+++ b/data/stories/continuity-initiative/storylet-routes.yaml
@@ -2107,10 +2107,12 @@ canonical_bridge_events:
   scene_id: 1B
   activation:
     all_facts_true:
+    - park_pursuit_resolved
+    any_of:
     - transport_route_identified
     - brandon_identified
     - missing_may_be_alive
-    - park_pursuit_resolved
+    at_least: 2
   produces:
   - op: assert
     fact_id: transport_route_departure_ready
@@ -2119,8 +2121,9 @@ canonical_bridge_events:
   - SL-1B-A
   - SL-1B-B
   - SL-1B-C
-  fallback_realization: The transit clue/Brandon explanation and a validated resolution of the park pursuit may
-    establish departure toward the freight terminal without requiring a particular escape action.
+  fallback_realization: Any two of the transit clue, Brandon explanation, or evidence that May may be alive, together
+    with a validated resolution of the park pursuit, may establish departure toward the freight terminal without
+    requiring a particular escape action.
 - id: bridge_1c_infiltration_needed
   scene_id: 1C
   activation:
@@ -2156,9 +2159,11 @@ canonical_bridge_events:
   activation:
     all_facts_true:
     - janus_evidence
+    any_of:
     - brandon_janus_role_known
     - brandon_claimed_reform_motive
     - michelle_resistance_known
+    at_least: 2
   produces:
   - op: assert
     fact_id: archive_crisis_understood
@@ -2167,8 +2172,8 @@ canonical_bridge_events:
   - SL-2B-A
   - SL-2B-B
   - SL-2B-C
-  fallback_realization: Free-text archive investigation and confrontation may establish the same JANUS, bait, Brandon,
-    and Michelle-resistance revelations without selecting a storylet.
+  fallback_realization: Free-text archive investigation and confrontation may establish JANUS evidence plus any two of
+    Brandon’s JANUS role, his claimed reform motive, and Michelle’s resistance without selecting a storylet.
 - id: bridge_2c_combined_plan
   scene_id: 2C
   activation:
@@ -2203,11 +2208,13 @@ canonical_bridge_events:
   scene_id: 3B
   activation:
     all_facts_true:
+    - relay_open
+    any_of:
     - human_security_control
     - charles_abandoned_rebecca
     - detention_locations_secured
     - brandon_confession_available
-    - relay_open
+    at_least: 3
   produces:
   - op: assert
     fact_id: broadcast_started
@@ -2216,8 +2223,8 @@ canonical_bridge_events:
   - SL-3B-A
   - SL-3B-B
   - SL-3B-C
-  fallback_realization: After JANUS loses predictive control, Rebecca’s location data is secured, Charles betrays
-    her, and Brandon opens the relay with his confession, Michelle/Kristin begin the transmission.
+  fallback_realization: After the relay is open and any three of human security control, Rebecca’s location data,
+    Charles abandoning her, or Brandon’s confession are established, Michelle/Kristin begin the transmission.
 canonical_resolution_events:
 - id: resolution_exposure_holds
   scene_id: 3C

--- a/data/stories/continuity-initiative/storylet-routes.yaml
+++ b/data/stories/continuity-initiative/storylet-routes.yaml
@@ -22,7 +22,7 @@ contract:
 pacing_event_review:
 - event_id: pressure_1a
   scene_id: 1A
-  at_seconds: 120
+  at_turn: 2
   effect:
     op: assert
     fact_id: patrol_return_pressure
@@ -369,9 +369,9 @@ storylets:
     - fact_id: michelle_abduction_suspicion
       equals: false
     pacing:
-      earliest_seconds: 0
-      target_seconds: 60
-      latest_seconds: 60
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 1
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: If Kristin searches slowly or treats the disappearance as generic chaos, foreground contradictory
     physical evidence so curiosity naturally tightens into abduction suspicion.
@@ -420,9 +420,9 @@ storylets:
     - fact_id: continuity_initiative_known
       equals: false
     pacing:
-      earliest_seconds: 120
-      target_seconds: 120
-      latest_seconds: 120
+      earliest_turn: 2
+      target_turn: 2
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: When the player lingers in Michelle’s work area, let her preparation reward investigation and connect
     her disappearance to a deliberate threat rather than require a specific search command.
@@ -483,9 +483,9 @@ storylets:
     - fact_id: michelle_warning_known
       equals: true
     pacing:
-      earliest_seconds: 0
-      target_seconds: 180
-      latest_seconds: 300
+      earliest_turn: 0
+      target_turn: 3
+      latest_turn: 3
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: If Kristin stalls after finding evidence, official scrutiny raises urgency and makes staying costly
     without dictating whether she hides, lies, argues, or leaves.
@@ -542,9 +542,9 @@ storylets:
     - fact_id: michelle_warning_known
       equals: true
     pacing:
-      earliest_seconds: 0
-      target_seconds: 120
-      latest_seconds: 300
+      earliest_turn: 0
+      target_turn: 2
+      latest_turn: 3
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: When Kristin reached the damaged recording before the files, the card is still under the drawer;
     the warning tells her Michelle hid something deliberately, so keep searching for what it points to.
@@ -601,9 +601,9 @@ storylets:
     scene_id: 1B
     conditions: []
     pacing:
-      earliest_seconds: 120
-      target_seconds: 195
-      latest_seconds: 270
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: Turn lingering investigation into several converging leads—tests, a man in Michelle’s photo, and physical
     transport infrastructure—without making one clue the required interaction.
@@ -650,9 +650,9 @@ storylets:
     scene_id: 1B
     conditions: []
     pacing:
-      earliest_seconds: 120
-      target_seconds: 195
-      latest_seconds: 270
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: When the player resists trusting Brandon, let behavior under pressure earn only provisional cooperation
     while keeping his deeper history unresolved.
@@ -715,9 +715,9 @@ storylets:
     - fact_id: missing_may_be_alive
       equals: true
     pacing:
-      earliest_seconds: 120
-      target_seconds: 195
-      latest_seconds: 270
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: 'Convert pursuit into both forward motion and suspicion: Brandon can solve the immediate escape
     problem, but doing so exposes unexplained retained access.'
@@ -775,9 +775,9 @@ storylets:
     scene_id: 1C
     conditions: []
     pacing:
-      earliest_seconds: 270
-      target_seconds: 330
-      latest_seconds: 390
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: Use Kristin’s Army infrastructure and operations background to reward free-form inspection and turn hesitation into accumulating
     physical proof of an active hidden installation.
@@ -830,9 +830,9 @@ storylets:
     - fact_id: facility_proof
       equals: true
     pacing:
-      earliest_seconds: 270
-      target_seconds: 330
-      latest_seconds: 390
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: If the player fixates on immediate rescue, show living captives and an uncertain Michelle sighting
     to heighten urgency while preserving the need for broader understanding.
@@ -888,9 +888,9 @@ storylets:
     - fact_id: captives_confirmed_alive
       equals: true
     pacing:
-      earliest_seconds: 270
-      target_seconds: 330
-      latest_seconds: 390
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: When the player is ready to treat the site as the whole conspiracy, widen the scale through logistics
     and recordings so the next phase feels necessary.
@@ -939,9 +939,9 @@ storylets:
     scene_id: 2A
     conditions: []
     pacing:
-      earliest_seconds: 390
-      target_seconds: 450
-      latest_seconds: 510
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: If planning becomes static, make Brandon’s long preparation useful but suspicious, encouraging
     questioning while keeping his JANUS role protected.
@@ -987,9 +987,9 @@ storylets:
     - fact_id: facility_infiltration_needed
       equals: true
     pacing:
-      earliest_seconds: 390
-      target_seconds: 450
-      latest_seconds: 510
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: Give the player many ways to contribute expertise to infiltration preparation; any plausible cover
     built around the real defect can converge on readiness.
@@ -1037,9 +1037,9 @@ storylets:
     - fact_id: false_identities_ready
       equals: true
     pacing:
-      earliest_seconds: 390
-      target_seconds: 450
-      latest_seconds: 510
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: If the player hesitates at security or challenges the cover, make the supervisor a free-form social/technical
     pressure test rather than a fixed dialogue puzzle.
@@ -1092,9 +1092,9 @@ storylets:
     scene_id: 2B
     conditions: []
     pacing:
-      earliest_seconds: 510
-      target_seconds: 570
-      latest_seconds: 630
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: When the player explores the archive, let Michelle’s record, Kristin’s record, or classification
     categories independently reveal the selection mechanism.
@@ -1149,9 +1149,9 @@ storylets:
     - fact_id: janus_evidence
       equals: true
     pacing:
-      earliest_seconds: 510
-      target_seconds: 570
-      latest_seconds: 630
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: Turn accumulated suspicion into a confrontation that can occur immediately or after observation,
     without forcing forgiveness or hostility.
@@ -1203,9 +1203,9 @@ storylets:
     - fact_id: janus_evidence
       equals: true
     pacing:
-      earliest_seconds: 510
-      target_seconds: 570
-      latest_seconds: 630
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: After betrayal pressure spikes, give the player a constructive route forward by recognizing Michelle’s
     agency in corrupted files and maintenance messages.
@@ -1252,9 +1252,9 @@ storylets:
     scene_id: 2C
     conditions: []
     pacing:
-      earliest_seconds: 630
-      target_seconds: 705
-      latest_seconds: 780
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: Use antagonist fracture to create pressure and possible executive access without making Rebecca
     trustworthy or requiring Kristin to accept Brandon’s performance.
@@ -1299,9 +1299,9 @@ storylets:
     scene_id: 2C
     conditions: []
     pacing:
-      earliest_seconds: 630
-      target_seconds: 705
-      latest_seconds: 780
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: 'If the player lingers over strategy, convert delay into an explicit worsening deadline: transfers
     accelerate and safe options narrow.'
@@ -1344,9 +1344,9 @@ storylets:
     - fact_id: purge_clock_started
       equals: true
     pacing:
-      earliest_seconds: 630
-      target_seconds: 705
-      latest_seconds: 780
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: Let argument, refusal, or hesitation play naturally until Michelle’s coded message creates the authored
     combined mission and focuses urgency.
@@ -1396,9 +1396,9 @@ storylets:
     scene_id: 3A
     conditions: []
     pacing:
-      earliest_seconds: 780
-      target_seconds: 840
-      latest_seconds: 900
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: If Kristin focuses narrowly on extracting Michelle, her visible leadership reframes the objective
     and turns reunion into immediate coordinated action.
@@ -1447,9 +1447,9 @@ storylets:
     - fact_id: michelle_reached
       equals: true
     pacing:
-      earliest_seconds: 780
-      target_seconds: 840
-      latest_seconds: 900
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: When the player wants to rush upward, make the medical level evidence matter by showing why exposure
     must include the conditioning program, and let the imprisoned official's expiring codes reward the documentation
@@ -1509,9 +1509,9 @@ storylets:
     - fact_id: uprising_prepared
       equals: true
     pacing:
-      earliest_seconds: 780
-      target_seconds: 840
-      latest_seconds: 900
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: 'Convert the expiring authorization into forward motion: once the codes lose value with Charles’s
     new authority, Michelle’s prepared disturbances become the only viable route upward.'
@@ -1558,9 +1558,9 @@ storylets:
     scene_id: 3B
     conditions: []
     pacing:
-      earliest_seconds: 900
-      target_seconds: 975
-      latest_seconds: 1050
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: When predictive security blocks obvious routes, reward irrational, operations-driven disruption;
     failed attempts can worsen local pressure without prescribing a single puzzle answer.
@@ -1604,9 +1604,9 @@ storylets:
     - fact_id: human_security_control
       equals: true
     pacing:
-      earliest_seconds: 900
-      target_seconds: 975
-      latest_seconds: 1050
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: 'If the player stalls in Rebecca’s office, force antagonist conflict into the open: her information
     remains useful even as Charles strips her control.'
@@ -1673,9 +1673,9 @@ storylets:
     - fact_id: detention_locations_secured
       equals: true
     pacing:
-      earliest_seconds: 900
-      target_seconds: 975
-      latest_seconds: 1050
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: When the broadcast is otherwise ready, make the relay the concrete final bottleneck; Brandon’s
     accountability and danger create climax pressure without scripting Kristin’s response.
@@ -1727,9 +1727,9 @@ storylets:
     - fact_id: broadcast_started
       equals: true
     pacing:
-      earliest_seconds: 1050
-      target_seconds: 1140
-      latest_seconds: 1200
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: 'Once transmission begins, prevent the climax from becoming a passive upload: Charles contests
     credibility, and accumulated verifiable evidence lets Michelle answer him.'
@@ -1776,9 +1776,9 @@ storylets:
     - fact_id: truth_no_longer_containable
       equals: true
     pacing:
-      earliest_seconds: 1050
-      target_seconds: 1140
-      latest_seconds: 1200
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: Turn Rebecca’s attempted escape into an information-custody dilemma so destruction is not an easy
     moral shortcut.
@@ -1850,9 +1850,9 @@ storylets:
     - fact_id: rebecca_captured
       equals: true
     pacing:
-      earliest_seconds: 1050
-      target_seconds: 1140
-      latest_seconds: 1200
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: 'Keep falling action dangerous: Kristin’s Army infrastructure and operations choices preserve routes while Michelle moves
     people, but no single maneuver guarantees every section survives.'
@@ -1904,9 +1904,9 @@ storylets:
     - fact_id: captives_reaching_surface
       equals: true
     pacing:
-      earliest_seconds: 1050
-      target_seconds: 1140
-      latest_seconds: 1200
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: After the canonical resolution conditions land, provide optional distributed consequence color
     without creating a new playable scene or new ending.
@@ -1952,9 +1952,9 @@ storylets:
     - fact_id: captives_reaching_surface
       equals: true
     pacing:
-      earliest_seconds: 1050
-      target_seconds: 1140
-      latest_seconds: 1200
+      earliest_turn: 0
+      target_turn: 1
+      latest_turn: 2
       pressure_bias: normal_before_target; prefer_after_target; strongly_prefer_near_latest
   pressure_role: Only after the sole ending is secure, deliver the final unresolved-threat reversal; this is sequel-scale
     context, not an alternate ending.

--- a/data/stories/continuity-initiative/storylets.md
+++ b/data/stories/continuity-initiative/storylets.md
@@ -71,9 +71,9 @@ Each entry below is authoring data, not a player action menu.
 - Does not reveal who took Michelle, JANUS, Brandon’s role, the detention network, or the true mechanics of the disappearances.
 
 **Pacing window**
-- earliest: `00:00:00`
-- target: `00:01:00`
-- latest: `00:01:00`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 1`
 
 **Pacing impact**
 `brief_delay`
@@ -123,9 +123,9 @@ Each entry below is authoring data, not a player action menu.
 - “Continuity Initiative” may be known as Michelle’s suspicious emergency program, but its actual national purpose remains protected.
 
 **Pacing window**
-- earliest: `00:02:00`
-- target: `00:02:00`
-- latest: `00:02:00`
+- earliest: `turn 2`
+- target: `turn 2`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -171,9 +171,9 @@ Each entry below is authoring data, not a player action menu.
 - “Continuity Initiative” may be known as Michelle’s suspicious emergency program, but its actual national purpose remains protected.
 
 **Pacing window**
-- earliest: `00:00:00`
-- target: `00:02:00`
-- latest: `00:05:00`
+- earliest: `turn 0`
+- target: `turn 2`
+- latest: `turn 3`
 
 **Pacing impact**
 `brief_delay`
@@ -226,9 +226,9 @@ Each entry below is authoring data, not a player action menu.
 - Patrol officers do not know or disclose the later JANUS bait revelation.
 
 **Pacing window**
-- earliest: `00:00:00`
-- target: `00:03:00`
-- latest: `00:05:00`
+- earliest: `turn 0`
+- target: `turn 3`
+- latest: `turn 3`
 
 **Pacing impact**
 `brief_delay`
@@ -281,9 +281,9 @@ Each entry below is authoring data, not a player action menu.
 - Brandon is not yet established as trustworthy or as a JANUS developer.
 
 **Pacing window**
-- earliest: `00:02:00`
-- target: `00:03:15`
-- latest: `00:04:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -333,9 +333,9 @@ Each entry below is authoring data, not a player action menu.
 - Brandon may admit prior Continuity Initiative work, but not yet the full JANUS-development history.
 
 **Pacing window**
-- earliest: `00:02:00`
-- target: `00:03:15`
-- latest: `00:04:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -385,9 +385,9 @@ Each entry below is authoring data, not a player action menu.
 - The access proves deeper involvement, not the exact nature of Brandon’s guilt.
 
 **Pacing window**
-- earliest: `00:02:00`
-- target: `00:03:15`
-- latest: `00:04:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -437,9 +437,9 @@ Each entry below is authoring data, not a player action menu.
 - Does not reveal the full national network before the logistics evidence is reached.
 
 **Pacing window**
-- earliest: `00:04:30`
-- target: `00:05:30`
-- latest: `00:06:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -491,9 +491,9 @@ Each entry below is authoring data, not a player action menu.
 - Michelle’s exact position and resistance network remain protected.
 
 **Pacing window**
-- earliest: `00:04:30`
-- target: `00:05:30`
-- latest: `00:06:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -545,9 +545,9 @@ Each entry below is authoring data, not a player action menu.
 - JANUS itself, Kristin-as-bait, Brandon’s development role, and Michelle’s resistance network remain protected for Scene 2B.
 
 **Pacing window**
-- earliest: `00:04:30`
-- target: `00:05:30`
-- latest: `00:06:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -601,9 +601,9 @@ Each entry below is authoring data, not a player action menu.
 - Brandon’s direct work on JANUS remains protected.
 
 **Pacing window**
-- earliest: `00:06:30`
-- target: `00:07:30`
-- latest: `00:08:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -653,9 +653,9 @@ Each entry below is authoring data, not a player action menu.
 - Does not grant knowledge of later archive discoveries or Rebecca’s surveillance decision.
 
 **Pacing window**
-- earliest: `00:06:30`
-- target: `00:07:30`
-- latest: `00:08:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -706,9 +706,9 @@ Each entry below is authoring data, not a player action menu.
 - Kristin and Brandon do not learn that Rebecca is observing them merely because the state flag exists.
 
 **Pacing window**
-- earliest: `00:06:30`
-- target: `00:07:30`
-- latest: `00:08:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -758,9 +758,9 @@ Each entry below is authoring data, not a player action menu.
 - The exact reason Charles expected Kristin to expose Brandon may emerge only as supported by the authored records; no new hidden motives are invented.
 
 **Pacing window**
-- earliest: `00:08:30`
-- target: `00:09:30`
-- latest: `00:10:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -810,9 +810,9 @@ Each entry below is authoring data, not a player action menu.
 - Brandon’s later sacrifice/confession is not foreshadowed as guaranteed.
 
 **Pacing window**
-- earliest: `00:08:30`
-- target: `00:09:30`
-- latest: `00:10:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -862,9 +862,9 @@ Each entry below is authoring data, not a player action menu.
 - The exact uprising plan and broadcast solution remain protected until later scenes.
 
 **Pacing window**
-- earliest: `00:08:30`
-- target: `00:09:30`
-- latest: `00:10:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -915,9 +915,9 @@ Each entry below is authoring data, not a player action menu.
 - Rebecca’s later claim that she opposed killing captives is not treated as verified truth.
 
 **Pacing window**
-- earliest: `00:10:30`
-- target: `00:11:45`
-- latest: `00:13:00`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -966,9 +966,9 @@ Each entry below is authoring data, not a player action menu.
 - Does not reveal the later exact broadcast-system solution before Michelle provides it.
 
 **Pacing window**
-- earliest: `00:10:30`
-- target: `00:11:45`
-- latest: `00:13:00`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -1021,9 +1021,9 @@ Each entry below is authoring data, not a player action menu.
 - Exact events of the uprising, Brandon’s sacrifice, facility destruction, and final broadcast outcome remain protected.
 
 **Pacing window**
-- earliest: `00:10:30`
-- target: `00:11:45`
-- latest: `00:13:00`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -1080,9 +1080,9 @@ Each entry below is authoring data, not a player action menu.
 - The final outcome of the broadcast and Brandon’s fate remain unknown.
 
 **Pacing window**
-- earliest: `00:13:00`
-- target: `00:14:00`
-- latest: `00:15:00`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -1135,9 +1135,9 @@ Each entry below is authoring data, not a player action menu.
 - The codes do not automatically solve the facility fight or national conspiracy.
 
 **Pacing window**
-- earliest: `00:13:00`
-- target: `00:14:00`
-- latest: `00:15:00`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -1184,9 +1184,9 @@ Each entry below is authoring data, not a player action menu.
 - The uprising does not by itself defeat JANUS, seize the broadcast, or resolve the national conspiracy.
 
 **Pacing window**
-- earliest: `00:13:00`
-- target: `00:14:00`
-- latest: `00:15:00`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -1237,9 +1237,9 @@ Each entry below is authoring data, not a player action menu.
 - The disruption does not itself disconnect the external relay; that remains Brandon’s later task.
 
 **Pacing window**
-- earliest: `00:15:00`
-- target: `00:16:15`
-- latest: `00:17:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -1292,9 +1292,9 @@ Each entry below is authoring data, not a player action menu.
 - Rebecca’s offer is not automatically trusted; later archive evidence remains independently valuable.
 
 **Pacing window**
-- earliest: `00:15:00`
-- target: `00:16:15`
-- latest: `00:17:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -1347,9 +1347,9 @@ Each entry below is authoring data, not a player action menu.
 - Brandon’s final survival/fate remains unresolved until the authored escape/collapse outcome permits it.
 
 **Pacing window**
-- earliest: `00:15:00`
-- target: `00:16:15`
-- latest: `00:17:30`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -1404,9 +1404,9 @@ Each entry below is authoring data, not a player action menu.
 - Phase Two remains protected until the resolution discovery.
 
 **Pacing window**
-- earliest: `00:17:30`
-- target: `00:19:00`
-- latest: `00:20:00`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -1455,9 +1455,9 @@ Each entry below is authoring data, not a player action menu.
 - The archive does not automatically contain or reveal Phase Two unless that is explicitly declared elsewhere in the package.
 
 **Pacing window**
-- earliest: `00:17:30`
-- target: `00:19:00`
-- latest: `00:20:00`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -1510,9 +1510,9 @@ Each entry below is authoring data, not a player action menu.
 - The final Phase Two revelation is delivered only by the authored recovered-JANUS resolution event, not by this escape storylet.
 
 **Pacing window**
-- earliest: `00:17:30`
-- target: `00:19:00`
-- latest: `00:20:00`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -1563,9 +1563,9 @@ These do **not** create a new playable scene after `3C`. The storylets themselve
 - Off-scene facilities are described only through public/currently-known reports.
 
 **Pacing window**
-- earliest: `00:17:30`
-- target: `00:19:00`
-- latest: `00:20:00`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`
@@ -1610,9 +1610,9 @@ These do **not** create a new playable scene after `3C`. The storylets themselve
 - Do not invent Phase Two mechanisms beyond the source statement that it was designed to provoke conflict among those who remained.
 
 **Pacing window**
-- earliest: `00:17:30`
-- target: `00:19:00`
-- latest: `00:20:00`
+- earliest: `turn 0`
+- target: `turn 1`
+- latest: `turn 2`
 
 **Pacing impact**
 `brief_delay`

--- a/docs/testing-runbook.md
+++ b/docs/testing-runbook.md
@@ -41,6 +41,77 @@ location label or tag. The opening-payload test derives the expected location
 display name from the package rather than pinning `McGehee home`; verified on
 2026-08-29 with `TMPDIR=/tmp uv run pytest -q` (123 passed; 90.97% coverage).
 
+## Scene 1A reveal-to-transition continuity — fixed 2026-08-30
+
+**Purpose:** Record why a move to Scene 1B could follow a drawer search without
+the player being shown the memory-card files or any reason to visit the park,
+and what now prevents it.
+
+**Setup / seed:** A Scene 1A session, investigating Michelle's workstation
+through free-text drawer searches until a reveal is selected.
+
+**Safe actions:** Inspect package routes, knowledge statements, and the
+resolver/engine code. The regression is covered by the local suite, so no
+hosted session is needed to exercise it.
+
+**Destructive or external actions:** None.
+
+**Diagnosis (2026-08-30, from a player transcript).** Two independent defects
+produced one symptom. `SelectedRevealResolver.resolve` proved only that the
+selected knowledge ID appeared in some segment's `grounding_ids`; it never
+compared the segment prose with the knowledge statement, so a model could
+select the memory-card reveal, narrate only its broadcast-warning half, and
+still commit `michelle_lead_actionable`. Separately, `k_sl_1a_b_r1` asserted
+that fact while its own statement named no lead and no place, so even a
+faithful narration of it told the player nothing about where to go. The
+reported transcript was a correct rendering of a defective statement.
+
+**Fix.** Knowledge definitions now carry authored `must_convey` synonym groups,
+and both commit paths check the narration against them before anything is
+applied: `SelectedRevealResolver.resolve` raises before validation and before
+`apply_proposal`, and `CloudflareTurnProvider._parse_eligible_proposal` mirrors
+the rule so a miss spends the transport's one guided recovery instead of the
+player's turn. The loader refuses to load a package in which a selectable,
+trigger-establishing reveal declares no groups. `k_sl_1a_b_r1` was rewritten to
+name the memory card, the damaged recording, and the dead drop at the park
+bench, and `SL-1A-B-R1`'s `dramatic_intent` was brought into agreement.
+
+The investigation behind the fix found three further defects that would have
+made the obvious repair fail elsewhere; all are now addressed. Bridge events
+activated on a full conjunction of facts, so a player who explored differently
+could be permanently stuck — they now support a threshold rule. Pacing was
+measured in absolute story-seconds against a global clock, so an ordinary player
+entered every scene from 2B onward already overdue — it is now counted in turns
+since scene entry. And a player short of a scene's exit had no way forward — a
+declared `FactDelivery` per player-safe fact now lets the runtime hint first and
+then stage an in-world handoff, which is committed atomically with its costs and
+the transition.
+
+**Verify:**
+
+```bash
+TMPDIR=/tmp uv run pytest -q
+npm --prefix frontend test
+```
+
+Expected on 2026-08-30: 177 passed, 91.29% coverage; frontend 30 passed, 0
+failed. `tests/test_must_convey.py` covers the matcher,
+`tests/test_scene_progression_phase4.py` holds the reported transcript's exact
+shape — select `k_sl_1a_b_r1`, ground it, narrate only the broadcast-warning
+half, and assert nothing commits and the scene does not move — and
+`tests/test_pacing_handoff.py` covers the hint, the handoff, the guided
+recovery, and the authored fallback.
+
+**Cleanup:** None.
+
+**Notes:** This entry records local evidence only. Nothing here has been
+re-run against a deployment since the fix landed, and the hosted observations
+recorded elsewhere in this runbook predate it. Replaying the reported
+transcript against staging — searching the drawer in 1A and confirming the
+narration names the memory card *and* the bench before the park paragraph, and
+that a partial narration is retried rather than silently advancing — is still
+outstanding.
+
 ## Full-journey acceptance — verified state (2026-08-29)
 
 **Purpose:** Record what the hosted canon playthrough proves and what it does
@@ -55,7 +126,9 @@ TMPDIR=/tmp uv run pytest -q
 - `tests/test_canon_journey.py` drives two complete 1A→3C playthroughs with a
   scripted provider — one on the package clock, one at the default 60-second
   cadence — and asserts `resolution_complete`, every pacing event, and the
-  20-minute budget.
+  30-minute budget. The budget was raised from 20 minutes on 2026-08-30 when
+  pacing became turn-based: the per-scene handoff allowance sums to 30 turns,
+  which at 60 story-seconds per turn is exactly 1800 seconds.
 - `test_no_single_reveal_can_strand_a_scene_exit` audits every transition
   against every realization. It exists because playing Michelle's damaged
   recording before finding her memory card used to consume Scene 1A's only
@@ -81,6 +154,14 @@ Observed on 2026-08-29 against staging: the playthrough walks all nine scenes
 in authored order, fires all four pacing events in their own scenes, commits a
 reveal on close to every turn, and reaches the independent judge. Runs vary
 between roughly 22 and 28 turns.
+
+**That observation is stale as of 2026-08-30 and has not been repeated.** It
+was taken before pacing became turn-based, so its turn counts were measured
+against the old absolute-seconds windows and the old 20-minute budget. The
+`E2E_PACKAGE_CLOCK` harness was rewritten to arm turn milestones rather than
+inject a clock value, and those Playwright specs have been changed but not
+executed, because they need a live deployment. Re-run this section before
+trusting any number in it.
 
 **Known open items:**
 

--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -2,7 +2,7 @@ import { expect } from "@playwright/test";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 
-import { applyTestClock, isTurnRequest } from "./package-clock-request.js";
+import { isTurnRequest } from "./package-clock-request.js";
 import { createPackageClockController } from "./package-clock-controller.js";
 
 const TURN_TIMEOUT_MS = Number.parseInt(process.env.E2E_TURN_TIMEOUT_MS || "30000", 10);
@@ -80,37 +80,9 @@ function sessionResponseFor(page, controller) {
   });
 }
 
-export async function installPackageClock(page, { pacing, token, controller } = {}) {
+export async function installPackageClock(page, { controller } = {}) {
   const packageClockController = controller ?? createPackageClockController();
   packageClockControllers.set(page, packageClockController);
-
-  await page.route("**/api/v1/turn*", async (route) => {
-    const request = route.request();
-    if (!isTurnRequest(request.url(), request.method())) {
-      await route.continue();
-      return;
-    }
-
-    try {
-      if (packageClockController.armed() === null) {
-        await route.continue();
-        return;
-      }
-      const deltaSeconds = packageClockController.deltaForRequest();
-      const postData = applyTestClock(request.postData() ?? "", { deltaSeconds, token });
-      await route.continue({
-        url: request.url(),
-        method: request.method(),
-        headers: request.headers(),
-        postData,
-      });
-    } catch (error) {
-      throw new Error(
-        `Package clock could not rewrite turn request: ${error instanceof Error ? error.message : String(error)}.`,
-      );
-    }
-  });
-
   return packageClockController;
 }
 

--- a/frontend/e2e/package-clock-controller.js
+++ b/frontend/e2e/package-clock-controller.js
@@ -1,25 +1,26 @@
-const MAX_DELTA_SECONDS = 3600;
-
-function readElapsed(state, description) {
+function readState(state, description) {
   if (
     state === null ||
     typeof state !== "object" ||
     Array.isArray(state) ||
-    !Number.isInteger(state.story_elapsed_seconds) ||
-    state.story_elapsed_seconds < 0
+    typeof state.scene_id !== "string" ||
+    state.scene_id.length === 0 ||
+    !Number.isSafeInteger(state.turn_index) ||
+    state.turn_index < 0 ||
+    !Number.isSafeInteger(state.turns_since_scene_entry) ||
+    state.turns_since_scene_entry < 0 ||
+    state.turns_since_scene_entry > state.turn_index
   ) {
     throw new Error(
-      `${description}: missing or malformed elapsed time; expected a non-negative integer story elapsed value.`,
+      `${description}: missing or malformed turn state; expected a scene ID, a non-negative integer turn index, and a non-negative integer scene-relative turn value.`,
     );
   }
-  return state.story_elapsed_seconds;
+  return state;
 }
 
 function milestoneIdentity(milestone) {
-  const scene = milestone.scene_id;
-  const event = milestone.event_id;
-  const eventDescription = event === undefined ? "" : `, event ${String(event)}`;
-  return `scene ${String(scene)}${eventDescription}`;
+  const eventDescription = milestone.event_id === undefined ? "" : `, event ${String(milestone.event_id)}`;
+  return `scene ${String(milestone.scene_id)}${eventDescription}`;
 }
 
 function validateMilestone(milestone) {
@@ -29,24 +30,25 @@ function validateMilestone(milestone) {
     Array.isArray(milestone) ||
     (milestone.kind !== "scene_point" && milestone.kind !== "pacing_event") ||
     typeof milestone.scene_id !== "string" ||
-    !Number.isInteger(milestone.target_seconds) ||
-    milestone.target_seconds < 0 ||
-    (milestone.kind === "pacing_event" && typeof milestone.event_id !== "string")
+    milestone.scene_id.length === 0 ||
+    !Number.isSafeInteger(milestone.target_turn) ||
+    milestone.target_turn < 0 ||
+    (milestone.kind === "scene_point" && !new Set(["min", "nudge", "handoff"]).has(milestone.point)) ||
+    (milestone.kind === "pacing_event" && typeof milestone.event_id !== "string") ||
+    Object.hasOwn(milestone, "target_seconds")
   ) {
-    throw new Error("Cannot arm milestone: malformed milestone target or identity.");
+    throw new Error("Cannot arm milestone: malformed milestone target or identity; expected target_turn.");
   }
 }
 
 export function createPackageClockController() {
-  let lastObservedElapsedSeconds = null;
+  let observedState = null;
   let armedMilestone = null;
-  let sentDeltaSeconds = null;
   const records = [];
 
   return {
     observeState(state) {
-      lastObservedElapsedSeconds = readElapsed(state, "Cannot observe state");
-      sentDeltaSeconds = null;
+      observedState = readState(state, "Cannot observe state");
     },
 
     arm(milestone) {
@@ -57,59 +59,50 @@ export function createPackageClockController() {
         );
       }
       armedMilestone = milestone;
-      sentDeltaSeconds = null;
     },
 
     armed() {
       return armedMilestone;
     },
 
-    deltaForRequest() {
-      if (lastObservedElapsedSeconds === null) {
+    turnsUntilMilestone() {
+      if (observedState === null) {
         throw new Error(
-          "Cannot compute clock delta: no elapsed session state has been observed.",
+          "Cannot compute turns until milestone: no session or turn state has been observed.",
         );
       }
       if (armedMilestone === null) {
-        throw new Error("Cannot compute clock delta: no milestone is armed.");
+        throw new Error("Cannot compute turns until milestone: no milestone is armed.");
       }
-
-      const targetSeconds = armedMilestone.target_seconds;
-      const deltaSeconds = targetSeconds - lastObservedElapsedSeconds;
-      if (deltaSeconds < 0) {
+      if (observedState.scene_id !== armedMilestone.scene_id) {
         throw new Error(
-          `Cannot compute clock delta for ${milestoneIdentity(armedMilestone)}: observed elapsed ${lastObservedElapsedSeconds} is later than requested target_seconds ${targetSeconds}.`,
-        );
-      }
-      if (deltaSeconds > MAX_DELTA_SECONDS) {
-        throw new Error(
-          `Cannot compute clock delta for ${milestoneIdentity(armedMilestone)}: requested delta ${deltaSeconds} exceeds the 3600-second limit.`,
+          `Cannot compute turns until milestone for ${milestoneIdentity(armedMilestone)}: observed scene ${observedState.scene_id} does not match the requested scene.`,
         );
       }
 
-      sentDeltaSeconds = deltaSeconds;
-      return deltaSeconds;
+      const turns = armedMilestone.target_turn - observedState.turns_since_scene_entry;
+      if (turns < 0) {
+        throw new Error(
+          `Cannot compute turns until milestone for ${milestoneIdentity(armedMilestone)}: observed turns_since_scene_entry ${observedState.turns_since_scene_entry} is later than requested target_turn ${armedMilestone.target_turn}.`,
+        );
+      }
+      return turns;
     },
 
     observeTurnResponse(payload) {
       if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
-        throw new Error(
-          "Cannot observe turn response: missing or malformed elapsed state.",
-        );
+        throw new Error("Cannot observe turn response: missing or malformed turn state.");
       }
-      const state = payload.state;
-      const returnedElapsedSeconds = readElapsed(
-        state,
-        "Cannot observe turn response",
-      );
-      const priorElapsedSeconds = lastObservedElapsedSeconds;
-      lastObservedElapsedSeconds = returnedElapsedSeconds;
+      const state = readState(payload.state, "Cannot observe turn response");
+      const priorState = observedState;
+      observedState = state;
 
       if (armedMilestone === null) {
-        sentDeltaSeconds = null;
         return {
           reached: false,
-          elapsed_seconds: returnedElapsedSeconds,
+          scene_id: state.scene_id,
+          turn_index: state.turn_index,
+          turns_since_scene_entry: state.turns_since_scene_entry,
           requested_milestone: null,
         };
       }
@@ -118,23 +111,27 @@ export function createPackageClockController() {
       armedMilestone = null;
       const reached =
         state.pending_game_break !== true &&
-        returnedElapsedSeconds === requestedMilestone.target_seconds;
+        state.scene_id === requestedMilestone.scene_id &&
+        state.turns_since_scene_entry === requestedMilestone.target_turn;
       records.push({
         requested_milestone: requestedMilestone,
-        prior_elapsed_seconds: priorElapsedSeconds,
-        sent_delta_seconds: sentDeltaSeconds,
-        returned_elapsed_seconds: returnedElapsedSeconds,
-        scene_id: state.scene_id ?? null,
+        prior_scene_id: priorState?.scene_id ?? null,
+        prior_turn_index: priorState?.turn_index ?? null,
+        prior_turns_since_scene_entry: priorState?.turns_since_scene_entry ?? null,
+        scene_id: state.scene_id,
+        turn_index: state.turn_index,
+        turns_since_scene_entry: state.turns_since_scene_entry,
         fired_pacing_event_ids: Array.isArray(state.fired_pacing_event_ids)
           ? [...state.fired_pacing_event_ids]
           : [],
         reached,
       });
-      sentDeltaSeconds = null;
 
       return {
         reached,
-        elapsed_seconds: returnedElapsedSeconds,
+        scene_id: state.scene_id,
+        turn_index: state.turn_index,
+        turns_since_scene_entry: state.turns_since_scene_entry,
         requested_milestone: requestedMilestone,
       };
     },
@@ -147,16 +144,4 @@ export function createPackageClockController() {
       }));
     },
   };
-}
-
-export function assertExclusiveClockMode(environment) {
-  const packageClock = environment?.E2E_PACKAGE_CLOCK;
-  const scalarClock = environment?.E2E_TEST_CLOCK_SECONDS;
-  const packageClockSet = packageClock !== undefined && packageClock !== null && String(packageClock).length > 0;
-  const scalarClockSet = scalarClock !== undefined && scalarClock !== null && String(scalarClock).length > 0;
-  if (packageClockSet && scalarClockSet) {
-    throw new Error(
-      "E2E_PACKAGE_CLOCK and E2E_TEST_CLOCK_SECONDS are mutually exclusive clock modes; set only one.",
-    );
-  }
 }

--- a/frontend/e2e/package-clock-controller.test.js
+++ b/frontend/e2e/package-clock-controller.test.js
@@ -1,106 +1,119 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import {
-  assertExclusiveClockMode,
-  createPackageClockController,
-} from "./package-clock-controller.js";
+import { createPackageClockController } from "./package-clock-controller.js";
 
-function state(elapsed, overrides = {}) {
+function state(turnIndex, turnsSinceSceneEntry, overrides = {}) {
   return {
     scene_id: "1A",
-    story_elapsed_seconds: elapsed,
+    turn_index: turnIndex,
+    turns_since_scene_entry: turnsSinceSceneEntry,
     pending_game_break: false,
     fired_pacing_event_ids: [],
     ...overrides,
   };
 }
 
-test("computes a forward package-clock delta from the observed elapsed time", () => {
+test("reports the further turns needed for an armed milestone", () => {
   const controller = createPackageClockController();
-  controller.observeState(state(120));
-  controller.arm({ kind: "scene_point", scene_id: "1B", point: "target", target_seconds: 195 });
+  controller.observeState(state(1, 1));
+  controller.arm({ kind: "scene_point", scene_id: "1A", point: "nudge", target_turn: 3 });
 
-  assert.equal(controller.deltaForRequest(), 75);
+  assert.equal(controller.turnsUntilMilestone(), 2);
 });
 
-test("allows a zero delta when the observed time equals the target", () => {
+test("allows zero further turns when the observed scene-relative turn equals the target", () => {
   const controller = createPackageClockController();
-  controller.observeState(state(195));
-  controller.arm({ kind: "scene_point", scene_id: "1B", point: "target", target_seconds: 195 });
+  controller.observeState(state(3, 3));
+  controller.arm({ kind: "scene_point", scene_id: "1A", point: "handoff", target_turn: 3 });
 
-  assert.equal(controller.deltaForRequest(), 0);
+  assert.equal(controller.turnsUntilMilestone(), 0);
 });
 
-test("rejects a target earlier than the observed elapsed time", () => {
+test("rejects a milestone for a different scene", () => {
   const controller = createPackageClockController();
-  controller.observeState(state(195));
-  controller.arm({ kind: "pacing_event", scene_id: "2C", event_id: "purge_2c", target_seconds: 150 });
+  controller.observeState(state(2, 2));
+  controller.arm({ kind: "pacing_event", scene_id: "2C", event_id: "purge_2c", target_turn: 2 });
 
   assert.throws(
-    () => controller.deltaForRequest(),
+    () => controller.turnsUntilMilestone(),
     (error) =>
       error instanceof Error &&
-      error.message.includes("195") &&
-      error.message.includes("150") &&
+      error.message.includes("1A") &&
       error.message.includes("2C") &&
       error.message.includes("purge_2c"),
   );
 });
 
-test("requires an observed session or turn state before computing a delta", () => {
+test("requires an observed session or turn state before computing remaining turns", () => {
   const controller = createPackageClockController();
-  controller.arm({ kind: "scene_point", scene_id: "1B", point: "target", target_seconds: 195 });
+  controller.arm({ kind: "scene_point", scene_id: "1A", point: "min", target_turn: 2 });
 
   assert.throws(
-    () => controller.deltaForRequest(),
-    /elapsed|session|state|observed/i,
+    () => controller.turnsUntilMilestone(),
+    /session|state|observed/i,
+  );
+});
+
+test("rejects a target earlier than the observed scene-relative turn", () => {
+  const controller = createPackageClockController();
+  controller.observeState(state(3, 3));
+  controller.arm({ kind: "pacing_event", scene_id: "1A", event_id: "pressure_1a", target_turn: 2 });
+
+  assert.throws(
+    () => controller.turnsUntilMilestone(),
+    (error) => error instanceof Error && error.message.includes("3") && error.message.includes("2"),
   );
 });
 
 test("rejects arming a second milestone", () => {
   const controller = createPackageClockController();
-  controller.arm({ kind: "scene_point", scene_id: "1B", point: "target", target_seconds: 195 });
+  controller.arm({ kind: "scene_point", scene_id: "1A", point: "min", target_turn: 2 });
 
   assert.throws(
-    () => controller.arm({ kind: "scene_point", scene_id: "1C", point: "target", target_seconds: 240 }),
+    () => controller.arm({ kind: "scene_point", scene_id: "1A", point: "nudge", target_turn: 3 }),
     /arm/i,
   );
 });
 
-test("enforces the upper delta bound while allowing exactly 3600 seconds", () => {
-  const tooLarge = createPackageClockController();
-  tooLarge.observeState(state(0));
-  tooLarge.arm({ kind: "scene_point", scene_id: "1B", point: "target", target_seconds: 3601 });
-  assert.throws(() => tooLarge.deltaForRequest(), /3600/);
-
-  const exactLimit = createPackageClockController();
-  exactLimit.observeState(state(0));
-  exactLimit.arm({ kind: "scene_point", scene_id: "1B", point: "target", target_seconds: 3600 });
-  assert.equal(exactLimit.deltaForRequest(), 3600);
+test("rejects malformed milestones and obsolete absolute targets", () => {
+  const controller = createPackageClockController();
+  for (const milestone of [
+    null,
+    { kind: "scene_point", scene_id: "1A", point: "target", target_turn: 2 },
+    { kind: "scene_point", scene_id: "1A", point: "min", target_turn: "2" },
+    { kind: "scene_point", scene_id: "1A", point: "min", target_seconds: 120 },
+    { kind: "pacing_event", scene_id: "1A", target_turn: 2 },
+  ]) {
+    assert.throws(() => controller.arm(milestone), /malformed|target_turn/i);
+  }
 });
 
-test("records an accepted turn that reaches the requested target exactly", () => {
+test("records a turn that reaches the requested target exactly", () => {
   const controller = createPackageClockController();
-  const milestone = { kind: "scene_point", scene_id: "1B", point: "target", target_seconds: 195 };
-  controller.observeState(state(120));
+  const milestone = { kind: "scene_point", scene_id: "1A", point: "nudge", target_turn: 2 };
+  controller.observeState(state(1, 1));
   controller.arm(milestone);
-  assert.equal(controller.deltaForRequest(), 75);
+  assert.equal(controller.turnsUntilMilestone(), 1);
 
-  const outcome = controller.observeTurnResponse({ state: state(195, { scene_id: "1B" }) });
+  const outcome = controller.observeTurnResponse({ state: state(2, 2) });
 
   assert.deepEqual(outcome, {
     reached: true,
-    elapsed_seconds: 195,
+    scene_id: "1A",
+    turn_index: 2,
+    turns_since_scene_entry: 2,
     requested_milestone: milestone,
   });
   assert.deepEqual(controller.history(), [
     {
       requested_milestone: milestone,
-      prior_elapsed_seconds: 120,
-      sent_delta_seconds: 75,
-      returned_elapsed_seconds: 195,
-      scene_id: "1B",
+      prior_scene_id: "1A",
+      prior_turn_index: 1,
+      prior_turns_since_scene_entry: 1,
+      scene_id: "1A",
+      turn_index: 2,
+      turns_since_scene_entry: 2,
       fired_pacing_event_ids: [],
       reached: true,
     },
@@ -108,80 +121,78 @@ test("records an accepted turn that reaches the requested target exactly", () =>
   assert.equal(controller.armed(), null);
 });
 
-test("reports an accepted turn landing short of its milestone", () => {
+test("reports a valid turn landing short of its milestone", () => {
   const controller = createPackageClockController();
-  controller.observeState(state(120));
-  controller.arm({ kind: "scene_point", scene_id: "1B", point: "target", target_seconds: 195 });
-  controller.deltaForRequest();
+  controller.observeState(state(1, 1));
+  controller.arm({ kind: "scene_point", scene_id: "1A", point: "handoff", target_turn: 3 });
+  assert.equal(controller.turnsUntilMilestone(), 2);
 
-  const outcome = controller.observeTurnResponse({ state: state(180) });
+  const outcome = controller.observeTurnResponse({ state: state(2, 2) });
 
   assert.equal(outcome.reached, false);
-  assert.equal(outcome.elapsed_seconds, 180);
-  assert.equal(controller.history()[0].returned_elapsed_seconds, 180);
+  assert.equal(outcome.turns_since_scene_entry, 2);
+  assert.equal(controller.history()[0].turns_since_scene_entry, 2);
 });
 
-test("keeps a pending game break anchored to its actual elapsed time", () => {
+test("does not mark a pending game break as reaching a milestone", () => {
   const controller = createPackageClockController();
-  const milestone = { kind: "pacing_event", scene_id: "2C", event_id: "purge_2c", target_seconds: 690 };
-  controller.observeState(state(600));
+  const milestone = { kind: "pacing_event", scene_id: "1A", event_id: "pressure_1a", target_turn: 2 };
+  controller.observeState(state(1, 1));
   controller.arm(milestone);
-  assert.equal(controller.deltaForRequest(), 90);
+  assert.equal(controller.turnsUntilMilestone(), 1);
 
   const outcome = controller.observeTurnResponse({
-    state: state(600, { pending_game_break: true, scene_id: "2C" }),
+    state: state(2, 2, { pending_game_break: true }),
   });
 
   assert.equal(outcome.reached, false);
-  assert.equal(outcome.elapsed_seconds, 600);
-  assert.equal(controller.history()[0].returned_elapsed_seconds, 600);
+  assert.equal(controller.history()[0].reached, false);
   assert.equal(controller.armed(), null);
 });
 
-test("uses the real elapsed value for a subsequent delta after a game break", () => {
-  const controller = createPackageClockController();
-  controller.observeState(state(600));
-  controller.arm({ kind: "pacing_event", scene_id: "2C", event_id: "purge_2c", target_seconds: 690 });
-  controller.deltaForRequest();
-  controller.observeTurnResponse({ state: state(600, { pending_game_break: true }) });
-
-  controller.arm({ kind: "scene_point", scene_id: "2D", point: "target", target_seconds: 650 });
-  assert.equal(controller.deltaForRequest(), 50);
-});
-
-test("rejects a malformed turn response state", () => {
+test("updates the observed state for an unarmed turn without fabricating history", () => {
   const controller = createPackageClockController();
 
-  assert.throws(
-    () => controller.observeTurnResponse({ state: { scene_id: "1A" } }),
-    /elapsed|missing|malformed/i,
-  );
-});
+  const outcome = controller.observeTurnResponse({ state: state(1, 1) });
 
-test("updates the anchor for an unarmed turn without fabricating history", () => {
-  const controller = createPackageClockController();
-
-  const outcome = controller.observeTurnResponse({ state: state(120) });
-
-  assert.equal(outcome.reached, false);
-  assert.equal(outcome.elapsed_seconds, 120);
-  assert.equal(outcome.requested_milestone, null);
+  assert.deepEqual(outcome, {
+    reached: false,
+    scene_id: "1A",
+    turn_index: 1,
+    turns_since_scene_entry: 1,
+    requested_milestone: null,
+  });
   assert.deepEqual(controller.history(), []);
 
-  controller.arm({ kind: "scene_point", scene_id: "1B", point: "target", target_seconds: 195 });
-  assert.equal(controller.deltaForRequest(), 75);
+  controller.arm({ kind: "scene_point", scene_id: "1A", point: "handoff", target_turn: 3 });
+  assert.equal(controller.turnsUntilMilestone(), 2);
 });
 
-test("rejects mixing package and scalar clock modes", () => {
-  assert.throws(
-    () =>
-      assertExclusiveClockMode({
-        E2E_PACKAGE_CLOCK: "package.json",
-        E2E_TEST_CLOCK_SECONDS: "120",
-      }),
-    /E2E_PACKAGE_CLOCK.*E2E_TEST_CLOCK_SECONDS|E2E_TEST_CLOCK_SECONDS.*E2E_PACKAGE_CLOCK/,
-  );
-  assert.doesNotThrow(() => assertExclusiveClockMode({ E2E_PACKAGE_CLOCK: "package.json" }));
-  assert.doesNotThrow(() => assertExclusiveClockMode({ E2E_TEST_CLOCK_SECONDS: "120" }));
-  assert.doesNotThrow(() => assertExclusiveClockMode({}));
+test("accepts a scene transition and records that the old milestone was not reached", () => {
+  const controller = createPackageClockController();
+  controller.observeState(state(2, 2));
+  controller.arm({ kind: "scene_point", scene_id: "1A", point: "handoff", target_turn: 3 });
+
+  const outcome = controller.observeTurnResponse({
+    state: state(3, 0, { scene_id: "1B" }),
+  });
+
+  assert.equal(outcome.reached, false);
+  assert.equal(controller.history()[0].scene_id, "1B");
+  assert.equal(controller.history()[0].turns_since_scene_entry, 0);
+});
+
+test("rejects malformed reported turn state", () => {
+  const controller = createPackageClockController();
+
+  for (const reportedState of [
+    { scene_id: "1A", turn_index: 1 },
+    { scene_id: "1A", turn_index: 1, turns_since_scene_entry: 1.5 },
+    { scene_id: "1A", turn_index: 1, turns_since_scene_entry: 2 },
+  ]) {
+    assert.throws(
+      () => controller.observeTurnResponse({ state: reportedState }),
+      /turn state|missing|malformed/i,
+    );
+  }
 });

--- a/frontend/e2e/package-clock-request.js
+++ b/frontend/e2e/package-clock-request.js
@@ -10,31 +10,3 @@ export function isTurnRequest(url, method) {
 
   return parsedUrl.hostname !== "api.openai.com" && parsedUrl.pathname === "/api/v1/turn";
 }
-
-export function applyTestClock(rawBody, { deltaSeconds, token } = {}) {
-  if (!Number.isInteger(deltaSeconds)) {
-    throw new Error(`Cannot apply test clock: deltaSeconds must be an integer; received ${String(deltaSeconds)}.`);
-  }
-
-  let body;
-  try {
-    body = JSON.parse(rawBody);
-  } catch (error) {
-    throw new Error(
-      `Cannot apply test clock: request body is not valid JSON (${error instanceof Error ? error.message : String(error)}).`,
-    );
-  }
-
-  if (body === null || typeof body !== "object" || Array.isArray(body)) {
-    throw new Error("Cannot apply test clock: request body must be a JSON object.");
-  }
-
-  body.test_clock_seconds = deltaSeconds;
-  if (typeof token === "string" && token.length > 0) {
-    body.test_clock_token = token;
-  } else {
-    delete body.test_clock_token;
-  }
-
-  return JSON.stringify(body);
-}

--- a/frontend/e2e/package-clock-request.test.js
+++ b/frontend/e2e/package-clock-request.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { applyTestClock, isTurnRequest } from "./package-clock-request.js";
+import { isTurnRequest } from "./package-clock-request.js";
 
 test("recognizes only the exact turn endpoint and POST method", () => {
   assert.equal(isTurnRequest("https://story.example/api/v1/turn", "POST"), true);
@@ -16,50 +16,4 @@ test("recognizes only the exact turn endpoint and POST method", () => {
   assert.equal(isTurnRequest("https://api.openai.com/v1/responses", "POST"), false);
   assert.equal(isTurnRequest("https://api.openai.com/api/v1/turn", "POST"), false);
   assert.equal(isTurnRequest("not a URL", "POST"), false);
-});
-
-test("replaces the clock fields while preserving nested command input and other fields", () => {
-  const original = {
-    session_id: "session-1",
-    player_input: { command: "inspect", args: ["desk", { side: "left" }] },
-    metadata: { tags: ["one", { enabled: true }], count: 2 },
-    test_clock_seconds: 99,
-    test_clock_token: "old-token",
-  };
-
-  const rewritten = JSON.parse(
-    applyTestClock(JSON.stringify(original), { deltaSeconds: 0, token: "new-token" }),
-  );
-
-  assert.deepEqual(rewritten, {
-    ...original,
-    test_clock_seconds: 0,
-    test_clock_token: "new-token",
-  });
-});
-
-test("omits the token field when no non-empty token is configured", () => {
-  const body = { session_id: "session-1", test_clock_token: "old-token" };
-
-  for (const token of [undefined, null, ""]) {
-    const rewritten = JSON.parse(applyTestClock(JSON.stringify(body), { deltaSeconds: 12, token }));
-    assert.equal(rewritten.test_clock_seconds, 12);
-    assert.equal(Object.hasOwn(rewritten, "test_clock_token"), false);
-  }
-});
-
-test("rejects malformed JSON with a diagnostic", () => {
-  assert.throws(
-    () => applyTestClock("{not-json", { deltaSeconds: 1 }),
-    /request body is not valid JSON/i,
-  );
-});
-
-test("rejects a non-integer clock delta with a diagnostic", () => {
-  for (const deltaSeconds of [1.5, "2", null, undefined]) {
-    assert.throws(
-      () => applyTestClock("{}", { deltaSeconds }),
-      /deltaSeconds must be an integer/i,
-    );
-  }
 });

--- a/frontend/e2e/package-clock.js
+++ b/frontend/e2e/package-clock.js
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 
 import YAML from "yaml";
 
-const PACING_POINTS = new Set(["earliest", "target", "latest"]);
+const PACING_POINTS = new Set(["min", "nudge", "handoff"]);
 
 function pacingError(storyId, pacingPath, identifier, detail) {
   return new Error(
@@ -31,7 +31,7 @@ function sequenceItems(node) {
   return Array.isArray(node?.items) ? node.items : [];
 }
 
-function timestamp(entry, field, identifier, storyId, pacingPath, entryNode) {
+function turnCount(entry, field, identifier, storyId, pacingPath, entryNode) {
   const valueNode = mappingValue(entryNode, field);
   const isDecimalInteger =
     valueNode == null ||
@@ -111,48 +111,40 @@ export function loadPackagePacing({ storyId, repoRoot, pacingPath } = {}) {
     }
 
     const entryNode = sceneNodes[index];
-    const earliest = timestamp(
+    const min = turnCount(
       entry,
-      "earliest_seconds",
+      "min_turns",
       sceneId,
       storyId,
       resolvedPacingPath,
       entryNode,
     );
-    const target = timestamp(
+    const nudge = turnCount(
       entry,
-      "target_seconds",
+      "nudge_after_turns",
       sceneId,
       storyId,
       resolvedPacingPath,
       entryNode,
     );
-    const latest = timestamp(
+    const handoff = turnCount(
       entry,
-      "latest_seconds",
+      "handoff_after_turns",
       sceneId,
       storyId,
       resolvedPacingPath,
       entryNode,
     );
-    if (earliest > latest) {
+    if (!(min <= nudge && nudge <= handoff)) {
       throw pacingError(
         storyId,
         resolvedPacingPath,
         sceneId,
-        "earliest_seconds must not exceed latest_seconds",
-      );
-    }
-    if (target < earliest || target > latest) {
-      throw pacingError(
-        storyId,
-        resolvedPacingPath,
-        sceneId,
-        "target_seconds must fall within earliest_seconds..latest_seconds",
+        "scene turn points must be ordered min_turns <= nudge_after_turns <= handoff_after_turns",
       );
     }
 
-    sceneRecords.set(sceneId, { earliest, target, latest });
+    sceneRecords.set(sceneId, { min, nudge, handoff });
     sceneOrder.push(sceneId);
   }
 
@@ -171,20 +163,20 @@ export function loadPackagePacing({ storyId, repoRoot, pacingPath } = {}) {
       throw pacingError(storyId, resolvedPacingPath, eventId, `event names undeclared scene "${sceneId}"`);
     }
 
-    const at = timestamp(
+    const at = turnCount(
       entry,
-      "at_seconds",
+      "at_turn",
       eventId,
       storyId,
       resolvedPacingPath,
       eventNodes[index],
     );
-    if (at < scene.earliest || at > scene.latest) {
+    if (at > scene.handoff) {
       throw pacingError(
         storyId,
         resolvedPacingPath,
         eventId,
-        `at_seconds must fall within scene "${sceneId}" earliest_seconds..latest_seconds`,
+        `at_turn must fall within scene "${sceneId}" 0..handoff_after_turns`,
       );
     }
     eventRecords.set(eventId, { sceneId, at });
@@ -196,9 +188,9 @@ export function loadPackagePacing({ storyId, repoRoot, pacingPath } = {}) {
     sceneMilestones.set(
       sceneId,
       new Map([
-        ["earliest", Object.freeze({ kind: "scene_point", scene_id: sceneId, point: "earliest", target_seconds: scene.earliest })],
-        ["target", Object.freeze({ kind: "scene_point", scene_id: sceneId, point: "target", target_seconds: scene.target })],
-        ["latest", Object.freeze({ kind: "scene_point", scene_id: sceneId, point: "latest", target_seconds: scene.latest })],
+        ["min", Object.freeze({ kind: "scene_point", scene_id: sceneId, point: "min", target_turn: scene.min })],
+        ["nudge", Object.freeze({ kind: "scene_point", scene_id: sceneId, point: "nudge", target_turn: scene.nudge })],
+        ["handoff", Object.freeze({ kind: "scene_point", scene_id: sceneId, point: "handoff", target_turn: scene.handoff })],
       ]),
     );
   }
@@ -206,7 +198,7 @@ export function loadPackagePacing({ storyId, repoRoot, pacingPath } = {}) {
   const eventMilestones = new Map(
     [...eventRecords].map(([eventId, event]) => [
       eventId,
-      Object.freeze({ kind: "pacing_event", scene_id: event.sceneId, event_id: eventId, target_seconds: event.at }),
+      Object.freeze({ kind: "pacing_event", scene_id: event.sceneId, event_id: eventId, target_turn: event.at }),
     ]),
   );
 

--- a/frontend/e2e/package-clock.test.js
+++ b/frontend/e2e/package-clock.test.js
@@ -39,48 +39,51 @@ function assertFixtureError(source, identifier, expectedText = identifier) {
 }
 
 const validScene = `
+budget_seconds: 60
 scenes:
   - scene_id: A
-    earliest_seconds: 0
-    target_seconds: 10
-    latest_seconds: 20
+    min_turns: 0
+    nudge_after_turns: 1
+    handoff_after_turns: 2
 events:
   - id: event_a
     scene_id: A
-    at_seconds: 15
+    at_turn: 2
 `;
 
-test("loads the real package and resolves irregular scene and event milestones", () => {
+test("loads the real package and resolves turn milestones", () => {
   const projection = loadPackagePacing({ storyId: "continuity_initiative", repoRoot });
 
   assert.deepEqual(projection.sceneOrder, ["1A", "1B", "1C", "2A", "2B", "2C", "3A", "3B", "3C"]);
-  assert.deepEqual(projection.scenePoint("1B", "earliest"), {
+  assert.deepEqual(projection.scenePoint("1B", "min"), {
     kind: "scene_point",
     scene_id: "1B",
-    point: "earliest",
-    target_seconds: 120,
+    point: "min",
+    target_turn: 2,
   });
-  assert.deepEqual(projection.scenePoint("1B", "target"), {
+  assert.deepEqual(projection.scenePoint("1B", "nudge"), {
     kind: "scene_point",
     scene_id: "1B",
-    point: "target",
-    target_seconds: 195,
+    point: "nudge",
+    target_turn: 3,
   });
-  assert.deepEqual(projection.scenePoint("1B", "latest"), {
+  assert.deepEqual(projection.scenePoint("1B", "handoff"), {
     kind: "scene_point",
     scene_id: "1B",
-    point: "latest",
-    target_seconds: 270,
+    point: "handoff",
+    target_turn: 4,
   });
   assert.deepEqual(projection.eventPoint("purge_2c"), {
     kind: "pacing_event",
     scene_id: "2C",
     event_id: "purge_2c",
-    target_seconds: 690,
+    target_turn: 2,
   });
+  assert.equal(Object.hasOwn(projection.scenePoint("1B", "min"), "target_seconds"), false);
+  assert.equal(Object.hasOwn(projection.eventPoint("purge_2c"), "target_seconds"), false);
   assert.equal(Object.isFrozen(projection), true);
   assert.equal(Object.isFrozen(projection.sceneOrder), true);
-  assert.equal(Object.isFrozen(projection.scenePoint("1B", "target")), true);
+  assert.equal(Object.isFrozen(projection.scenePoint("1B", "handoff")), true);
   assert.equal(Object.isFrozen(projection.eventPoint("purge_2c")), true);
   assert.deepEqual(Object.keys(projection), [
     "storyId",
@@ -100,8 +103,8 @@ test("reports unknown story, scene, event, and point identifiers", () => {
   );
 
   const projection = loadPackagePacing({ storyId: "continuity_initiative", repoRoot });
-  assert.throws(() => projection.scenePoint("9Z", "target"), /9Z/);
-  assert.throws(() => projection.scenePoint("1A", "midpoint"), /midpoint/);
+  assert.throws(() => projection.scenePoint("9Z", "handoff"), /9Z/);
+  assert.throws(() => projection.scenePoint("1A", "target"), /target/);
   assert.throws(() => projection.eventPoint("no_such_event"), /no_such_event/);
 });
 
@@ -123,13 +126,13 @@ test("reports duplicate scene and event identifiers", () => {
   assertFixtureError(
     `scenes:
   - scene_id: A
-    earliest_seconds: 0
-    target_seconds: 1
-    latest_seconds: 2
+    min_turns: 0
+    nudge_after_turns: 1
+    handoff_after_turns: 2
   - scene_id: A
-    earliest_seconds: 2
-    target_seconds: 3
-    latest_seconds: 4
+    min_turns: 0
+    nudge_after_turns: 1
+    handoff_after_turns: 2
 `,
     "A",
     "duplicate scene id",
@@ -137,7 +140,7 @@ test("reports duplicate scene and event identifiers", () => {
   assertFixtureError(
     `${validScene}  - id: event_a
     scene_id: A
-    at_seconds: 16
+    at_turn: 1
 `,
     "event_a",
     "duplicate event id",
@@ -147,9 +150,9 @@ test("reports duplicate scene and event identifiers", () => {
 test("reports missing scene and event identifier fields", () => {
   assertFixtureError(
     `scenes:
-  - earliest_seconds: 0
-    target_seconds: 1
-    latest_seconds: 2
+  - min_turns: 0
+    nudge_after_turns: 1
+    handoff_after_turns: 2
 `,
     "scene_id",
     "missing scene scene_id field",
@@ -157,89 +160,115 @@ test("reports missing scene and event identifier fields", () => {
   assertFixtureError(
     `scenes:
   - scene_id: A
-    earliest_seconds: 0
-    target_seconds: 1
-    latest_seconds: 2
+    min_turns: 0
+    nudge_after_turns: 1
+    handoff_after_turns: 2
 events:
   - scene_id: A
-    at_seconds: 1
+    at_turn: 1
 `,
     "event id",
     "missing event id field",
   );
 });
 
-test("reports timestamps that are not non-negative integers", () => {
+test("reports turn counts that are not non-negative integers", () => {
   assertFixtureError(
     `scenes:
   - scene_id: A
-    earliest_seconds: 0.5
-    target_seconds: 1
-    latest_seconds: 2
+    min_turns: 0.5
+    nudge_after_turns: 1
+    handoff_after_turns: 2
 `,
     "A",
-    "earliest_seconds must be a non-negative integer",
+    "min_turns must be a non-negative integer",
   );
   assertFixtureError(
     `scenes:
   - scene_id: A
-    earliest_seconds: 0
-    target_seconds: 1.0
-    latest_seconds: 2
+    min_turns: 0
+    nudge_after_turns: 2.0
+    handoff_after_turns: 2
 `,
     "A",
-    "target_seconds must be a non-negative integer",
+    "nudge_after_turns must be a non-negative integer",
   );
   assertFixtureError(
     `scenes:
   - scene_id: A
-    earliest_seconds: 0
-    target_seconds: -1
-    latest_seconds: 2
+    min_turns: 0
+    nudge_after_turns: 1
+    handoff_after_turns: -1
 `,
     "A",
-    "target_seconds must be a non-negative integer",
+    "handoff_after_turns must be a non-negative integer",
   );
   assertFixtureError(
     `scenes:
   - scene_id: A
-    earliest_seconds: 0
-    target_seconds: 1
-    latest_seconds: 2
+    min_turns: 0
+    nudge_after_turns: 1
+    handoff_after_turns: 2
 events:
   - id: event_a
     scene_id: A
-    at_seconds: 1.5
+    at_turn: 1.5
 `,
     "event_a",
-    "at_seconds must be a non-negative integer",
+    "at_turn must be a non-negative integer",
   );
 });
 
-test("reports scene and event timestamps outside their declared windows", () => {
+test("rejects the old absolute-seconds schema", () => {
   assertFixtureError(
     `scenes:
   - scene_id: A
-    earliest_seconds: 10
-    target_seconds: 9
-    latest_seconds: 20
+    earliest_seconds: 0
+    target_seconds: 1
+    latest_seconds: 2
 `,
     "A",
-    "target_seconds must fall within",
+    "min_turns must be a non-negative integer",
+  );
+});
+
+test("reports scene turn points outside their declared order", () => {
+  assertFixtureError(
+    `scenes:
+  - scene_id: A
+    min_turns: 2
+    nudge_after_turns: 1
+    handoff_after_turns: 3
+`,
+    "A",
+    "turn points must be ordered",
   );
   assertFixtureError(
     `scenes:
   - scene_id: A
-    earliest_seconds: 10
-    target_seconds: 15
-    latest_seconds: 20
+    min_turns: 0
+    nudge_after_turns: 3
+    handoff_after_turns: 2
+`,
+    "A",
+    "turn points must be ordered",
+  );
+});
+
+test("reports events outside their scene handoff window", () => {
+  assertFixtureError(
+    `scenes:
+  - scene_id: A
+    min_turns: 0
+    nudge_after_turns: 1
+    handoff_after_turns: 2
 events:
   - id: event_a
     scene_id: A
-    at_seconds: 21
+    at_turn: 3
 `,
     "event_a",
-    "at_seconds must fall within",
+    "at_turn must fall within",
   );
 });
 
@@ -247,13 +276,13 @@ test("reports events that name undeclared scenes", () => {
   assertFixtureError(
     `scenes:
   - scene_id: A
-    earliest_seconds: 0
-    target_seconds: 10
-    latest_seconds: 20
+    min_turns: 0
+    nudge_after_turns: 1
+    handoff_after_turns: 2
 events:
   - id: event_missing_scene
     scene_id: B
-    at_seconds: 10
+    at_turn: 1
 `,
     "event_missing_scene",
     "undeclared scene",

--- a/frontend/e2e/scene-runtime.spec.js
+++ b/frontend/e2e/scene-runtime.spec.js
@@ -74,18 +74,33 @@ test("drives the main spine and reports reachability and pressure @spine", async
   test.setTimeout(20 * 60_000);
   await startSceneSession(page);
   const turns = [];
+  const deliveryRecords = [];
   for (const action of spineJourney) {
     const payload = await submitTurn(page, action);
     turns.push({ scene_id: payload.state?.scene_id, elapsed_seconds: payload.state?.story_elapsed_seconds });
+    deliveryRecords.push(payload.delivery || {});
     await resolveWarningIfPresent(page);
   }
   const sceneOrder = turns.map((turn) => turn.scene_id).filter(Boolean);
+  const delivery = {
+    total_turns: deliveryRecords.length,
+    turns_with_misses: deliveryRecords.filter((record) => (record.must_convey_misses || []).length > 0).length,
+    recovery_turns: deliveryRecords.filter((record) => record.recovery_used === true).length,
+    fallback_turns: deliveryRecords.filter((record) => record.fallback_used === true).length,
+    miss_tally: {},
+  };
+  for (const record of deliveryRecords) {
+    for (const factId of record.must_convey_misses || []) {
+      delivery.miss_tally[factId] = (delivery.miss_tally[factId] || 0) + 1;
+    }
+  }
   await writeCategoryReport("spine", {
     ending_reachable: sceneOrder.at(-1) === "3C",
     dead_end: !sceneOrder.length,
     revelation_order: sceneOrder,
     pressure_trajectory: turns,
     distinct_paths_to_climax: [sceneOrder.join(">")],
+    delivery,
   });
   expect(sceneOrder.every((scene) => /^[123][ABC]$/.test(scene))).toBe(true);
   expect(sceneOrder.at(-1)).toBe("3C");

--- a/frontend/e2e/scene-runtime.spec.js
+++ b/frontend/e2e/scene-runtime.spec.js
@@ -111,33 +111,39 @@ test("judges every reached scene against the five-file narrative canon @llm-cano
   test.skip(!process.env.E2E_PACKAGE_CLOCK, "requires the opt-in package E2E game clock");
   test.setTimeout(20 * 60_000);
   const pacing = loadPackagePacing({ storyId: "continuity_initiative" });
-  const controller = await installPackageClock(page, {
-    pacing,
-    token: process.env.FREYTAG_TEST_CLOCK_TOKEN,
-  });
+  const controller = await installPackageClock(page);
   await startSceneSession(page);
   const opening = (await page.locator(".entry-output").first().textContent())?.trim() || "";
   const byScene = new Map([["1A", { opening, turns: [] }]]);
   const sceneOrder = pacing.sceneOrder;
   let sceneId = "1A";
-  let elapsed = 0;
+  let turnIndex = 0;
+  let turnsSinceSceneEntry = 0;
   let stalledTurns = 0;
   let lastCommittedCount = 0;
   const promptsUsed = new Map();
   const progress = [];
+  const firedPacingEventIds = new Set();
 
-  // The clock follows the story, never the other way round. A scene needs
-  // several turns to earn its outgoing bridge, so time advances only as far as
-  // the next scene's authored entry window and then holds until the story is
-  // ready. Advancing on every turn instead lets the clock outrun the spine and
-  // strands scene-bound pacing events in a scene the story has not reached.
-  const clockTargetFor = (currentSceneId, currentElapsed) => {
-    const next = sceneOrder[sceneOrder.indexOf(currentSceneId) + 1];
-    const goal = next
-      ? pacing.scenePoint(next, "earliest")
-      : pacing.scenePoint(currentSceneId, "target");
-    if (goal.target_seconds > currentElapsed) return goal;
-    return { kind: "scene_point", scene_id: currentSceneId, point: "hold", target_seconds: currentElapsed };
+  const turnMilestoneFor = (currentSceneId, currentTurns) => {
+    const pendingEvent = pacing.eventOrder
+      .map((eventId) => pacing.eventPoint(eventId))
+      .find(
+        (event) =>
+          event.scene_id === currentSceneId &&
+          !firedPacingEventIds.has(event.event_id) &&
+          event.target_turn >= currentTurns,
+      );
+    if (pendingEvent) return pendingEvent;
+
+    const min = pacing.scenePoint(currentSceneId, "min");
+    const nudge = pacing.scenePoint(currentSceneId, "nudge");
+    const handoff = pacing.scenePoint(currentSceneId, "handoff");
+    if (currentTurns < min.target_turn) return min;
+    if (currentTurns < nudge.target_turn) return nudge;
+    if (currentTurns < handoff.target_turn) return handoff;
+    if (currentSceneId === sceneOrder.at(-1)) return null;
+    throw new Error(`Scene ${currentSceneId} exceeded its handoff turn ${String(handoff.target_turn)}.`);
   };
 
   for (let index = 0; index < MAX_CANON_TURNS; index += 1) {
@@ -145,25 +151,25 @@ test("judges every reached scene against the five-file narrative canon @llm-cano
     const sourceSceneId = sceneId;
     const used = promptsUsed.get(sourceSceneId) || 0;
     const input = promptFor(sourceSceneId, used);
-    const milestone = clockTargetFor(sourceSceneId, elapsed);
-    await test.step(`turn ${index + 1}: scene ${sourceSceneId} at ${milestone.target_seconds}s`, async () => {
-      controller.arm(milestone);
+    const milestone = turnMilestoneFor(sourceSceneId, turnsSinceSceneEntry);
+    await test.step(`turn ${index + 1}: scene ${sourceSceneId} at turn ${turnsSinceSceneEntry}`, async () => {
+      if (milestone) controller.arm(milestone);
+      const turnsUntilMilestone = milestone ? controller.turnsUntilMilestone() : null;
       const payload = await submitTurn(page, input);
-      const warningResolved = await resolveWarningIfPresent(page);
-      const timing = controller.history().at(-1);
-      const observedElapsed = payload.state?.story_elapsed_seconds;
-      if (!timing?.reached) {
+      await resolveWarningIfPresent(page);
+      const timing = milestone ? controller.history().at(-1) : null;
+      const observedTurns = payload.state?.turns_since_scene_entry;
+      const reachedSameScene = payload.state?.scene_id === sourceSceneId;
+      if (milestone && reachedSameScene && observedTurns > milestone.target_turn) {
         throw new Error(
-          `Package clock missed ${milestone.kind} ${milestone.event_id || `${milestone.scene_id} ${milestone.point}`}; observed elapsed ${String(observedElapsed)} (pending game break: ${String(payload.state?.pending_game_break === true)}, warning resolved: ${String(warningResolved)}).`,
+          `Turn milestone ${milestone.kind} ${milestone.event_id || `${milestone.scene_id} ${milestone.point}`} was overshot: observed scene-relative turn ${String(observedTurns)} after ${String(turnsUntilMilestone)} turns were needed.`,
         );
       }
 
       const narration = narrationText(payload);
       const reachedSceneId = payload.state?.scene_id;
       promptsUsed.set(sourceSceneId, used + 1);
-      expect(payload.state?.story_elapsed_seconds, `Turn ${index + 1} missed its package milestone.`).toBe(
-        milestone.target_seconds,
-      );
+      expect(payload.state?.turn_index).toBe(turnIndex + 1);
 
       // The spine may pause in a scene or step forward exactly one scene, never
       // backward and never skipping an authored scene.
@@ -179,9 +185,10 @@ test("judges every reached scene against the five-file narrative canon @llm-cano
       for (const eventId of pacing.eventOrder) {
         const event = pacing.eventPoint(eventId);
         const eventScene = sceneOrder.indexOf(event.scene_id);
-        const inScenePastDue = eventScene === to && observedElapsed >= event.target_seconds;
+        const inScenePastDue = eventScene === to && observedTurns >= event.target_turn;
         if (!inScenePastDue && eventScene >= to) continue;
         expect(payload.state?.fired_pacing_event_ids, `Turn ${index + 1} is missing pacing event ${eventId}.`).toContain(eventId);
+        firedPacingEventIds.add(eventId);
       }
 
       // A scene that commits nothing several turns running is stalled: the reveals
@@ -215,7 +222,8 @@ test("judges every reached scene against the five-file narrative canon @llm-cano
         byScene.set(reachedSceneId, { opening: segments.at(-1).text.trim(), turns: [] });
       }
       sceneId = reachedSceneId;
-      elapsed = observedElapsed;
+      turnIndex = payload.state?.turn_index;
+      turnsSinceSceneEntry = payload.state?.turns_since_scene_entry;
       progress.push({
         turn: index + 1,
         input,
@@ -299,12 +307,14 @@ test("samples optional storylets without presenting a menu @storylets", async ({
   expect(fired.size).toBeGreaterThan(0);
 });
 
-test("advances declared pressure with the opt-in E2E clock instead of wall-clock waiting @timed-events", async ({ page }) => {
+test("keeps the display budget clock independent from turn-based pressure @timed-events", async ({ page }) => {
   test.skip(!process.env.E2E_TEST_CLOCK_SECONDS, "requires the local test clock");
   await startSceneSession(page);
-  const payload = await submitTurn(page, "I pause long enough for the house's pressure to build.");
+  await submitTurn(page, "I pause long enough for the house's pressure to build.");
+  const payload = await submitTurn(page, "I listen for the pressure that follows.");
   await writeCategoryReport("timed-events", { state: payload.state });
   expect(payload.state?.story_elapsed_seconds).toBeGreaterThanOrEqual(120);
+  expect(payload.state?.turn_index).toBe(2);
   expect(payload.state?.fired_pacing_event_ids).toContain("pressure_1a");
 });
 

--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -16,6 +16,7 @@ from storygame.runtime.contracts import (
 )
 from storygame.runtime.knowledge import KnowledgeProjector, TurnKnowledgeContext
 from storygame.runtime.state import RuntimeState
+from storygame.runtime.validation import unconveyed_terms
 from storygame.story_package.models import Scene, SceneBeat, SceneMetadata
 
 
@@ -111,8 +112,10 @@ class CloudflareTurnProvider:
                 "you MUST reveal it by placing exactly that one ID in selected_knowledge_ids - narrating the "
                 "moment without selecting it leaves the story unable to move on. You must also tell it: one of your "
                 "segments has to state, in the narration the player reads, what that candidate's statement says, and "
-                "that segment must list the ID in its grounding_ids. Selecting a reveal the narration never delivers "
-                "is rejected. Leave the list empty only when none of them fits what just happened."
+                "that segment must list the ID in its grounding_ids. Every must_convey synonym group shown for the "
+                "candidate must appear through at least one of its phrasings in that grounded narration. Selecting a "
+                "reveal the narration never delivers is rejected. Leave the list empty only when none of them fits "
+                "what just happened."
             )
         else:
             selection_rule = (
@@ -335,6 +338,21 @@ class CloudflareTurnProvider:
                 "learn it. Resend with a segment whose text actually states what that reveal says, listing that ID "
                 "in its grounding_ids - or, if the player has not earned it yet, with selected_knowledge_ids empty.",
             )
+        candidates = {candidate.id: candidate for candidate in self.last_projection.candidates}
+        for knowledge_id in proposal.selected_knowledge_ids:
+            candidate = candidates[knowledge_id]
+            grounded_text = " ".join(
+                segment.text for segment in proposal.segments if knowledge_id in segment.grounding_ids
+            )
+            missing = unconveyed_terms(candidate.must_convey, grounded_text)
+            if missing:
+                missing_text = ", ".join(missing)
+                raise _EligibilityError(
+                    f"selected knowledge does not convey: {missing_text}",
+                    f"You selected {knowledge_id}, but its grounded narration is missing: {missing_text}. "
+                    "Resend with a segment whose text conveys every must_convey group for that candidate and lists "
+                    f"{knowledge_id} in its grounding_ids, or use an empty selected_knowledge_ids list.",
+                )
         return proposal
 
     def _speaker_contexts(self, player_input: str) -> dict[str, dict[str, object]]:

--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -122,6 +122,27 @@ class CloudflareTurnProvider:
                 "This turn offers no candidates: selected_knowledge_ids MUST be an empty list. Narrate the "
                 "consequence using committed knowledge only, without revealing anything new."
             )
+        hinted = self.last_projection.hinted_deliveries if self.last_projection else ()
+        handoffs = self.last_projection.handoff_deliveries if self.last_projection else ()
+        if handoffs:
+            handoff_rule = (
+                "This is a HANDOFF turn. Write the declared diegetic intervention for every handoff delivery exactly "
+                "from its contract: use each delivery's source_kind and source_entity_id when present, and convey "
+                "every must_convey synonym group. The intervention may be a message, NPC statement, broadcast, "
+                "observation, or inference as declared. Do not claim that the player took an action they did not "
+                "take. Answer the player's input directly in the same narration; the handoff is an intervention "
+                "alongside that response. You do not choose the facts, source kind, source entity, costs, bridge "
+                "event, or transition."
+            )
+        elif hinted:
+            handoff_rule = (
+                "This is a HINT turn. Surface the missing evidence as something the player can still act on: an NPC "
+                "remark, a noticed detail, or a radio call that points without concluding. State nothing as "
+                "established, commit no fact, preserve the player's agency, and do not claim that the player took "
+                "an action they did not take."
+            )
+        else:
+            handoff_rule = "This is neither a hint nor a handoff turn."
         return (
             "Return one JSON TurnProposal matching response_schema. Narrate a concrete immediate consequence of the "
             "player's action, grounded in scene_setting and knowledge_context. Answer what the player actually did: "
@@ -131,7 +152,7 @@ class CloudflareTurnProvider:
             "or invent durable evidence. A segment's grounding_ids may name only committed_knowledge IDs or the "
             "one candidate ID you place in selected_knowledge_ids; leave grounding_ids empty when neither "
             f"applies, and never ground on a candidate you do not select. Dialogue may use only its speaker's "
-            f"sayable context. {selection_rule} Never return "
+            f"sayable context. {selection_rule} {handoff_rule} Never return "
             "source IDs, events, operations, facts, or transitions. Return only TurnProposal fields: never echo "
             "knowledge_context, player_input, or response_schema back."
         )
@@ -253,6 +274,8 @@ class CloudflareTurnProvider:
             self._parse_eligible_proposal(response)
         except _EligibilityError:
             proposal = parse_turn_proposal(response)
+            if self.last_projection and self.last_projection.handoff_deliveries:
+                return self._fallback_handoff()
             return {
                 "segments": [
                     {
@@ -265,6 +288,8 @@ class CloudflareTurnProvider:
                 "selected_knowledge_ids": [],
             }
         except RuntimeContractError as error:
+            if self.last_projection and self.last_projection.handoff_deliveries:
+                return self._fallback_handoff()
             summary = contract_error_summary(error) or "invalid proposal"
             raise NarrationProviderError(
                 f"narration service returned an invalid proposal ({summary})",
@@ -353,7 +378,30 @@ class CloudflareTurnProvider:
                     "Resend with a segment whose text conveys every must_convey group for that candidate and lists "
                     f"{knowledge_id} in its grounding_ids, or use an empty selected_knowledge_ids list.",
                 )
+        missing_handoff = self._missing_handoff_terms(proposal.narration)
+        if missing_handoff:
+            missing_text = ", ".join(missing_handoff)
+            raise _EligibilityError(
+                f"handoff narration does not convey: {missing_text}",
+                "This is a HANDOFF turn. Your narration must convey every missed handoff group: "
+                f"{missing_text}. Keep the player's direct response and write the declared intervention; do not "
+                "select facts or a transition.",
+            )
         return proposal
+
+    def _missing_handoff_terms(self, narration: str) -> tuple[str, ...]:
+        deliveries = self.last_projection.handoff_deliveries if self.last_projection else ()
+        missing: list[str] = []
+        for delivery in deliveries:
+            missing.extend(unconveyed_terms(delivery.must_convey, narration))
+        return tuple(missing)
+
+    def _fallback_handoff(self) -> dict[str, object]:
+        deliveries = self.last_projection.handoff_deliveries if self.last_projection else ()
+        return {
+            "segments": [{"kind": "narration", "text": delivery.fallback_text} for delivery in deliveries],
+            "selected_knowledge_ids": [],
+        }
 
     def _speaker_contexts(self, player_input: str) -> dict[str, dict[str, object]]:
         """Send each speaker only what bounds their dialogue.

--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -73,6 +73,13 @@ class CloudflareTurnProvider:
 
     def __call__(self, player_input: str) -> object:
         self.last_projection = self.projector.project(self.state, "player", player_input)
+        handoff_staged = bool(self.last_projection.handoff_deliveries)
+        self.state.last_turn_delivery = self.state.last_turn_delivery.model_copy(
+            update={
+                "hint_staged": bool(self.last_projection.hinted_deliveries),
+                "handoff_staged": handoff_staged,
+            }
+        )
         speaker_contexts = self._speaker_contexts(player_input)
         return self._dispatch(
             self._turn_instruction(),
@@ -232,6 +239,7 @@ class CloudflareTurnProvider:
             return response
 
         fallback_payload = {key: value for key, value in payload.items() if key != "response_format"}
+        self._record_recovery()
         try:
             response = self._request_allowing_one_transient_retry(fallback_payload)
         except HTTPError as error:
@@ -251,6 +259,7 @@ class CloudflareTurnProvider:
                 "groundable, omit grounding_ids entirely."
             ),
         }
+        self._record_recovery()
         try:
             response = self._request_allowing_one_transient_retry(recovery_payload)
         except HTTPError as error:
@@ -371,6 +380,7 @@ class CloudflareTurnProvider:
             )
             missing = unconveyed_terms(candidate.must_convey, grounded_text)
             if missing:
+                self._record_misses((knowledge_id,))
                 missing_text = ", ".join(missing)
                 raise _EligibilityError(
                     f"selected knowledge does not convey: {missing_text}",
@@ -380,6 +390,14 @@ class CloudflareTurnProvider:
                 )
         missing_handoff = self._missing_handoff_terms(proposal.narration)
         if missing_handoff:
+            deliveries = self.last_projection.handoff_deliveries if self.last_projection else ()
+            self._record_misses(
+                tuple(
+                    delivery.fact_id
+                    for delivery in deliveries
+                    if unconveyed_terms(delivery.must_convey, proposal.narration)
+                )
+            )
             missing_text = ", ".join(missing_handoff)
             raise _EligibilityError(
                 f"handoff narration does not convey: {missing_text}",
@@ -398,10 +416,22 @@ class CloudflareTurnProvider:
 
     def _fallback_handoff(self) -> dict[str, object]:
         deliveries = self.last_projection.handoff_deliveries if self.last_projection else ()
+        self.state.last_turn_delivery = self.state.last_turn_delivery.model_copy(update={"fallback_used": True})
         return {
             "segments": [{"kind": "narration", "text": delivery.fallback_text} for delivery in deliveries],
             "selected_knowledge_ids": [],
         }
+
+    def _record_misses(self, ids: tuple[str, ...]) -> None:
+        existing = self.state.last_turn_delivery.must_convey_misses
+        additions = tuple(item for item in ids if item not in existing)
+        if additions:
+            self.state.last_turn_delivery = self.state.last_turn_delivery.model_copy(
+                update={"must_convey_misses": (*existing, *additions)}
+            )
+
+    def _record_recovery(self) -> None:
+        self.state.last_turn_delivery = self.state.last_turn_delivery.model_copy(update={"recovery_used": True})
 
     def _speaker_contexts(self, player_input: str) -> dict[str, dict[str, object]]:
         """Send each speaker only what bounds their dialogue.

--- a/storygame/runtime/engine.py
+++ b/storygame/runtime/engine.py
@@ -52,6 +52,7 @@ class RuntimeEngine:
         """Call the provider once, then validate before any canonical mutation."""
 
         self.state.require_turn_allowed()
+        self.state.turn_index += 1
         self._activate_pacing()
         self.last_projection = self.projector.project(self.state, "player", player_input)
         provider_proposal = parse_turn_proposal(self.provider(player_input))
@@ -132,18 +133,18 @@ class RuntimeEngine:
     def _apply_authored_transition(self) -> str | None:
         """Advance along the highest-priority authored transition once its declared triggers hold.
 
-        The target scene's earliest_seconds is a hard pacing floor so committed
-        triggers cannot rush the story ahead of its authored 20-minute budget.
+        The source scene's min_turns is a hard pacing floor so committed
+        triggers cannot rush the player out before the scene has had its minimum play.
         Returns the entered scene's authored entry text so the turn can open the
         new scene with the package's own words.
         """
 
         if self.state.has_pending_break:
             return None
-        elapsed = self._elapsed_seconds()
+        turns_since_entry = self.state.turn_index - self.state.scene_entered_at_turn
         windows = {window.scene_id: window for window in self.state.package.pacing.scenes}
         for transition in self.validator.eligible_transitions(self.state):
-            if elapsed < windows[transition.target_scene_id].earliest_seconds:
+            if turns_since_entry < windows[transition.source_scene_id].min_turns:
                 continue
             if not self.validator.transition_dependencies_available(transition, self.state.facts):
                 continue
@@ -162,11 +163,11 @@ class RuntimeEngine:
     def _activate_pacing(self) -> None:
         """Activate only package-declared, scene-bound optional storylets."""
 
-        elapsed = self._elapsed_seconds()
+        turns_since_entry = self.state.turn_index - self.state.scene_entered_at_turn
         for storylet in self.state.package.storylet_routes.storylets:
             if (
                 storylet.scene_id == self.state.current_scene_id
-                and storylet.earliest_seconds <= elapsed
+                and storylet.earliest_turn <= turns_since_entry
                 and all(self._predicate_matches(predicate) for predicate in storylet.activation_conditions)
                 and storylet.id not in self.state.fired_event_ids
             ):
@@ -175,7 +176,7 @@ class RuntimeEngine:
             if (
                 event.scene_id == self.state.current_scene_id
                 and event.id not in self.state.fired_event_ids
-                and elapsed >= event.at_seconds
+                and turns_since_entry >= event.at_turn
             ):
                 for effect in event.effects:
                     self.state.facts.assert_fact(

--- a/storygame/runtime/engine.py
+++ b/storygame/runtime/engine.py
@@ -202,7 +202,10 @@ class RuntimeEngine:
         for event in events:
             if event.scene_id != self.state.current_scene_id or event.id in self.state.fired_event_ids:
                 continue
-            if not all(self._predicate_matches(predicate) for predicate in event.activation_conditions):
+            true_facts = frozenset(
+                fact.predicate for fact in self.state.facts.asserted if str(fact.value).lower() == "true"
+            )
+            if not event.activation.is_satisfied(true_facts):
                 continue
             operations = tuple(
                 FactOperation(

--- a/storygame/runtime/engine.py
+++ b/storygame/runtime/engine.py
@@ -9,12 +9,19 @@ from storygame.runtime.contracts import (
     GameBreakWarning,
     NarrationSegment,
     ResolvedTurnProposal,
+    SceneTransitionProposal,
     parse_turn_proposal,
 )
 from storygame.runtime.facts import Fact
 from storygame.runtime.knowledge import KnowledgeProjector, TurnKnowledgeContext
 from storygame.runtime.state import RuntimeState, TurnRecord
-from storygame.runtime.validation import ProgressionValidator, SelectedRevealResolver
+from storygame.runtime.validation import (
+    ProgressionValidator,
+    SelectedRevealResolver,
+    predicate_matches,
+    unconveyed_terms,
+)
+from storygame.story_package.models import FactDelivery
 
 SCENE_ENTRY_REQUEST = "Narrate the opening of this scene."
 
@@ -69,18 +76,20 @@ class RuntimeEngine:
             )
             self.state.set_pending_break(warning, proposal=proposal)
             return proposal.model_copy(update={"game_break": warning})
-        self.state.apply_proposal(proposal)
+        canonical_event_id = None
+        if self.state.staged_handoff_fact_ids and not provider_proposal.selected_knowledge_ids:
+            proposal, canonical_event_id = self._prepare_handoff(proposal)
+        self.state.apply_proposal(proposal, canonical_event_ids=(canonical_event_id,) if canonical_event_id else ())
         self._record_turn(proposal)
         self._advance_pacing(proposal.narrative_seconds if clock_seconds is None else clock_seconds)
         self._activate_pacing()
-        self._apply_canonical_route_events()
+        if not (canonical_event_id and proposal.transition):
+            self._apply_canonical_route_events()
         self._activate_pacing()
-        entry_text = self._apply_authored_transition()
+        entry_segments = self._apply_authored_transition()
         self._activate_pacing()
-        if entry_text:
-            return proposal.model_copy(
-                update={"segments": (*proposal.segments, NarrationSegment(kind="narration", text=entry_text))}
-            )
+        if entry_segments:
+            return proposal.model_copy(update={"segments": (*proposal.segments, *entry_segments)})
         return proposal
 
     def _record_turn(self, proposal: ResolvedTurnProposal) -> None:
@@ -130,13 +139,13 @@ class RuntimeEngine:
             self._apply_authored_transition()
             self._activate_pacing()
 
-    def _apply_authored_transition(self) -> str | None:
+    def _apply_authored_transition(self) -> tuple[NarrationSegment, ...] | None:
         """Advance along the highest-priority authored transition once its declared triggers hold.
 
         The source scene's min_turns is a hard pacing floor so committed
         triggers cannot rush the player out before the scene has had its minimum play.
-        Returns the entered scene's authored entry text so the turn can open the
-        new scene with the package's own words.
+        Returns the source bridge and entered scene's authored entry as two
+        narration segments so both package-owned paragraphs reach the player.
         """
 
         if self.state.has_pending_break:
@@ -151,13 +160,18 @@ class RuntimeEngine:
             scene = next(
                 item for item in self.state.package.scenes if item.metadata.scene_id == transition.target_scene_id
             )
+            source_scene = next(
+                item for item in self.state.package.scenes if item.metadata.scene_id == transition.source_scene_id
+            )
+            bridge = NarrationSegment(kind="narration", text=source_scene.metadata.bridge_text[transition.id])
+            entry = NarrationSegment(kind="narration", text=scene.metadata.entry_text)
             self.state.apply_proposal(
                 ResolvedTurnProposal(
-                    segments=(NarrationSegment(kind="narration", text=scene.metadata.entry_text),),
+                    segments=(bridge, entry),
                     transition={"transition_id": transition.id},
                 )
             )
-            return scene.metadata.entry_text
+            return bridge, entry
         return None
 
     def _activate_pacing(self) -> None:
@@ -172,6 +186,7 @@ class RuntimeEngine:
                 and storylet.id not in self.state.fired_event_ids
             ):
                 self.state.active_event_ids.add(storylet.id)
+        self._apply_world_actions()
         for event in self.state.package.pacing.events:
             if (
                 event.scene_id == self.state.current_scene_id
@@ -194,6 +209,198 @@ class RuntimeEngine:
                             transition={"transition_id": event.transition_id},
                         )
                     )
+        windows = {window.scene_id: window for window in self.state.package.pacing.scenes}
+        window = windows[self.state.current_scene_id]
+        turns_since_entry = self.state.turn_index - self.state.scene_entered_at_turn
+        missing = self._bridge_delivery_fact_ids()
+        if turns_since_entry >= window.nudge_after_turns:
+            self.state.staged_hint_fact_ids = missing
+        if turns_since_entry >= window.handoff_after_turns:
+            self.state.staged_handoff_fact_ids = missing
+
+    def _bridge_delivery_fact_ids(self) -> tuple[str, ...]:
+        true_facts = frozenset(
+            fact.predicate for fact in self.state.facts.asserted if str(fact.value).lower() == "true"
+        )
+        deliveries = {delivery.fact_id for delivery in self.state.package.deliveries}
+        for event in self.state.package.storylet_routes.bridge_events:
+            if event.scene_id != self.state.current_scene_id or event.id in self.state.fired_event_ids:
+                continue
+            if event.activation.is_satisfied(true_facts):
+                continue
+            missing = event.activation.minimal_undelivered_facts(true_facts)
+            return tuple(fact_id for fact_id in missing if fact_id in deliveries)
+        return ()
+
+    def _apply_world_actions(self) -> None:
+        """Apply active, player-hidden route effects once their prerequisites hold."""
+
+        for knowledge in self.state.package.knowledge.knowledge:
+            if (
+                knowledge.audience.kind != "world_only"
+                or self.state.current_scene_id not in knowledge.available_in_scenes
+                or knowledge.source.storylet_id not in self.state.active_event_ids
+                or knowledge.source.storylet_id in self.state.fired_event_ids
+                or not all(predicate_matches(predicate, self.state.facts) for predicate in knowledge.requires)
+                or not any(
+                    self._knowledge_effect_established(effect.fact_id, effect.op, effect.value)
+                    for effect in knowledge.establishes
+                )
+            ):
+                continue
+            for effect in knowledge.establishes:
+                fact = Fact(predicate=effect.fact_id, subject="story", value=str(effect.value).lower())
+                if effect.op == "assert":
+                    self.state.facts.assert_fact(fact)
+                else:
+                    self.state.facts.retract_fact(fact)
+
+    def _knowledge_effect_established(self, fact_id: str, operation: str, value: object) -> bool:
+        expected = str(value).lower()
+        matched = any(
+            (fact.value if fact.value is not None else fact.object) == expected
+            for fact in self.state.facts.matching(fact_id)
+        )
+        return matched if operation == "assert" else not matched
+
+    def _prepare_handoff(self, proposal: ResolvedTurnProposal) -> tuple[ResolvedTurnProposal, str | None]:
+        deliveries = {
+            delivery.fact_id: delivery
+            for delivery in self.state.package.deliveries
+            if delivery.fact_id in self.state.staged_handoff_fact_ids
+        }
+        segments = proposal.segments
+        missing = self._missing_handoff_terms(deliveries.values(), proposal.narration)
+        if missing:
+            segments = tuple(
+                NarrationSegment(kind="narration", text=delivery.fallback_text) for delivery in deliveries.values()
+            )
+        delivery_operations = tuple(
+            operation for delivery in deliveries.values() for operation in self._delivery_operations(delivery)
+        )
+        candidate_facts = self.state.facts.clone()
+        for operation in (*proposal.operations, *delivery_operations):
+            self.state._apply_operation(candidate_facts, operation)
+        for event in proposal.events:
+            for operation in event.operations:
+                self.state._apply_operation(candidate_facts, operation)
+        world_operations = self._world_action_operations(candidate_facts)
+        for operation in world_operations:
+            self.state._apply_operation(candidate_facts, operation)
+        bridge_event = next(
+            (
+                event
+                for event in self.state.package.storylet_routes.bridge_events
+                if event.scene_id == self.state.current_scene_id
+                and event.id not in self.state.fired_event_ids
+                and event.activation.is_satisfied(self._true_facts(candidate_facts))
+            ),
+            None,
+        )
+        bridge_operations = (
+            tuple(
+                FactOperation(
+                    operation=operation.op,
+                    fact=Fact(predicate=operation.fact_id, subject="story", value=str(operation.value).lower()),
+                )
+                for operation in bridge_event.operations
+            )
+            if bridge_event
+            else ()
+        )
+        for operation in bridge_operations:
+            self.state._apply_operation(candidate_facts, operation)
+        transition = self._handoff_transition(candidate_facts) if bridge_event else None
+        if transition:
+            source_scene = next(
+                item for item in self.state.package.scenes if item.metadata.scene_id == transition.source_scene_id
+            )
+            target_scene = next(
+                item for item in self.state.package.scenes if item.metadata.scene_id == transition.target_scene_id
+            )
+            segments = (
+                *segments,
+                NarrationSegment(kind="narration", text=source_scene.metadata.bridge_text[transition.id]),
+                NarrationSegment(kind="narration", text=target_scene.metadata.entry_text),
+            )
+        combined = proposal.model_copy(
+            update={
+                "segments": segments,
+                "operations": (*proposal.operations, *delivery_operations, *world_operations, *bridge_operations),
+                "transition": SceneTransitionProposal(transition_id=transition.id) if transition else None,
+            }
+        )
+        return combined, bridge_event.id if bridge_event else None
+
+    @staticmethod
+    def _true_facts(facts) -> frozenset[str]:
+        return frozenset(fact.predicate for fact in facts.asserted if str(fact.value).lower() == "true")
+
+    @staticmethod
+    def _delivery_operations(delivery: FactDelivery) -> tuple[FactOperation, ...]:
+        operations = [
+            FactOperation(operation="assert", fact=Fact(predicate=delivery.fact_id, subject="story", value="true"))
+        ]
+        operations.extend(
+            FactOperation(
+                operation=cost.op,
+                fact=Fact(predicate=cost.fact_id, subject="story", value=str(cost.value).lower()),
+            )
+            for cost in delivery.costs
+        )
+        return tuple(operations)
+
+    def _world_action_operations(self, facts) -> tuple[FactOperation, ...]:
+        operations: list[FactOperation] = []
+        for knowledge in self.state.package.knowledge.knowledge:
+            if (
+                knowledge.audience.kind != "world_only"
+                or self.state.current_scene_id not in knowledge.available_in_scenes
+                or knowledge.source.storylet_id not in self.state.active_event_ids
+                or knowledge.source.storylet_id in self.state.fired_event_ids
+                or not all(predicate_matches(predicate, facts) for predicate in knowledge.requires)
+                or all(
+                    self._fact_operation_established(facts, effect.op, effect.fact_id, effect.value)
+                    for effect in knowledge.establishes
+                )
+            ):
+                continue
+            operations.extend(
+                FactOperation(
+                    operation=effect.op,
+                    fact=Fact(predicate=effect.fact_id, subject="story", value=str(effect.value).lower()),
+                )
+                for effect in knowledge.establishes
+            )
+        return tuple(operations)
+
+    @staticmethod
+    def _fact_operation_established(facts, operation: str, fact_id: str, value: object) -> bool:
+        expected = str(value).lower()
+        matched = any(
+            (fact.value if fact.value is not None else fact.object) == expected for fact in facts.matching(fact_id)
+        )
+        return matched if operation == "assert" else not matched
+
+    @staticmethod
+    def _missing_handoff_terms(deliveries, narration: str) -> tuple[str, ...]:
+        missing: list[str] = []
+        for delivery in deliveries:
+            missing.extend(unconveyed_terms(delivery.must_convey, narration))
+        return tuple(missing)
+
+    def _handoff_transition(self, facts):
+        turns_since_entry = self.state.turn_index - self.state.scene_entered_at_turn
+        windows = {window.scene_id: window for window in self.state.package.pacing.scenes}
+        eligible = [
+            transition
+            for transition in self.state.package.pacing.transitions
+            if transition.source_scene_id == self.state.current_scene_id
+            and turns_since_entry >= windows[transition.source_scene_id].min_turns
+            and all(predicate_matches(trigger, facts) for trigger in transition.triggers)
+            and self.validator.transition_dependencies_available(transition, facts)
+        ]
+        return max(eligible, key=lambda transition: transition.priority, default=None)
 
     def _apply_canonical_route_events(self) -> None:
         """Commit only route-authored bridge/resolution facts once their conditions hold."""

--- a/storygame/runtime/engine.py
+++ b/storygame/runtime/engine.py
@@ -14,7 +14,7 @@ from storygame.runtime.contracts import (
 )
 from storygame.runtime.facts import Fact
 from storygame.runtime.knowledge import KnowledgeProjector, TurnKnowledgeContext
-from storygame.runtime.state import RuntimeState, TurnRecord
+from storygame.runtime.state import RuntimeState, TurnDelivery, TurnRecord
 from storygame.runtime.validation import (
     ProgressionValidator,
     SelectedRevealResolver,
@@ -59,8 +59,15 @@ class RuntimeEngine:
         """Call the provider once, then validate before any canonical mutation."""
 
         self.state.require_turn_allowed()
+        self.state.last_turn_delivery = TurnDelivery()
         self.state.turn_index += 1
         self._activate_pacing()
+        self.state.last_turn_delivery = self.state.last_turn_delivery.model_copy(
+            update={
+                "hint_staged": bool(self.state.staged_hint_fact_ids),
+                "handoff_staged": bool(self.state.staged_handoff_fact_ids),
+            }
+        )
         self.last_projection = self.projector.project(self.state, "player", player_input)
         provider_proposal = parse_turn_proposal(self.provider(player_input))
         proposal, self.last_post_selection_projection = self.reveal_resolver.resolve(

--- a/storygame/runtime/knowledge.py
+++ b/storygame/runtime/knowledge.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict
 
 from storygame.runtime.state import RuntimeState
 from storygame.runtime.validation import predicate_matches
-from storygame.story_package.models import KnowledgeDefinition
+from storygame.story_package.models import FactDelivery, KnowledgeDefinition
 
 
 class _KnowledgeModel(BaseModel):
@@ -41,6 +41,8 @@ class TurnKnowledgeContext(_KnowledgeModel):
     referenced_entity_ids: tuple[str, ...]
     continuity_ids: tuple[str, ...]
     candidates: tuple[RevealCandidate, ...]
+    hinted_deliveries: tuple[FactDelivery, ...] = ()
+    handoff_deliveries: tuple[FactDelivery, ...] = ()
 
     def payload_size(self) -> int:
         return len(self.model_dump_json(exclude={"sayable_knowledge"}).encode())
@@ -90,6 +92,7 @@ class KnowledgeProjector:
         established_ids = tuple(sorted({entity_id for item in committed for entity_id in item.entity_ids}))
         referenced_ids = self._referenced_established_ids(state, player_input, established_ids)
         candidates = self._candidates(state, audience_id, referenced_ids)
+        deliveries = {delivery.fact_id: delivery for delivery in state.package.deliveries}
         return TurnKnowledgeContext(
             scene_id=state.current_scene_id,
             phase=state.phase,
@@ -102,6 +105,12 @@ class KnowledgeProjector:
             referenced_entity_ids=referenced_ids,
             continuity_ids=tuple(record.id for record in state.turn_records[-self.max_continuity_records :]),
             candidates=candidates,
+            hinted_deliveries=tuple(
+                deliveries[fact_id] for fact_id in state.staged_hint_fact_ids if fact_id in deliveries
+            ),
+            handoff_deliveries=tuple(
+                deliveries[fact_id] for fact_id in state.staged_handoff_fact_ids if fact_id in deliveries
+            ),
         )
 
     def _established_for(self, state: RuntimeState, audience_id: str, limit: int) -> tuple[ProjectedKnowledge, ...]:

--- a/storygame/runtime/knowledge.py
+++ b/storygame/runtime/knowledge.py
@@ -24,6 +24,7 @@ class ProjectedKnowledge(_KnowledgeModel):
 class RevealCandidate(_KnowledgeModel):
     id: str
     statement: str
+    must_convey: tuple[tuple[str, ...], ...]
 
 
 class TurnKnowledgeContext(_KnowledgeModel):
@@ -195,4 +196,4 @@ class KnowledgeProjector:
     def _candidate(item: KnowledgeDefinition) -> RevealCandidate:
         """Expose only the player-safe selection affordance to the provider."""
 
-        return RevealCandidate(id=item.id, statement=item.statement)
+        return RevealCandidate(id=item.id, statement=item.statement, must_convey=item.must_convey)

--- a/storygame/runtime/state.py
+++ b/storygame/runtime/state.py
@@ -41,6 +41,8 @@ class RuntimeSnapshot(BaseModel):
     scene_entered_at_turn: int = Field(ge=0)
     narrative_history: tuple[str, ...] = ()
     turn_records: tuple[TurnRecord, ...] = ()
+    staged_hint_fact_ids: tuple[str, ...] = ()
+    staged_handoff_fact_ids: tuple[str, ...] = ()
 
 
 class RuntimeState(BaseModel):
@@ -60,6 +62,8 @@ class RuntimeState(BaseModel):
     pending_break: GameBreakWarning | None = None
     pending_snapshot: RuntimeSnapshot | None = None
     pending_proposal: ResolvedTurnProposal | None = None
+    staged_hint_fact_ids: tuple[str, ...] = ()
+    staged_handoff_fact_ids: tuple[str, ...] = ()
 
     @model_validator(mode="after")
     def scene_and_phase_match_package(self) -> RuntimeState:
@@ -100,6 +104,8 @@ class RuntimeState(BaseModel):
             scene_entered_at_turn=self.scene_entered_at_turn,
             narrative_history=tuple(self.narrative_history),
             turn_records=tuple(self.turn_records),
+            staged_hint_fact_ids=self.staged_hint_fact_ids,
+            staged_handoff_fact_ids=self.staged_handoff_fact_ids,
         )
 
     def set_pending_break(
@@ -118,7 +124,7 @@ class RuntimeState(BaseModel):
             segments=({"kind": "narration", "text": "Pending game-break candidate."},)
         )
 
-    def apply_proposal(self, proposal: ResolvedTurnProposal) -> None:
+    def apply_proposal(self, proposal: ResolvedTurnProposal, *, canonical_event_ids: tuple[str, ...] = ()) -> None:
         """Validate a complete candidate before replacing canonical session state.
 
         A warning intentionally commits no candidate facts: only the explicit
@@ -130,6 +136,15 @@ class RuntimeState(BaseModel):
         candidate_facts = self.facts.clone()
         candidate_active = set(self.active_event_ids)
         candidate_fired = set(self.fired_event_ids)
+        canonical_events = {
+            event.id: event
+            for event in (*self.package.storylet_routes.bridge_events, *self.package.storylet_routes.resolution_events)
+        }
+        for event_id in canonical_event_ids:
+            event = canonical_events.get(event_id)
+            if event is None or event.scene_id != self.current_scene_id or event_id in candidate_fired:
+                raise RuntimeStateError("canonical event is not eligible")
+            candidate_fired.add(event_id)
         for operation in proposal.operations:
             self._apply_operation(candidate_facts, operation)
         for event in proposal.events:
@@ -168,6 +183,8 @@ class RuntimeState(BaseModel):
         """Commit the typed scene-entry reveal before any opening can render."""
 
         self.scene_entered_at_turn = self.turn_index
+        self.staged_hint_fact_ids = ()
+        self.staged_handoff_fact_ids = ()
         self.facts.assert_fact(Fact(predicate=f"scene_{scene_id.lower()}_entry_known", subject="story", value="true"))
 
     @staticmethod
@@ -191,6 +208,8 @@ class RuntimeState(BaseModel):
             self.scene_entered_at_turn = snapshot.scene_entered_at_turn
             self.narrative_history = list(snapshot.narrative_history)
             self.turn_records = list(snapshot.turn_records)
+            self.staged_hint_fact_ids = snapshot.staged_hint_fact_ids
+            self.staged_handoff_fact_ids = snapshot.staged_handoff_fact_ids
         elif decision != "proceed":
             raise RuntimeStateError("game break decision must be proceed or return_to_scene")
         else:

--- a/storygame/runtime/state.py
+++ b/storygame/runtime/state.py
@@ -29,6 +29,16 @@ class TurnRecord(BaseModel):
     fact_keys: tuple[str, ...] = ()
 
 
+class TurnDelivery(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    must_convey_misses: tuple[str, ...] = ()
+    recovery_used: bool = False
+    fallback_used: bool = False
+    hint_staged: bool = False
+    handoff_staged: bool = False
+
+
 class RuntimeSnapshot(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
     version: int = Field(default=SNAPSHOT_VERSION, ge=1)
@@ -64,6 +74,7 @@ class RuntimeState(BaseModel):
     pending_proposal: ResolvedTurnProposal | None = None
     staged_hint_fact_ids: tuple[str, ...] = ()
     staged_handoff_fact_ids: tuple[str, ...] = ()
+    last_turn_delivery: TurnDelivery = TurnDelivery()
 
     @model_validator(mode="after")
     def scene_and_phase_match_package(self) -> RuntimeState:

--- a/storygame/runtime/state.py
+++ b/storygame/runtime/state.py
@@ -10,7 +10,7 @@ from storygame.runtime.contracts import FactOperation, GameBreakWarning, Resolve
 from storygame.runtime.facts import Fact, FactStore
 from storygame.story_package.models import StoryPackage
 
-SNAPSHOT_VERSION = 1
+SNAPSHOT_VERSION = 2
 
 
 class RuntimeStateError(ValueError):
@@ -37,6 +37,8 @@ class RuntimeSnapshot(BaseModel):
     active_event_ids: tuple[str, ...]
     fired_event_ids: tuple[str, ...]
     facts: FactStore
+    turn_index: int = Field(ge=0)
+    scene_entered_at_turn: int = Field(ge=0)
     narrative_history: tuple[str, ...] = ()
     turn_records: tuple[TurnRecord, ...] = ()
 
@@ -51,6 +53,8 @@ class RuntimeState(BaseModel):
     active_event_ids: set[str] = Field(default_factory=set)
     fired_event_ids: set[str] = Field(default_factory=set)
     facts: FactStore = Field(default_factory=FactStore)
+    turn_index: int = Field(default=0, ge=0)
+    scene_entered_at_turn: int = Field(default=0, ge=0)
     narrative_history: list[str] = Field(default_factory=list)
     turn_records: list[TurnRecord] = Field(default_factory=list)
     pending_break: GameBreakWarning | None = None
@@ -92,6 +96,8 @@ class RuntimeState(BaseModel):
             active_event_ids=tuple(sorted(self.active_event_ids)),
             fired_event_ids=tuple(sorted(self.fired_event_ids)),
             facts=self.facts.clone(),
+            turn_index=self.turn_index,
+            scene_entered_at_turn=self.scene_entered_at_turn,
             narrative_history=tuple(self.narrative_history),
             turn_records=tuple(self.turn_records),
         )
@@ -161,6 +167,7 @@ class RuntimeState(BaseModel):
     def _assert_scene_entry_fact(self, scene_id: str) -> None:
         """Commit the typed scene-entry reveal before any opening can render."""
 
+        self.scene_entered_at_turn = self.turn_index
         self.facts.assert_fact(Fact(predicate=f"scene_{scene_id.lower()}_entry_known", subject="story", value="true"))
 
     @staticmethod
@@ -180,6 +187,8 @@ class RuntimeState(BaseModel):
             self.active_event_ids = set(snapshot.active_event_ids)
             self.fired_event_ids = set(snapshot.fired_event_ids)
             self.facts = snapshot.facts.clone()
+            self.turn_index = snapshot.turn_index
+            self.scene_entered_at_turn = snapshot.scene_entered_at_turn
             self.narrative_history = list(snapshot.narrative_history)
             self.turn_records = list(snapshot.turn_records)
         elif decision != "proceed":

--- a/storygame/runtime/validation.py
+++ b/storygame/runtime/validation.py
@@ -39,13 +39,29 @@ def unconveyed_terms(groups: tuple[tuple[str, ...], ...], text: str) -> tuple[st
     def normalize(value: str) -> str:
         return re.sub(r"\s+", " ", value.translate(replacements).casefold()).strip()
 
-    normalized_text = normalize(text)
+    def words(value: str) -> tuple[str, ...]:
+        return tuple(re.findall(r"[^\W_]+(?:'[^\W_]+)*", normalize(value)))
+
+    def word_matches(authored: str, prose: str) -> bool:
+        return prose == authored or any(prose == authored + suffix for suffix in ("s", "es", "ed", "d", "ing"))
+
+    def phrase_matches(phrasing: str, prose_words: tuple[str, ...]) -> bool:
+        phrasing_words = words(phrasing)
+        if not phrasing_words or len(phrasing_words) > len(prose_words):
+            return False
+        width = len(phrasing_words)
+        return any(
+            all(
+                word_matches(authored, prose)
+                for authored, prose in zip(phrasing_words, prose_words[start : start + width], strict=True)
+            )
+            for start in range(len(prose_words) - width + 1)
+        )
+
+    normalized_text = words(text)
     missing: list[str] = []
     for group in groups:
-        normalized_group = tuple((phrasing, normalize(phrasing)) for phrasing in group)
-        if not any(
-            normalized_phrase and normalized_phrase in normalized_text for _, normalized_phrase in normalized_group
-        ):
+        if not any(phrase_matches(phrasing, normalized_text) for phrasing in group):
             missing.append(group[0] if group else "")
     return tuple(missing)
 

--- a/storygame/runtime/validation.py
+++ b/storygame/runtime/validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
 from copy import deepcopy
 
@@ -19,6 +20,34 @@ from storygame.story_package.models import FactPredicate, StoryPackage, Transiti
 
 class ProposalValidationError(RuntimeStateError):
     """An untrusted provider proposal violates the loaded package contract."""
+
+
+def unconveyed_terms(groups: tuple[tuple[str, ...], ...], text: str) -> tuple[str, ...]:
+    """Return the first phrasing from each synonym group absent from ``text``."""
+
+    replacements = str.maketrans(
+        {
+            "“": '"',
+            "”": '"',
+            "‘": "'",
+            "’": "'",
+            "–": "-",
+            "—": "-",
+        }
+    )
+
+    def normalize(value: str) -> str:
+        return re.sub(r"\s+", " ", value.translate(replacements).casefold()).strip()
+
+    normalized_text = normalize(text)
+    missing: list[str] = []
+    for group in groups:
+        normalized_group = tuple((phrasing, normalize(phrasing)) for phrasing in group)
+        if not any(
+            normalized_phrase and normalized_phrase in normalized_text for _, normalized_phrase in normalized_group
+        ):
+            missing.append(group[0] if group else "")
+    return tuple(missing)
 
 
 def predicate_matches(predicate: FactPredicate, facts: FactStore) -> bool:
@@ -85,6 +114,16 @@ class SelectedRevealResolver:
         undelivered = sorted(knowledge_id for knowledge_id in selected if knowledge_id not in grounded)
         if undelivered:
             raise ProposalValidationError("selected knowledge must be grounded in the segment that reveals it")
+        for knowledge_id in selected:
+            knowledge = self.package.knowledge_indexes.by_id[knowledge_id]
+            grounded_text = " ".join(
+                segment.text for segment in resolved.segments if knowledge_id in segment.grounding_ids
+            )
+            missing = unconveyed_terms(knowledge.must_convey, grounded_text)
+            if missing:
+                raise ProposalValidationError(
+                    f"selected knowledge '{knowledge_id}' does not convey: {', '.join(missing)}"
+                )
         self._validator.validate(state, resolved)
         candidate_state = deepcopy(state)
         candidate_state.apply_proposal(resolved)

--- a/storygame/story_package/loader.py
+++ b/storygame/story_package/loader.py
@@ -441,12 +441,12 @@ def _validate_deliveries(package: StoryPackage) -> None:
     scenes = {scene.metadata.scene_id: scene for scene in package.scenes}
     facts = package.fact_ids
     canonical_events = package.storylet_routes.bridge_events
-    required_facts = {
+    exit_prerequisite_facts = {
         fact_id
         for event in canonical_events
         for fact_id in (*event.activation.all_facts_true, *event.activation.any_of)
     }
-    player_visible_facts = {
+    player_safe_facts = {
         effect.fact_id
         for known in package.knowledge.knowledge
         if known.audience.player_visible
@@ -486,7 +486,10 @@ def _validate_deliveries(package: StoryPackage) -> None:
             raise StoryPackageError(
                 f"delivery for fact '{delivery.fact_id}' has no player-visible knowledge definition"
             )
-    missing_deliveries = sorted((required_facts & player_visible_facts) - set(deliveries_by_fact))
+    # World-only prerequisites, such as Rebecca's observation, are deliberately
+    # absent from this audit: they arrive from declared world actions rather
+    # than from a player-visible handoff.
+    missing_deliveries = sorted((exit_prerequisite_facts & player_safe_facts) - set(deliveries_by_fact))
     if missing_deliveries:
         fact_id = missing_deliveries[0]
         raise StoryPackageError(f"bridge-required fact '{fact_id}' has no FactDelivery")

--- a/storygame/story_package/loader.py
+++ b/storygame/story_package/loader.py
@@ -10,6 +10,7 @@ import yaml
 from pydantic import ValidationError
 
 from storygame.story_package.models import (
+    FactDelivery,
     KnowledgeCatalog,
     KnowledgeIndexes,
     PacingSource,
@@ -74,6 +75,8 @@ def _parse_scenes(text: str) -> tuple[Scene, ...]:
             raise StoryPackageError(f"invalid frontmatter for scene {match.group(1)}: {exc}") from exc
         if metadata.scene_id != match.group(1):
             raise StoryPackageError(f"heading and frontmatter disagree for scene {match.group(1)}")
+        if set(metadata.bridge_text) != set(metadata.transition_ids):
+            raise StoryPackageError(f"scene {match.group(1)} bridge_text keys must match transition_ids exactly")
         prose = body[frontmatter.end() :].strip()
         scenes.append(Scene(metadata=metadata, prose=prose, opening_beat=_parse_opening_beat(metadata.scene_id, prose)))
     return tuple(scenes)
@@ -430,6 +433,65 @@ def _validate(package: StoryPackage) -> None:
             raise StoryPackageError(f"transitions from {source_id} have ambiguous priority")
 
 
+def _validate_deliveries(package: StoryPackage) -> None:
+    """Fail closed when a canonical bridge cannot safely carry a fact."""
+
+    from storygame.runtime.validation import unconveyed_terms
+
+    scenes = {scene.metadata.scene_id: scene for scene in package.scenes}
+    facts = package.fact_ids
+    canonical_events = package.storylet_routes.bridge_events
+    required_facts = {
+        fact_id
+        for event in canonical_events
+        for fact_id in (*event.activation.all_facts_true, *event.activation.any_of)
+    }
+    player_visible_facts = {
+        effect.fact_id
+        for known in package.knowledge.knowledge
+        if known.audience.player_visible
+        for effect in known.establishes
+    }
+    deliveries_by_fact: dict[str, FactDelivery] = {}
+    for delivery in package.deliveries:
+        if delivery.fact_id not in facts:
+            raise StoryPackageError(f"delivery for fact '{delivery.fact_id}' references an unknown fact")
+        if delivery.fact_id in deliveries_by_fact:
+            raise StoryPackageError(f"fact '{delivery.fact_id}' has more than one delivery")
+        deliveries_by_fact[delivery.fact_id] = delivery
+        scene = scenes.get(delivery.scene_id)
+        if scene is None:
+            raise StoryPackageError(f"delivery for fact '{delivery.fact_id}' references an unknown scene")
+        if delivery.source_entity_id and delivery.source_entity_id not in scene.metadata.participant_ids:
+            raise StoryPackageError(
+                f"delivery for fact '{delivery.fact_id}' names source entity '{delivery.source_entity_id}' "
+                f"absent from scene {delivery.scene_id} participants"
+            )
+        unknown_costs = {cost.fact_id for cost in delivery.costs} - facts
+        if unknown_costs:
+            raise StoryPackageError(
+                f"delivery for fact '{delivery.fact_id}' has unknown cost fact(s): {sorted(unknown_costs)}"
+            )
+        missing = unconveyed_terms(delivery.must_convey, delivery.fallback_text)
+        if missing:
+            raise StoryPackageError(
+                f"delivery for fact '{delivery.fact_id}' fallback_text does not convey: {', '.join(missing)}"
+            )
+        player_safe = any(
+            known.audience.player_visible
+            for known in package.knowledge.knowledge
+            if any(effect.fact_id == delivery.fact_id for effect in known.establishes)
+        )
+        if not player_safe:
+            raise StoryPackageError(
+                f"delivery for fact '{delivery.fact_id}' has no player-visible knowledge definition"
+            )
+    missing_deliveries = sorted((required_facts & player_visible_facts) - set(deliveries_by_fact))
+    if missing_deliveries:
+        fact_id = missing_deliveries[0]
+        raise StoryPackageError(f"bridge-required fact '{fact_id}' has no FactDelivery")
+
+
 def load_story_package(root: Path) -> StoryPackage:
     """Load one package directory without accepting prose as runtime truth."""
     try:
@@ -442,6 +504,11 @@ def load_story_package(root: Path) -> StoryPackage:
         pacing = PacingSource.model_validate(_yaml(root / "pacing.yaml"))
         routes_raw = _yaml(root / "storylet-routes.yaml")
         knowledge = KnowledgeCatalog.model_validate(_yaml(root / "knowledge.yaml"))
+        handoffs_raw = _yaml(root / "handoffs.yaml")
+        raw_deliveries = handoffs_raw.get("deliveries")
+        if not isinstance(raw_deliveries, list):
+            raise StoryPackageError("YAML handoffs.yaml must contain a deliveries list")
+        deliveries = tuple(FactDelivery.model_validate(item) for item in raw_deliveries)
 
         def event_source(item: dict[str, Any]) -> dict[str, Any]:
             activation = item.get("activation", {})
@@ -493,7 +560,9 @@ def load_story_package(root: Path) -> StoryPackage:
         storylet_routes=routes,
         knowledge=knowledge,
         knowledge_indexes=_compile_knowledge_indexes(knowledge),
+        deliveries=deliveries,
     )
     _validate(package)
     _validate_knowledge(package)
+    _validate_deliveries(package)
     return package

--- a/storygame/story_package/loader.py
+++ b/storygame/story_package/loader.py
@@ -202,6 +202,11 @@ def _validate_knowledge(package: StoryPackage) -> None:
         event.id: event
         for event in (*package.storylet_routes.bridge_events, *package.storylet_routes.resolution_events)
     }
+    transition_trigger_facts = {
+        (transition.source_scene_id, trigger.fact_id)
+        for transition in package.pacing.transitions
+        for trigger in transition.triggers
+    }
     scene_order = {scene.metadata.scene_id: index for index, scene in enumerate(package.scenes)}
     produced_by: dict[str, set[str]] = {}
     for known in catalog.knowledge:
@@ -222,6 +227,18 @@ def _validate_knowledge(package: StoryPackage) -> None:
         established_facts = {effect.fact_id for effect in item.establishes}
         if required_facts - facts or established_facts - facts:
             raise StoryPackageError(f"knowledge '{item.id}' references an unknown fact")
+        if (
+            item.source.kind == "storylet_realization"
+            and any(
+                effect.op == "assert" and (scene_id, effect.fact_id) in transition_trigger_facts
+                for scene_id in item.available_in_scenes
+                for effect in item.establishes
+            )
+            and not item.must_convey
+        ):
+            raise StoryPackageError(
+                f"selectable knowledge '{item.id}' establishes a scene-transition trigger but has no must_convey"
+            )
         if item.audience.kind == "characters" and set(item.audience.character_ids) - {
             entity.id for entity in package.world.npcs
         }:

--- a/storygame/story_package/loader.py
+++ b/storygame/story_package/loader.py
@@ -388,8 +388,20 @@ def _validate(package: StoryPackage) -> None:
     for event in (*package.storylet_routes.bridge_events, *package.storylet_routes.resolution_events):
         if event.scene_id not in scenes:
             raise StoryPackageError(f"canonical route event '{event.id}' references an unknown scene")
-        if {item.fact_id for item in event.activation_conditions} - set(package.world.facts):
+        activation_facts = set(event.activation.all_facts_true) | set(event.activation.any_of)
+        if activation_facts - set(package.world.facts):
             raise StoryPackageError(f"canonical route event '{event.id}' has an unknown activation fact")
+        if event.activation.any_of and not 1 <= event.activation.at_least <= len(event.activation.any_of):
+            raise StoryPackageError(
+                f"canonical route event '{event.id}' has an activation threshold outside "
+                f"1..{len(event.activation.any_of)}"
+            )
+        if not event.activation.any_of and event.activation.at_least > 0:
+            raise StoryPackageError(
+                f"canonical route event '{event.id}' has an activation threshold without a fact pool"
+            )
+        if not event.activation.all_facts_true and not event.activation.any_of:
+            raise StoryPackageError(f"canonical route event '{event.id}' has a vacuous activation rule")
         if {operation.fact_id for operation in event.operations} - set(package.world.facts):
             raise StoryPackageError(f"canonical route event '{event.id}' has an unknown operation fact")
     visiting: set[str] = set()
@@ -431,9 +443,11 @@ def load_story_package(root: Path) -> StoryPackage:
             return {
                 "id": item["id"],
                 "scene_id": item["scene_id"],
-                "activation_conditions": tuple(
-                    {"fact_id": fact_id, "equals": True} for fact_id in activation.get("all_facts_true", ())
-                ),
+                "activation": {
+                    "all_facts_true": activation.get("all_facts_true", ()),
+                    "any_of": activation.get("any_of", ()),
+                    "at_least": activation.get("at_least", 0),
+                },
                 "operations": item["produces"],
             }
 

--- a/storygame/story_package/loader.py
+++ b/storygame/story_package/loader.py
@@ -93,14 +93,11 @@ def _parse_opening_beat(scene_id: str, prose: str) -> SceneBeat:
     return SceneBeat(id=first.group(1), title=first.group(2).strip(), prose=body)
 
 
-def _clock(value: str) -> int:
-    match = re.fullmatch(r"(\d{2}):(\d{2}):(\d{2})", value.strip())
+def _turn(value: str) -> int:
+    match = re.fullmatch(r"turn\s+(\d+)", value.strip(), re.IGNORECASE)
     if not match:
-        raise StoryPackageError(f"invalid timestamp '{value}' (use HH:MM:SS)")
-    hour, minute, second = map(int, match.groups())
-    if minute > 59 or second > 59:
-        raise StoryPackageError(f"invalid timestamp '{value}'")
-    return hour * 3600 + minute * 60 + second
+        raise StoryPackageError(f"invalid turn offset '{value}' (use 'turn N')")
+    return int(match.group(1))
 
 
 def _parse_storylets(text: str, plot_anchors: set[str]) -> tuple[Storylet, ...]:
@@ -122,7 +119,7 @@ def _parse_storylets(text: str, plot_anchors: set[str]) -> tuple[Storylet, ...]:
             raise StoryPackageError(f"storylet {match.group(1)} lacks plot.md source links")
         if any(not any(link.startswith(anchor) for anchor in plot_anchors) for link in links):
             raise StoryPackageError(f"storylet {match.group(1)} links to an unknown plot heading")
-        window = dict(re.findall(r"(earliest|target|latest):\s*`?([0-9:]+)`?", sections["Pacing window"]))
+        window = dict(re.findall(r"-\s*(earliest|target|latest):\s*`([^`]+)`", sections["Pacing window"]))
         if set(window) != {"earliest", "target", "latest"}:
             raise StoryPackageError(f"storylet {match.group(1)} has an invalid pacing window")
         impact = sections["Pacing impact"].strip("` \n")
@@ -133,9 +130,9 @@ def _parse_storylets(text: str, plot_anchors: set[str]) -> tuple[Storylet, ...]:
                 title=match.group(3),
                 source_links=links,
                 sections=sections,
-                earliest_seconds=_clock(window["earliest"]),
-                target_seconds=_clock(window["target"]),
-                latest_seconds=_clock(window["latest"]),
+                earliest_turn=_turn(window["earliest"]),
+                target_turn=_turn(window["target"]),
+                latest_turn=_turn(window["latest"]),
                 pacing_impact=impact,
             )
         )
@@ -344,6 +341,11 @@ def _validate(package: StoryPackage) -> None:
     if len(pacing_scene_ids) != len(package.pacing.scenes) or pacing_scene_ids != set(scenes):
         raise StoryPackageError("pacing must declare exactly one window per scene")
     windows = {p.scene_id: p for p in package.pacing.scenes}
+    handoff_seconds = sum(window.handoff_after_turns for window in package.pacing.scenes) * 60
+    if handoff_seconds > package.pacing.budget_seconds:
+        raise StoryPackageError(
+            f"pacing handoff sum {handoff_seconds} seconds exceeds budget_seconds {package.pacing.budget_seconds}"
+        )
     event_ids: set[str] = set()
     for event in package.pacing.events:
         if event.id in event_ids:
@@ -356,15 +358,15 @@ def _validate(package: StoryPackage) -> None:
         if {effect.fact_id for effect in event.effects} - set(package.world.facts):
             raise StoryPackageError(f"pacing event '{event.id}' has an unknown effect predicate")
         window = windows[event.scene_id]
-        if not window.earliest_seconds <= event.at_seconds <= window.latest_seconds:
+        if not 0 <= event.at_turn <= window.handoff_after_turns:
             raise StoryPackageError(f"pacing event '{event.id}' escapes its scene pacing window")
     for storylet in package.storylets:
         if storylet.scene_id not in scenes:
             raise StoryPackageError(f"storylet '{storylet.id}' references unknown scene")
         window = windows[storylet.scene_id]
         within_scene_window = (
-            window.earliest_seconds <= storylet.earliest_seconds <= storylet.target_seconds
-            and storylet.latest_seconds <= window.latest_seconds
+            0 <= storylet.earliest_turn <= storylet.target_turn <= storylet.latest_turn
+            and storylet.latest_turn <= window.handoff_after_turns
         )
         if not within_scene_window:
             raise StoryPackageError(f"storylet '{storylet.id}' escapes its scene pacing window")
@@ -378,6 +380,9 @@ def _validate(package: StoryPackage) -> None:
     for route in package.storylet_routes.storylets:
         if route.scene_id not in scenes or route.id not in route_ids:
             raise StoryPackageError("storylet route references unknown scene")
+        window = windows[route.scene_id]
+        if not 0 <= route.earliest_turn <= route.target_turn <= route.latest_turn <= window.handoff_after_turns:
+            raise StoryPackageError(f"storylet '{route.id}' escapes its scene pacing window")
         if {item.fact_id for item in route.activation_conditions} - set(package.world.facts):
             raise StoryPackageError(f"storylet route '{route.id}' has an unknown activation fact")
         for realization in route.realizations:
@@ -462,9 +467,9 @@ def load_story_package(root: Path) -> StoryPackage:
                         "scene_id": item["scene_id"],
                         "title": item["title"],
                         "activation_conditions": item["activation"].get("conditions", ()),
-                        "earliest_seconds": item["activation"]["pacing"]["earliest_seconds"],
-                        "target_seconds": item["activation"]["pacing"]["target_seconds"],
-                        "latest_seconds": item["activation"]["pacing"]["latest_seconds"],
+                        "earliest_turn": item["activation"]["pacing"]["earliest_turn"],
+                        "target_turn": item["activation"]["pacing"]["target_turn"],
+                        "latest_turn": item["activation"]["pacing"]["latest_turn"],
                         "pressure_role": item["pressure_role"],
                         "realizations": item["realization_options"],
                     }

--- a/storygame/story_package/models.py
+++ b/storygame/story_package/models.py
@@ -185,14 +185,14 @@ class Transition(_Model):
 
 class ScenePacing(_Model):
     scene_id: str = Field(pattern=_SCENE_ID)
-    earliest_seconds: int = Field(ge=0)
-    target_seconds: int = Field(ge=0)
-    latest_seconds: int = Field(ge=0)
+    min_turns: int = Field(ge=0)
+    nudge_after_turns: int = Field(ge=1)
+    handoff_after_turns: int = Field(ge=1)
 
     @model_validator(mode="after")
     def ordered(self) -> ScenePacing:
-        if not self.earliest_seconds <= self.target_seconds <= self.latest_seconds:
-            raise ValueError("pacing timestamps must be ordered")
+        if not self.min_turns <= self.nudge_after_turns <= self.handoff_after_turns:
+            raise ValueError("pacing turn allocations must be ordered")
         return self
 
 
@@ -201,12 +201,13 @@ class PacingEvent(_Model):
 
     id: str = Field(pattern=_ID)
     scene_id: str = Field(pattern=_SCENE_ID)
-    at_seconds: int = Field(ge=0)
+    at_turn: int = Field(ge=0)
     effects: tuple[FactPredicate, ...] = Field(min_length=1)
     transition_id: str | None = Field(default=None, pattern=_ID)
 
 
 class PacingSource(_Model):
+    budget_seconds: int = Field(ge=0)
     scenes: tuple[ScenePacing, ...]
     transitions: tuple[Transition, ...]
     events: tuple[PacingEvent, ...] = ()
@@ -218,15 +219,15 @@ class Storylet(_Model):
     title: str = Field(min_length=1)
     source_links: tuple[str, ...] = Field(min_length=1)
     sections: dict[str, str]
-    earliest_seconds: int = Field(ge=0)
-    target_seconds: int = Field(ge=0)
-    latest_seconds: int = Field(ge=0)
+    earliest_turn: int = Field(ge=0)
+    target_turn: int = Field(ge=0)
+    latest_turn: int = Field(ge=0)
     pacing_impact: Literal["none", "brief_delay", "pressure_increase", "advance_readiness"]
 
     @model_validator(mode="after")
     def ordered(self) -> Storylet:
-        if not self.earliest_seconds <= self.target_seconds <= self.latest_seconds:
-            raise ValueError("storylet timestamps must be ordered")
+        if not self.earliest_turn <= self.target_turn <= self.latest_turn:
+            raise ValueError("storylet turn offsets must be ordered")
         return self
 
 
@@ -250,11 +251,17 @@ class StoryletRoute(_Model):
     scene_id: str = Field(pattern=_SCENE_ID)
     title: str = Field(min_length=1)
     activation_conditions: tuple[FactPredicate, ...] = ()
-    earliest_seconds: int = Field(ge=0)
-    target_seconds: int = Field(ge=0)
-    latest_seconds: int = Field(ge=0)
+    earliest_turn: int = Field(ge=0)
+    target_turn: int = Field(ge=0)
+    latest_turn: int = Field(ge=0)
     pressure_role: str = Field(min_length=1)
     realizations: tuple[RouteRealization, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def ordered(self) -> StoryletRoute:
+        if not self.earliest_turn <= self.target_turn <= self.latest_turn:
+            raise ValueError("storylet route turn offsets must be ordered")
+        return self
 
 
 class CanonicalRouteEvent(_Model):

--- a/storygame/story_package/models.py
+++ b/storygame/story_package/models.py
@@ -22,6 +22,17 @@ class FactPredicate(_Model):
     equals: str | bool | int | None = None
 
 
+class ActivationRule(_Model):
+    all_facts_true: tuple[str, ...] = ()
+    any_of: tuple[str, ...] = ()
+    at_least: int = 0
+
+    def is_satisfied(self, true_facts):
+        return all(fact_id in true_facts for fact_id in self.all_facts_true) and (
+            not self.any_of or sum(fact_id in true_facts for fact_id in self.any_of) >= self.at_least
+        )
+
+
 class FactDefinition(_Model):
     """A named world predicate and its authoring purpose."""
 
@@ -249,7 +260,7 @@ class StoryletRoute(_Model):
 class CanonicalRouteEvent(_Model):
     id: str = Field(min_length=1)
     scene_id: str = Field(pattern=_SCENE_ID)
-    activation_conditions: tuple[FactPredicate, ...] = ()
+    activation: ActivationRule
     operations: tuple[RouteOperation, ...] = Field(min_length=1)
 
 

--- a/storygame/story_package/models.py
+++ b/storygame/story_package/models.py
@@ -158,6 +158,7 @@ class SceneMetadata(_Model):
     item_ids: tuple[str, ...] = ()
     entry_text: str = Field(min_length=1)
     transition_ids: tuple[str, ...] = ()
+    bridge_text: Mapping[str, str] = {}
 
 
 class SceneBeat(_Model):
@@ -237,6 +238,18 @@ class RouteOperation(_Model):
     value: str | bool | int | None = None
 
 
+class FactDelivery(_Model):
+    """A diegetic, player-safe way to carry an unearned fact forward."""
+
+    fact_id: str = Field(pattern=_ID)
+    scene_id: str = Field(pattern=_SCENE_ID)
+    source_kind: Literal["message", "npc", "broadcast", "observation", "inference"]
+    source_entity_id: str | None = None
+    must_convey: tuple[tuple[str, ...], ...] = Field(min_length=2)
+    fallback_text: str = Field(min_length=1)
+    costs: tuple[RouteOperation, ...] = ()
+
+
 class RouteRealization(_Model):
     id: str = Field(min_length=1)
     dramatic_intent: str = Field(min_length=1)
@@ -292,6 +305,7 @@ class StoryPackage(_Model):
     storylet_routes: StoryletRoutesSource
     knowledge: KnowledgeCatalog
     knowledge_indexes: KnowledgeIndexes
+    deliveries: tuple[FactDelivery, ...]
 
     @property
     def fact_ids(self) -> frozenset[str]:

--- a/storygame/story_package/models.py
+++ b/storygame/story_package/models.py
@@ -87,6 +87,7 @@ class KnowledgeDefinition(_Model):
     establishes: tuple[RouteOperation, ...] = Field(min_length=1)
     source: RevealSource
     relevance: Relevance = Field(default_factory=Relevance)
+    must_convey: tuple[tuple[str, ...], ...] = ()
 
 
 class SceneFrame(_Model):

--- a/storygame/story_package/models.py
+++ b/storygame/story_package/models.py
@@ -32,6 +32,25 @@ class ActivationRule(_Model):
             not self.any_of or sum(fact_id in true_facts for fact_id in self.any_of) >= self.at_least
         )
 
+    def minimal_undelivered_facts(self, true_facts):
+        """Return the smallest stable set of facts which completes this rule."""
+
+        known = set(true_facts)
+        selected: list[str] = []
+        for fact_id in self.all_facts_true:
+            if fact_id not in known and fact_id not in selected:
+                selected.append(fact_id)
+        pool_count = sum(fact_id in known for fact_id in self.any_of)
+        pool_count += sum(fact_id in self.any_of for fact_id in selected)
+        needed = max(0, self.at_least - pool_count)
+        for fact_id in self.any_of:
+            if needed == 0:
+                break
+            if fact_id not in known and fact_id not in selected:
+                selected.append(fact_id)
+                needed -= 1
+        return tuple(selected)
+
 
 class FactDefinition(_Model):
     """A named world predicate and its authoring purpose."""

--- a/storygame/web_demo.py
+++ b/storygame/web_demo.py
@@ -97,6 +97,7 @@ def _turn_payload(
         "segments": segments,
         "lines": [narration],
         "game_break": game_break,
+        "delivery": state.last_turn_delivery.model_dump(mode="json"),
         "state": _state_summary(state),
     }
 

--- a/storygame/web_demo.py
+++ b/storygame/web_demo.py
@@ -78,6 +78,8 @@ def _state_summary(state: RuntimeState) -> dict[str, object]:
             event.id for event in state.package.pacing.events if event.id in state.fired_event_ids
         ),
         "story_elapsed_seconds": int(elapsed[-1].value) if elapsed and elapsed[-1].value else 0,
+        "turn_index": state.turn_index,
+        "turns_since_scene_entry": state.turn_index - state.scene_entered_at_turn,
     }
 
 

--- a/tests/test_activation_threshold.py
+++ b/tests/test_activation_threshold.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+from storygame.runtime.engine import RuntimeEngine
+from storygame.runtime.facts import Fact
+from storygame.runtime.state import RuntimeState
+from storygame.story_package.loader import StoryPackageError, load_story_package
+from storygame.story_package.models import ActivationRule
+
+PACKAGE = Path("data/stories/continuity-initiative")
+
+
+@pytest.mark.parametrize(
+    ("rule", "true_facts", "expected"),
+    [
+        (ActivationRule(all_facts_true=("mandatory_fact",)), frozenset({"mandatory_fact"}), True),
+        (ActivationRule(all_facts_true=("mandatory_fact",)), frozenset(), False),
+        (
+            ActivationRule(all_facts_true=("mandatory_fact",), any_of=("pool_a",), at_least=1),
+            frozenset({"mandatory_fact", "pool_a"}),
+            True,
+        ),
+    ],
+)
+def test_activation_rule_requires_all_mandatory_facts(
+    rule: ActivationRule, true_facts: frozenset[str], expected: bool
+) -> None:
+    assert rule.is_satisfied(true_facts) is expected
+
+
+@pytest.mark.parametrize(
+    ("at_least", "true_facts", "expected"),
+    [
+        (2, frozenset({"mandatory_fact", "pool_a", "pool_b"}), True),
+        (2, frozenset({"mandatory_fact", "pool_a", "pool_b", "pool_c"}), True),
+        (2, frozenset({"mandatory_fact", "pool_a"}), False),
+    ],
+)
+def test_activation_rule_applies_pool_threshold(at_least: int, true_facts: frozenset[str], expected: bool) -> None:
+    rule = ActivationRule(all_facts_true=("mandatory_fact",), any_of=("pool_a", "pool_b", "pool_c"), at_least=at_least)
+
+    assert rule.is_satisfied(true_facts) is expected
+
+
+def test_activation_rule_full_pool_cannot_replace_missing_mandatory_fact() -> None:
+    rule = ActivationRule(all_facts_true=("mandatory_fact",), any_of=("pool_a", "pool_b"), at_least=2)
+
+    assert not rule.is_satisfied(frozenset({"pool_a", "pool_b"}))
+
+
+def test_activation_rule_rejects_too_few_pool_facts_with_mandatory_fact() -> None:
+    rule = ActivationRule(all_facts_true=("mandatory_fact",), any_of=("pool_a", "pool_b"), at_least=2)
+
+    assert not rule.is_satisfied(frozenset({"mandatory_fact", "pool_a"}))
+
+
+def _copied_package(tmp_path: Path) -> Path:
+    destination = tmp_path / "package"
+    shutil.copytree(PACKAGE, destination)
+    return destination
+
+
+def _change_event_activation(root: Path, event_id: str, activation: dict[str, object]) -> None:
+    source = root / "storylet-routes.yaml"
+    routes = yaml.safe_load(source.read_text(encoding="utf-8"))
+    event = next(item for item in routes["canonical_bridge_events"] if item["id"] == event_id)
+    event["activation"] = activation
+    source.write_text(yaml.safe_dump(routes, sort_keys=False), encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("event_id", "activation", "message"),
+    [
+        (
+            "bridge_1b_departure",
+            {"all_facts_true": ["park_pursuit_resolved"], "any_of": ["transport_route_identified"], "at_least": 0},
+            "outside",
+        ),
+        (
+            "bridge_1b_departure",
+            {"all_facts_true": ["park_pursuit_resolved"], "any_of": ["transport_route_identified"], "at_least": 2},
+            "outside",
+        ),
+        (
+            "bridge_2b_archive_crisis",
+            {"all_facts_true": ["janus_evidence"], "at_least": 1},
+            "without a fact pool",
+        ),
+        ("bridge_1c_infiltration_needed", {"at_least": 0}, "vacuous"),
+    ],
+)
+def test_loader_rejects_unsatisfiable_activation_rules(
+    tmp_path: Path, event_id: str, activation: dict[str, object], message: str
+) -> None:
+    root = _copied_package(tmp_path)
+    _change_event_activation(root, event_id, activation)
+
+    with pytest.raises(StoryPackageError, match=f"canonical route event '{event_id}'.*{message}"):
+        load_story_package(root)
+
+
+def test_loader_checks_pool_activation_facts_against_world(tmp_path: Path) -> None:
+    root = _copied_package(tmp_path)
+    _change_event_activation(
+        root,
+        "bridge_1b_departure",
+        {
+            "all_facts_true": ["park_pursuit_resolved"],
+            "any_of": ["unknown_activation_fact"],
+            "at_least": 1,
+        },
+    )
+
+    with pytest.raises(StoryPackageError, match="canonical route event 'bridge_1b_departure'.*unknown activation fact"):
+        load_story_package(root)
+
+
+def _set_true(state: RuntimeState, fact_id: str) -> None:
+    state.facts.assert_fact(Fact(predicate=fact_id, subject="story", value="true"))
+
+
+@pytest.mark.parametrize(
+    ("pool_facts", "fires", "exit_available"),
+    [
+        (("transport_route_identified", "brandon_identified"), True, True),
+        (("transport_route_identified",), False, False),
+    ],
+)
+def test_scene_1b_departure_bridge_uses_threshold_pool(
+    pool_facts: tuple[str, ...], fires: bool, exit_available: bool
+) -> None:
+    package = load_story_package(PACKAGE)
+    state = RuntimeState.bootstrap(package)
+    scene = next(item for item in package.scenes if item.metadata.scene_id == "1B")
+    state.current_scene_id = scene.metadata.scene_id
+    state.phase = scene.metadata.freytag_phase
+    _set_true(state, "park_pursuit_resolved")
+    for fact_id in pool_facts:
+        _set_true(state, fact_id)
+
+    engine = RuntimeEngine(state, lambda _: {"segments": [{"kind": "narration", "text": "The scene continues."}]})
+    engine._apply_canonical_route_events()
+
+    assert ("bridge_1b_departure" in state.fired_event_ids) is fires
+    assert state.facts.has("transport_route_departure_ready", "story", value="true") is fires
+    assert (
+        "t_1b_1c" in {transition.id for transition in engine.validator.eligible_transitions(state)}
+    ) is exit_available

--- a/tests/test_canon_journey.py
+++ b/tests/test_canon_journey.py
@@ -76,11 +76,14 @@ class _ScriptedProvider:
     def __call__(self, _player_input: str) -> dict[str, object]:
         # A selection must be grounded in the segment that tells it, exactly as the
         # runtime requires of a live provider; an ungrounded selection is rejected.
+        text = "A concrete authored consequence lands."
+        if self.selected:
+            text = PACKAGE.knowledge_indexes.by_id[self.selected[0]].statement
         return {
             "segments": [
                 {
                     "kind": "narration",
-                    "text": "A concrete authored consequence lands.",
+                    "text": text,
                     "grounding_ids": list(self.selected),
                 }
             ],

--- a/tests/test_canon_journey.py
+++ b/tests/test_canon_journey.py
@@ -28,8 +28,8 @@ CLOCKED_JOURNEY = [
     ("k_sl_2a_b_r1", 510, "2A"),
     ("k_sl_2a_c_r2", 570, "2B"),
     ("k_sl_2b_a_r2", 630, "2B"),
-    ("k_sl_2b_b_r1", 630, "2B"),
-    ("k_sl_2b_c_r1", 705, "2C"),
+    ("k_sl_2b_c_r1", 630, "2B"),
+    ("k_sl_2b_b_r1", 705, "2C"),
     ("k_sl_2c_a_r2", 780, "2C"),
     ("k_sl_2c_c_r1", 840, "3A"),
     ("k_sl_3a_a_r1", 870, "3A"),
@@ -53,8 +53,8 @@ UNCLOCKED_JOURNEY = [
     ("k_sl_2a_b_r1", "2A"),
     ("k_sl_2a_c_r2", "2B"),
     ("k_sl_2b_a_r1", "2B"),
-    ("k_sl_2b_b_r2", "2B"),
-    ("k_sl_2b_c_r2", "2C"),
+    ("k_sl_2b_c_r2", "2B"),
+    ("k_sl_2b_b_r2", "2C"),
     ("k_sl_2c_a_r2", "2C"),
     ("k_sl_2c_c_r2", "3A"),
     ("k_sl_3a_a_r2", "3A"),
@@ -178,7 +178,7 @@ def _reachable_facts(package, seed_facts: set[str], fired_storylets: set[str]) -
                         facts.add(operation.fact_id)
                         changed = True
         for event in package.storylet_routes.bridge_events:
-            if all(predicate.fact_id in facts for predicate in event.activation_conditions):
+            if event.activation.is_satisfied(frozenset(facts)):
                 for operation in event.operations:
                     if operation.op == "assert" and operation.fact_id not in facts:
                         facts.add(operation.fact_id)

--- a/tests/test_canon_journey.py
+++ b/tests/test_canon_journey.py
@@ -3,8 +3,8 @@
 These tests drive the runtime with a scripted provider so CI proves the story
 package and engine support a complete 1A -> 3C playthrough without any model
 call. The clocked variant mirrors the hosted Playwright package-clock recipe;
-the unclocked variant mirrors default 60-second turns and lands exactly on the
-authored 1200-second (20-minute) budget.
+the unclocked variant mirrors default 60-second turns and stays within the
+authored 1800-second (30-minute) budget.
 """
 
 from __future__ import annotations
@@ -12,33 +12,44 @@ from __future__ import annotations
 from pathlib import Path
 
 from storygame.runtime.engine import RuntimeEngine
+from storygame.runtime.facts import Fact
 from storygame.runtime.state import RuntimeState
 from storygame.story_package.loader import load_story_package
 
 PACKAGE = load_story_package(Path("data/stories/continuity-initiative"))
 
-# (selected knowledge id or None, armed elapsed target, expected scene at turn end)
+# (selected knowledge id or None, elapsed target, expected scene at turn end)
 CLOCKED_JOURNEY = [
-    ("k_sl_1a_a_r1", 120, "1A"),
-    ("k_sl_1a_b_r1", 195, "1B"),
-    ("k_sl_1b_b_r1", 270, "1B"),
-    ("k_sl_1b_c_r1", 330, "1C"),
-    ("k_sl_1c_a_r2", 390, "1C"),
-    ("k_sl_1c_b_r1", 450, "2A"),
-    ("k_sl_2a_b_r1", 510, "2A"),
-    ("k_sl_2a_c_r2", 570, "2B"),
-    ("k_sl_2b_a_r2", 630, "2B"),
-    ("k_sl_2b_c_r1", 630, "2B"),
-    ("k_sl_2b_b_r1", 705, "2C"),
-    ("k_sl_2c_a_r2", 780, "2C"),
-    ("k_sl_2c_c_r1", 840, "3A"),
-    ("k_sl_3a_a_r1", 870, "3A"),
-    ("k_sl_3a_b_r2", 900, "3A"),
-    ("k_sl_3a_c_r1", 975, "3B"),
-    ("k_sl_3b_a_r1", 1020, "3B"),
-    ("k_sl_3b_b_r1", 1050, "3B"),
-    ("k_sl_3b_c_r1", 1140, "3C"),
-    ("k_sl_3c_a_r1", 1200, "3C"),
+    ("k_sl_1a_a_r1", 60, "1A"),
+    (None, 120, "1A"),
+    ("k_sl_1a_b_r1", 180, "1B"),
+    ("k_sl_1b_b_r1", 240, "1B"),
+    (None, 300, "1B"),
+    (None, 360, "1B"),
+    ("k_sl_1b_c_r1", 420, "1C"),
+    ("k_sl_1c_a_r2", 480, "1C"),
+    (None, 540, "1C"),
+    ("k_sl_1c_b_r1", 600, "2A"),
+    ("k_sl_2a_b_r1", 660, "2A"),
+    (None, 720, "2A"),
+    ("k_sl_2a_c_r2", 780, "2B"),
+    ("k_sl_2b_a_r2", 840, "2B"),
+    ("k_sl_2b_c_r1", 900, "2B"),
+    (None, 960, "2B"),
+    ("k_sl_2b_b_r1", 1020, "2C"),
+    ("k_sl_2c_a_r2", 1080, "2C"),
+    (None, 1140, "2C"),
+    ("k_sl_2c_c_r1", 1200, "3A"),
+    ("k_sl_3a_a_r1", 1260, "3A"),
+    ("k_sl_3a_b_r2", 1320, "3A"),
+    ("k_sl_3a_c_r1", 1380, "3B"),
+    ("k_sl_3b_a_r1", 1440, "3B"),
+    ("k_sl_3b_b_r1", 1500, "3B"),
+    (None, 1560, "3B"),
+    (None, 1620, "3B"),
+    ("k_sl_3b_c_r1", 1680, "3C"),
+    ("k_sl_3c_a_r1", 1740, "3C"),
+    (None, 1800, "3C"),
 ]
 
 # Alternate-realization coverage at the default 60-second turn cadence.
@@ -47,21 +58,29 @@ UNCLOCKED_JOURNEY = [
     (None, "1A"),
     ("k_sl_1a_b_r1", "1B"),
     ("k_sl_1b_b_r1", "1B"),
+    (None, "1B"),
+    (None, "1B"),
     ("k_sl_1b_c_r1", "1C"),
     ("k_sl_1c_a_r2", "1C"),
+    (None, "1C"),
     ("k_sl_1c_b_r2", "2A"),
     ("k_sl_2a_b_r1", "2A"),
+    (None, "2A"),
     ("k_sl_2a_c_r2", "2B"),
     ("k_sl_2b_a_r1", "2B"),
     ("k_sl_2b_c_r2", "2B"),
+    (None, "2B"),
     ("k_sl_2b_b_r2", "2C"),
     ("k_sl_2c_a_r2", "2C"),
+    (None, "2C"),
     ("k_sl_2c_c_r2", "3A"),
     ("k_sl_3a_a_r2", "3A"),
     ("k_sl_3a_b_r1", "3A"),
     ("k_sl_3a_c_r2", "3B"),
     ("k_sl_3b_a_r2", "3B"),
     ("k_sl_3b_b_r2", "3B"),
+    (None, "3B"),
+    (None, "3B"),
     ("k_sl_3b_c_r2", "3C"),
     ("k_sl_3c_a_r2", "3C"),
 ]
@@ -118,7 +137,7 @@ def test_clocked_canon_journey_reaches_the_resolution_scene() -> None:
     assert state.facts.has("resolution_complete", "story", value="true")
 
 
-def test_unclocked_canon_journey_fits_the_twenty_minute_budget() -> None:
+def test_unclocked_canon_journey_fits_the_thirty_minute_budget() -> None:
     state = RuntimeState.bootstrap(PACKAGE)
     provider = _ScriptedProvider()
     engine = RuntimeEngine(state, provider)
@@ -134,7 +153,7 @@ def test_unclocked_canon_journey_fits_the_twenty_minute_budget() -> None:
 
 
 def test_committed_triggers_never_outrun_the_authored_pacing_floor() -> None:
-    """A committed transition trigger must wait for the target scene's earliest window."""
+    """A committed transition trigger must wait for the source scene's minimum turns."""
 
     state = RuntimeState.bootstrap(PACKAGE)
     provider = _ScriptedProvider()
@@ -144,14 +163,13 @@ def test_committed_triggers_never_outrun_the_authored_pacing_floor() -> None:
     _drive(engine, provider, "k_sl_1a_b_r1", clock_seconds=75)
     assert state.current_scene_id == "1B"
 
-    # Commit every bridge_1b fact well before scene 1C's earliest window (270s).
-    _drive(engine, provider, "k_sl_1b_b_r1", clock_seconds=40)
-    _drive(engine, provider, "k_sl_1b_c_r1", clock_seconds=20)
-    assert state.facts.has("park_pursuit_resolved", "story", value="true")
-    assert state.current_scene_id == "1B", "the transition must wait for 1C's authored earliest window"
+    # Commit the next trigger before the first turn in 1B; its two-turn floor
+    # keeps the committed trigger in the source scene until the next turn.
+    state.facts.assert_fact(Fact(predicate="transport_route_departure_ready", subject="story", value="true"))
+    _drive(engine, provider, None, clock_seconds=40)
+    assert state.current_scene_id == "1B", "the source scene must receive its minimum two turns"
 
     _drive(engine, provider, None, clock_seconds=15)
-    # At 270 seconds the authored window opens and the committed triggers carry Kristin out.
     assert state.current_scene_id == "1C"
 
 

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -346,6 +346,9 @@ def test_transport_retries_a_partially_conveyed_reveal(monkeypatch) -> None:
     assert len(payloads) == 2
     assert "memory card" in payloads[1]["system"]
     assert "must_convey" in payloads[1]["system"]
+    assert state.last_turn_delivery.must_convey_misses == ("k_sl_1a_b_r1",)
+    assert state.last_turn_delivery.recovery_used is True
+    assert state.last_turn_delivery.fallback_used is False
 
 
 def test_transport_drops_a_reveal_it_will_not_narrate_rather_than_committing_it(monkeypatch) -> None:

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -66,7 +66,8 @@ def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None
     drawer_context = json.loads(captured["payload"]["user"])["knowledge_context"]["player"]
     candidate = next(item for item in drawer_context["candidates"] if item["id"] == "k_sl_1a_b_r2")
     assert "damaged recording" in candidate["statement"]
-    assert set(candidate) == {"id", "statement"}
+    assert set(candidate) == {"id", "statement", "must_convey"}
+    assert candidate["must_convey"] == []
     assert provider.last_projection is not None
 
 
@@ -303,6 +304,50 @@ def test_transport_retries_a_reveal_the_narration_never_delivers(monkeypatch) ->
     assert "would never learn it" in payloads[1]["system"]
 
 
+def test_transport_retries_a_partially_conveyed_reveal(monkeypatch) -> None:
+    payloads: list[dict[str, object]] = []
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.active_event_ids.add("SL-1A-B")
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+
+    def open_request(request, timeout):
+        payloads.append(json.loads(request.data))
+        if len(payloads) == 1:
+            return _Response(
+                {
+                    "narration": (
+                        '{"segments":[{"kind":"narration","text":"Michelle fears the emergency broadcasts.",'
+                        '"grounding_ids":["k_sl_1a_b_r1"]}],"selected_knowledge_ids":["k_sl_1a_b_r1"]}'
+                    )
+                }
+            )
+        return _Response(
+            {
+                "narration": json.dumps(
+                    {
+                        "segments": [
+                            {
+                                "kind": "narration",
+                                "text": PACKAGE.knowledge_indexes.by_id["k_sl_1a_b_r1"].statement,
+                                "grounding_ids": ["k_sl_1a_b_r1"],
+                            }
+                        ],
+                        "selected_knowledge_ids": ["k_sl_1a_b_r1"],
+                    }
+                )
+            }
+        )
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+
+    proposal = provider("I search Michelle's workstation.")
+
+    assert proposal["selected_knowledge_ids"] == ["k_sl_1a_b_r1"]
+    assert len(payloads) == 2
+    assert "memory card" in payloads[1]["system"]
+    assert "must_convey" in payloads[1]["system"]
+
+
 def test_transport_drops_a_reveal_it_will_not_narrate_rather_than_committing_it(monkeypatch) -> None:
     """A provider that never delivers the reveal loses the selection, not the turn."""
 
@@ -428,6 +473,7 @@ def test_turn_prompt_matches_what_the_turn_actually_offers(monkeypatch) -> None:
     # narrate the earned moment without committing it, stalling the scene.
     assert "MUST reveal it" in offered_prompt
     assert "k_sl_1a_b_r2" in offered_prompt, "the offered candidate IDs must be named"
+    assert "must_convey" in offered_prompt
     assert "MUST be an empty list" not in offered_prompt
 
 

--- a/tests/test_markdown_story_package.py
+++ b/tests/test_markdown_story_package.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from storygame.runtime.validation import unconveyed_terms
 from storygame.story_package import StoryPackageError, load_story_package
 
 PACKAGE = Path("data/stories/continuity-initiative")
@@ -314,4 +315,100 @@ def test_loader_rejects_ambiguous_transition_priority(tmp_path: Path) -> None:
         )
     )
     with pytest.raises(StoryPackageError, match="ambiguous priority"):
+        load_story_package(root)
+
+
+def _handoffs(root: Path) -> tuple[Path, dict[str, object]]:
+    source = root / "handoffs.yaml"
+    return source, yaml.safe_load(source.read_text(encoding="utf-8"))
+
+
+def test_bridge_required_player_safe_facts_have_one_self_conveying_delivery() -> None:
+    package = load_story_package(PACKAGE)
+    required = {
+        fact_id
+        for event in package.storylet_routes.bridge_events
+        for fact_id in (*event.activation.all_facts_true, *event.activation.any_of)
+    }
+    player_safe = {
+        effect.fact_id
+        for knowledge in package.knowledge.knowledge
+        if knowledge.audience.player_visible
+        for effect in knowledge.establishes
+    }
+    deliveries = {delivery.fact_id: delivery for delivery in package.deliveries}
+
+    assert set(deliveries) == required & player_safe
+    assert len(package.deliveries) == len(deliveries)
+    assert all(not unconveyed_terms(delivery.must_convey, delivery.fallback_text) for delivery in deliveries.values())
+
+
+def test_loader_rejects_missing_bridge_delivery(tmp_path: Path) -> None:
+    root = copied_package(tmp_path)
+    source, handoffs = _handoffs(root)
+    handoffs["deliveries"].pop(0)  # type: ignore[index]
+    source.write_text(yaml.safe_dump(handoffs, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(StoryPackageError, match="continuity_initiative_known.*no FactDelivery"):
+        load_story_package(root)
+
+
+def test_loader_rejects_duplicate_fact_delivery(tmp_path: Path) -> None:
+    root = copied_package(tmp_path)
+    source, handoffs = _handoffs(root)
+    handoffs["deliveries"].append(dict(handoffs["deliveries"][0]))  # type: ignore[index]
+    source.write_text(yaml.safe_dump(handoffs, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(StoryPackageError, match="continuity_initiative_known.*more than one"):
+        load_story_package(root)
+
+
+def test_loader_rejects_delivery_source_outside_scene_participants(tmp_path: Path) -> None:
+    root = copied_package(tmp_path)
+    source, handoffs = _handoffs(root)
+    delivery = next(item for item in handoffs["deliveries"] if item["fact_id"] == "brandon_identified")  # type: ignore[index]
+    delivery["source_entity_id"] = "rebecca"
+    source.write_text(yaml.safe_dump(handoffs, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(StoryPackageError, match="brandon_identified.*source entity.*rebecca.*absent"):
+        load_story_package(root)
+
+
+def test_loader_rejects_delivery_fallback_that_misses_a_required_phrase(tmp_path: Path) -> None:
+    root = copied_package(tmp_path)
+    source, handoffs = _handoffs(root)
+    delivery = next(item for item in handoffs["deliveries"] if item["fact_id"] == "facility_proof")  # type: ignore[index]
+    delivery["fallback_text"] = "The terminal is quiet and empty."
+    source.write_text(yaml.safe_dump(handoffs, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(StoryPackageError, match="facility_proof.*fallback_text.*fresh tire tracks"):
+        load_story_package(root)
+
+
+def test_loader_rejects_delivery_for_world_only_fact(tmp_path: Path) -> None:
+    root = copied_package(tmp_path)
+    source, handoffs = _handoffs(root)
+    handoffs["deliveries"].append(  # type: ignore[index]
+        {
+            "fact_id": "rebecca_observing_infiltrators",
+            "scene_id": "2A",
+            "source_kind": "observation",
+            "must_convey": [["security alert"], ["Rebecca is watching"]],
+            "fallback_text": "The security alert makes clear that Rebecca is watching.",
+        }
+    )
+    source.write_text(yaml.safe_dump(handoffs, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(StoryPackageError, match="rebecca_observing_infiltrators.*no player-visible"):
+        load_story_package(root)
+
+
+def test_loader_rejects_bridge_text_keys_that_do_not_match_transition_ids(tmp_path: Path) -> None:
+    root = copied_package(tmp_path)
+    source = root / "plot.md"
+    contents = source.read_text(encoding="utf-8")
+    contents = contents.replace("transition_ids: [t_1a_1b]", "transition_ids: []", 1)
+    source.write_text(contents, encoding="utf-8")
+
+    with pytest.raises(StoryPackageError, match="scene 1A bridge_text keys must match transition_ids exactly"):
         load_story_package(root)

--- a/tests/test_markdown_story_package.py
+++ b/tests/test_markdown_story_package.py
@@ -223,7 +223,12 @@ def test_loader_rejects_incomplete_knowledge_catalog(tmp_path: Path, field: str,
         ("plot.md", "scene_id: 1A", "scene_id: 9Z", "heading and frontmatter"),
         ("plot.md", "---\nscene_id: 1A", "scene_id: 1A", "lacks YAML frontmatter"),
         ("world.yaml", "mcgehee_home", "unknown_home", "unknown entities"),
-        ("pacing.yaml", "latest_seconds: 120", "latest_seconds: 30", "pacing timestamps"),
+        (
+            "pacing.yaml",
+            "min_turns: 2\n  nudge_after_turns: 2",
+            "min_turns: 3\n  nudge_after_turns: 2",
+            "turn allocations",
+        ),
         ("storylets.md", "**Pacing impact**", "**Impact**", "lacks sections"),
         ("storylets.md", "plot.md#scene-1a1", "plot.md#missing", "unknown plot heading"),
     ],
@@ -239,7 +244,7 @@ def test_loader_rejects_malformed_sources(tmp_path: Path, path: str, old: str, n
 def test_loader_rejects_storylet_window_outside_parent_scene(tmp_path: Path) -> None:
     root = copied_package(tmp_path)
     source = root / "storylets.md"
-    source.write_text(source.read_text().replace("latest: `00:05:00`", "latest: `00:05:01`", 1))
+    source.write_text(source.read_text().replace("latest: `turn 3`", "latest: `turn 4`", 1))
     with pytest.raises(StoryPackageError, match="escapes its scene pacing window"):
         load_story_package(root)
 
@@ -278,7 +283,7 @@ def test_loader_rejects_unknown_trigger_predicate_and_fallback(tmp_path: Path) -
     [
         ("plot.md", "## Scene", "### Scene", "unknown scene"),
         ("storylets.md", "**Allowed scene:** `1A`", "**Allowed scene:** `1B`", "invalid allowed scene"),
-        ("storylets.md", "earliest: `00:00:00`", "earliest: `00:99:00`", "invalid timestamp"),
+        ("storylets.md", "earliest: `turn 0`", "earliest: `later`", "invalid turn offset"),
         (
             "pacing.yaml",
             "  - memory_card",

--- a/tests/test_markdown_story_package.py
+++ b/tests/test_markdown_story_package.py
@@ -194,6 +194,18 @@ def test_loader_indexes_reachable_knowledge_prerequisites(tmp_path: Path) -> Non
     assert "k_sl_1b_a_r1" in package.knowledge_indexes.prerequisite_dependents["michelle_abduction_suspicion"]
 
 
+def test_loader_rejects_selectable_transition_trigger_without_must_convey(tmp_path: Path) -> None:
+    root = copied_package(tmp_path)
+    source = root / "knowledge.yaml"
+    catalog = yaml.safe_load(source.read_text())
+    candidate = next(item for item in catalog["knowledge"] if item["id"] == "k_sl_1a_d_r1")
+    candidate.pop("must_convey")
+    source.write_text(yaml.safe_dump(catalog, sort_keys=False))
+
+    with pytest.raises(StoryPackageError, match="must_convey"):
+        load_story_package(root)
+
+
 @pytest.mark.parametrize(("field", "message"), [("facts", "facts must define"), ("scene_frames", "safe scene frame")])
 def test_loader_rejects_incomplete_knowledge_catalog(tmp_path: Path, field: str, message: str) -> None:
     root = copied_package(tmp_path)

--- a/tests/test_must_convey.py
+++ b/tests/test_must_convey.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from storygame.runtime.validation import unconveyed_terms
+from storygame.story_package import load_story_package
+
+PACKAGE = Path("data/stories/continuity-initiative")
 
 
 def test_unconveyed_terms_normalizes_case_curly_punctuation_dashes_and_spacing() -> None:
@@ -22,3 +27,56 @@ def test_unconveyed_terms_returns_the_first_phrase_for_each_missed_group() -> No
 
 def test_unconveyed_terms_empty_groups_are_empty() -> None:
     assert unconveyed_terms((), "anything") == ()
+
+
+def test_unconveyed_terms_matches_a_whole_word() -> None:
+    assert unconveyed_terms((("card",),), "The card is on the table.") == ()
+
+
+def test_unconveyed_terms_matches_an_ordinary_english_ending() -> None:
+    assert unconveyed_terms((("relay",), ("open",)), "The relays opened.") == ()
+
+
+def test_unconveyed_terms_matches_each_supported_ordinary_ending() -> None:
+    groups = (("relay",), ("watch",), ("wash",), ("use",), ("open",))
+
+    assert unconveyed_terms(groups, "Relays watches washed used opening.") == ()
+
+
+def test_unconveyed_terms_rejects_a_phrase_inside_a_longer_word() -> None:
+    assert unconveyed_terms((("card",),), "The discarded item is here.") == ("card",)
+
+
+def test_unconveyed_terms_requires_multi_word_phrasings_to_be_contiguous() -> None:
+    groups = (("memory card",),)
+
+    assert unconveyed_terms(groups, "The memory was hidden beside the card.") == ("memory card",)
+    assert unconveyed_terms(groups, "The hidden memory cards were recovered.") == ()
+
+
+def test_no_delivery_is_conveyed_by_another_delivery_fallback() -> None:
+    package = load_story_package(PACKAGE)
+
+    for delivery in package.deliveries:
+        for other_delivery in package.deliveries:
+            if delivery.fact_id == other_delivery.fact_id:
+                continue
+            assert unconveyed_terms(delivery.must_convey, other_delivery.fallback_text), (
+                delivery.fact_id,
+                other_delivery.fact_id,
+            )
+
+
+def test_generic_prose_conveys_no_delivery() -> None:
+    package = load_story_package(PACKAGE)
+
+    for delivery in package.deliveries:
+        assert unconveyed_terms(delivery.must_convey, "The situation changed."), delivery.fact_id
+
+
+def test_gated_reveal_statements_convey_their_own_groups() -> None:
+    package = load_story_package(PACKAGE)
+
+    for knowledge in package.knowledge.knowledge:
+        if knowledge.must_convey:
+            assert not unconveyed_terms(knowledge.must_convey, knowledge.statement), knowledge.id

--- a/tests/test_must_convey.py
+++ b/tests/test_must_convey.py
@@ -1,0 +1,24 @@
+"""Unit coverage for deterministic authored reveal requirements."""
+
+from __future__ import annotations
+
+from storygame.runtime.validation import unconveyed_terms
+
+
+def test_unconveyed_terms_normalizes_case_curly_punctuation_dashes_and_spacing() -> None:
+    groups = (("Memory—card", "unused card"), ("Michelle's note", "other note"))
+
+    assert unconveyed_terms(groups, "  the MEMORY-card\nwas from Michelle’s   note. ") == ()
+
+
+def test_unconveyed_terms_returns_the_first_phrase_for_each_missed_group() -> None:
+    groups = (("first missing", "alternate"), ("second missing",), ("found", "other"))
+
+    assert unconveyed_terms(groups, "The found details are here.") == (
+        "first missing",
+        "second missing",
+    )
+
+
+def test_unconveyed_terms_empty_groups_are_empty() -> None:
+    assert unconveyed_terms((), "anything") == ()

--- a/tests/test_pacing_handoff.py
+++ b/tests/test_pacing_handoff.py
@@ -9,7 +9,7 @@ from storygame.runtime.cloudflare import CloudflareTurnProvider
 from storygame.runtime.engine import RuntimeEngine
 from storygame.runtime.facts import Fact
 from storygame.runtime.knowledge import KnowledgeProjector
-from storygame.runtime.state import RuntimeState
+from storygame.runtime.state import RuntimeState, TurnDelivery
 from storygame.story_package.loader import load_story_package
 from storygame.story_package.models import ActivationRule
 
@@ -47,6 +47,16 @@ def _fallback_delivery_text(state: RuntimeState) -> str:
     return " ".join(deliveries[fact_id].fallback_text for fact_id in state.staged_handoff_fact_ids)
 
 
+def test_ordinary_turn_records_no_delivery_recovery_or_fallback() -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.last_turn_delivery = TurnDelivery(must_convey_misses=("previous_fact",), recovery_used=True)
+    engine = RuntimeEngine(state, lambda _input: {"segments": [{"kind": "narration", "text": "I listen."}]})
+
+    engine.turn("I listen.")
+
+    assert state.last_turn_delivery == TurnDelivery()
+
+
 def test_activation_rule_minimal_undelivered_facts_is_small_stable_and_non_repeating() -> None:
     rule = ActivationRule(
         all_facts_true=("mandatory_a", "mandatory_b"),
@@ -80,6 +90,8 @@ def test_hint_then_handoff_delivers_only_missing_facts_costs_and_transition() ->
     assert state.staged_handoff_fact_ids == ()
     assert not state.facts.has("transport_route_identified", "story", value="true")
     assert hint.segments[0].text == "A clue catches my attention."
+    assert state.last_turn_delivery.hint_staged is True
+    assert state.last_turn_delivery.handoff_staged is False
 
     handoff = engine.turn("I keep watching the park.")
     assert state.current_scene_id == "1C"
@@ -89,6 +101,8 @@ def test_hint_then_handoff_delivers_only_missing_facts_costs_and_transition() ->
     assert state.facts.has("transport_route_departure_ready", "story", value="true")
     assert state.staged_hint_fact_ids == ()
     assert state.staged_handoff_fact_ids == ()
+    assert state.last_turn_delivery.hint_staged is True
+    assert state.last_turn_delivery.handoff_staged is True
     texts = [segment.text for segment in handoff.segments]
     source_bridge = next(
         scene.metadata.bridge_text["t_1b_1c"] for scene in PACKAGE.scenes if scene.metadata.scene_id == "1B"
@@ -122,6 +136,30 @@ def test_projected_handoff_contract_is_player_safe_and_prompt_preserves_agency(m
     assert "this is a hint turn" in captured["payload"]["system"].casefold()
 
 
+def test_conveying_handoff_uses_one_worker_request_without_recovery_or_fallback(monkeypatch) -> None:
+    state = _state_1b()
+    state.staged_handoff_fact_ids = ("transport_route_identified",)
+    payloads: list[dict[str, object]] = []
+    delivery = next(item for item in PACKAGE.deliveries if item.fact_id == "transport_route_identified")
+
+    def open_request(request, **_kwargs: object) -> _Response:
+        payloads.append(json.loads(request.data))
+        return _Response(
+            {"narration": json.dumps({"segments": [{"kind": "narration", "text": delivery.fallback_text}]})}
+        )
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+    response = provider("I keep watching the park.")
+
+    assert len(payloads) == 1
+    assert response["segments"][0]["text"] == delivery.fallback_text
+    assert state.last_turn_delivery.must_convey_misses == ()
+    assert state.last_turn_delivery.recovery_used is False
+    assert state.last_turn_delivery.fallback_used is False
+    assert state.last_turn_delivery.handoff_staged is True
+
+
 def test_handoff_recovery_names_missed_groups_and_falls_back_to_authored_text(monkeypatch) -> None:
     state = _state_1b()
     state.staged_handoff_fact_ids = ("transport_route_identified",)
@@ -138,6 +176,10 @@ def test_handoff_recovery_names_missed_groups_and_falls_back_to_authored_text(mo
     assert len(payloads) == 2
     assert delivery.must_convey[0][0] in payloads[1]["system"]
     assert response["segments"][0]["text"] == delivery.fallback_text
+    assert state.last_turn_delivery.must_convey_misses == (delivery.fact_id,)
+    assert state.last_turn_delivery.recovery_used is True
+    assert state.last_turn_delivery.fallback_used is True
+    assert state.last_turn_delivery.handoff_staged is True
 
 
 def test_valid_handoff_recovery_is_accepted_once_and_keeps_direct_response(monkeypatch) -> None:

--- a/tests/test_pacing_handoff.py
+++ b/tests/test_pacing_handoff.py
@@ -1,0 +1,160 @@
+"""Two-stage pacing delivery and authored transition coverage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from storygame.runtime.cloudflare import CloudflareTurnProvider
+from storygame.runtime.engine import RuntimeEngine
+from storygame.runtime.facts import Fact
+from storygame.runtime.knowledge import KnowledgeProjector
+from storygame.runtime.state import RuntimeState
+from storygame.story_package.loader import load_story_package
+from storygame.story_package.models import ActivationRule
+
+PACKAGE = load_story_package(Path("data/stories/continuity-initiative"))
+
+
+class _Response:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode()
+
+
+def _state_1b() -> RuntimeState:
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.current_scene_id = "1B"
+    state.phase = next(scene.metadata.freytag_phase for scene in PACKAGE.scenes if scene.metadata.scene_id == "1B")
+    state._assert_scene_entry_fact("1B")
+    state.scene_entered_at_turn = 0
+    state.turn_index = 2
+    state.facts.assert_fact(Fact(predicate="park_pursuit_resolved", subject="story", value="true"))
+    state.facts.assert_fact(Fact(predicate="trust_brandon", subject="story", value="true"))
+    return state
+
+
+def _fallback_delivery_text(state: RuntimeState) -> str:
+    deliveries = {delivery.fact_id: delivery for delivery in PACKAGE.deliveries}
+    return " ".join(deliveries[fact_id].fallback_text for fact_id in state.staged_handoff_fact_ids)
+
+
+def test_activation_rule_minimal_undelivered_facts_is_small_stable_and_non_repeating() -> None:
+    rule = ActivationRule(
+        all_facts_true=("mandatory_a", "mandatory_b"),
+        any_of=("pool_a", "pool_b", "pool_c"),
+        at_least=2,
+    )
+
+    assert rule.minimal_undelivered_facts({"mandatory_a", "pool_a"}) == ("mandatory_b", "pool_b")
+    assert rule.minimal_undelivered_facts({"mandatory_a", "mandatory_b", "pool_a", "pool_b"}) == ()
+    assert ActivationRule(any_of=("pool_a", "pool_b"), at_least=1).minimal_undelivered_facts(set()) == ("pool_a",)
+    assert rule.minimal_undelivered_facts({"mandatory_a"}) == ("mandatory_b", "pool_a", "pool_b")
+    assert rule.minimal_undelivered_facts({"mandatory_a"}) == rule.minimal_undelivered_facts({"mandatory_a"})
+
+
+def test_hint_then_handoff_delivers_only_missing_facts_costs_and_transition() -> None:
+    state = _state_1b()
+    responses = iter(({"segments": [{"kind": "narration", "text": "A clue catches my attention."}]},))
+    calls = 0
+
+    def provider(_input: str) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return next(responses)
+        return {"segments": [{"kind": "narration", "text": _fallback_delivery_text(state)}]}
+
+    engine = RuntimeEngine(state, provider)
+
+    hint = engine.turn("I wait and listen.")
+    assert state.staged_hint_fact_ids == ("transport_route_identified", "brandon_identified")
+    assert state.staged_handoff_fact_ids == ()
+    assert not state.facts.has("transport_route_identified", "story", value="true")
+    assert hint.segments[0].text == "A clue catches my attention."
+
+    handoff = engine.turn("I keep watching the park.")
+    assert state.current_scene_id == "1C"
+    assert not state.facts.has("trust_brandon", "story", value="true")
+    assert state.facts.has("transport_route_identified", "story", value="true")
+    assert state.facts.has("brandon_identified", "story", value="true")
+    assert state.facts.has("transport_route_departure_ready", "story", value="true")
+    assert state.staged_hint_fact_ids == ()
+    assert state.staged_handoff_fact_ids == ()
+    texts = [segment.text for segment in handoff.segments]
+    source_bridge = next(
+        scene.metadata.bridge_text["t_1b_1c"] for scene in PACKAGE.scenes if scene.metadata.scene_id == "1B"
+    )
+    target_entry = next(scene.metadata.entry_text for scene in PACKAGE.scenes if scene.metadata.scene_id == "1C")
+    assert texts.index(source_bridge) < texts.index(target_entry)
+
+
+def test_projected_handoff_contract_is_player_safe_and_prompt_preserves_agency(monkeypatch) -> None:
+    state = _state_1b()
+    state.staged_hint_fact_ids = ("transport_route_identified",)
+    state.staged_handoff_fact_ids = ("transport_route_identified",)
+    captured: dict[str, object] = {}
+
+    def open_request(request, **_kwargs: object) -> _Response:
+        captured["payload"] = json.loads(request.data)
+        return _Response({"narration": '{"segments":[{"kind":"narration","text":"I keep watch."}]}'})
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+    provider("I keep watch.")
+    projection = KnowledgeProjector().project(state, "player", "I keep watch.")
+    assert [item.fact_id for item in projection.hinted_deliveries] == ["transport_route_identified"]
+    assert [item.fact_id for item in projection.handoff_deliveries] == ["transport_route_identified"]
+    serialized = json.dumps(captured["payload"]).casefold()
+    assert "rebecca_observing_infiltrators" not in serialized
+    assert "this is a handoff turn" in captured["payload"]["system"].casefold()
+    assert "do not claim that the player took an action they did not take" in captured["payload"]["system"].casefold()
+    state.staged_handoff_fact_ids = ()
+    provider("I keep watch.")
+    assert "this is a hint turn" in captured["payload"]["system"].casefold()
+
+
+def test_handoff_recovery_names_missed_groups_and_falls_back_to_authored_text(monkeypatch) -> None:
+    state = _state_1b()
+    state.staged_handoff_fact_ids = ("transport_route_identified",)
+    payloads: list[dict[str, object]] = []
+    delivery = next(item for item in PACKAGE.deliveries if item.fact_id == "transport_route_identified")
+
+    def open_request(request, **_kwargs: object) -> _Response:
+        payloads.append(json.loads(request.data))
+        return _Response({"narration": '{"segments":[{"kind":"narration","text":"I wait."}]}'})
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+    response = provider("I wait.")
+    assert len(payloads) == 2
+    assert delivery.must_convey[0][0] in payloads[1]["system"]
+    assert response["segments"][0]["text"] == delivery.fallback_text
+
+
+def test_valid_handoff_recovery_is_accepted_once_and_keeps_direct_response(monkeypatch) -> None:
+    state = _state_1b()
+    state.staged_handoff_fact_ids = ("transport_route_identified",)
+    payloads: list[dict[str, object]] = []
+    delivery = next(item for item in PACKAGE.deliveries if item.fact_id == "transport_route_identified")
+    text = "I search the route. " + delivery.fallback_text
+
+    def open_request(request, **_kwargs: object) -> _Response:
+        payloads.append(json.loads(request.data))
+        if len(payloads) == 1:
+            return _Response({"narration": '{"segments":[{"kind":"narration","text":"I search the route."}]}'})
+        return _Response({"narration": json.dumps({"segments": [{"kind": "narration", "text": text}]})})
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+    response = provider("I search the route.")
+    assert len(payloads) == 2
+    assert response["segments"][0]["text"] == text

--- a/tests/test_scene_progression_phase4.py
+++ b/tests/test_scene_progression_phase4.py
@@ -108,19 +108,23 @@ def test_a_fully_conveyed_reveal_commits_and_opens_the_scene_exit() -> None:
     state.active_event_ids.add("SL-1A-B")
     engine = RuntimeEngine(
         state,
-        lambda _: {
-            "segments": [
-                {
-                    "kind": "narration",
-                    "text": (
-                        "Kristin finds Michelle's hidden memory card and damaged recording; the card points to a "
-                        "dead drop at a bench in the park."
-                    ),
-                    "grounding_ids": ["k_sl_1a_b_r1"],
-                }
-            ],
-            "selected_knowledge_ids": ["k_sl_1a_b_r1"],
-        },
+        lambda _: (
+            {
+                "segments": [
+                    {
+                        "kind": "narration",
+                        "text": (
+                            "Kristin finds Michelle's hidden memory card and damaged recording; the card points to a "
+                            "dead drop at a bench in the park."
+                        ),
+                        "grounding_ids": ["k_sl_1a_b_r1"],
+                    }
+                ],
+                "selected_knowledge_ids": ["k_sl_1a_b_r1"],
+            }
+            if not state.fired_event_ids
+            else _turn("The house holds its breath while Kristin decides what to do next.")
+        ),
     )
 
     engine.turn("I look under the workstation.", clock_seconds=120)
@@ -128,6 +132,10 @@ def test_a_fully_conveyed_reveal_commits_and_opens_the_scene_exit() -> None:
     assert state.facts.has("continuity_initiative_known", "story", value="true")
     assert state.facts.has("michelle_lead_actionable", "story", value="true")
     assert "SL-1A-B" in state.fired_event_ids
+    assert state.current_scene_id == "1A"
+
+    engine.turn("I take the lead and leave the house.")
+
     assert state.current_scene_id == "1B"
 
 

--- a/tests/test_scene_progression_phase4.py
+++ b/tests/test_scene_progression_phase4.py
@@ -83,18 +83,52 @@ def test_a_reveal_the_narration_never_delivers_cannot_commit_or_move_the_scene()
     engine = RuntimeEngine(
         state,
         lambda _: {
-            "segments": [{"kind": "narration", "text": "A faint scratch and a few loose screws, nothing more."}],
+            "segments": [
+                {
+                    "kind": "narration",
+                    "text": "Michelle fears the emergency broadcasts.",
+                    "grounding_ids": ["k_sl_1a_b_r1"],
+                }
+            ],
             "selected_knowledge_ids": ["k_sl_1a_b_r1"],
         },
     )
 
-    with pytest.raises(ProposalValidationError, match="grounded"):
-        engine.turn("I look under the workstation.")
+    with pytest.raises(ProposalValidationError, match="memory card"):
+        engine.turn("I look under the workstation.", clock_seconds=120)
 
     assert not state.facts.has("continuity_initiative_known", "story", value="true")
     assert not state.facts.has("michelle_lead_actionable", "story", value="true")
     assert "SL-1A-B" not in state.fired_event_ids
     assert state.current_scene_id == "1A", "the story may not leave the house on a reveal the player never read"
+
+
+def test_a_fully_conveyed_reveal_commits_and_opens_the_scene_exit() -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.active_event_ids.add("SL-1A-B")
+    engine = RuntimeEngine(
+        state,
+        lambda _: {
+            "segments": [
+                {
+                    "kind": "narration",
+                    "text": (
+                        "Kristin finds Michelle's hidden memory card and damaged recording; the card points to a "
+                        "dead drop at a bench in the park."
+                    ),
+                    "grounding_ids": ["k_sl_1a_b_r1"],
+                }
+            ],
+            "selected_knowledge_ids": ["k_sl_1a_b_r1"],
+        },
+    )
+
+    engine.turn("I look under the workstation.", clock_seconds=120)
+
+    assert state.facts.has("continuity_initiative_known", "story", value="true")
+    assert state.facts.has("michelle_lead_actionable", "story", value="true")
+    assert "SL-1A-B" in state.fired_event_ids
+    assert state.current_scene_id == "1B"
 
 
 def test_declared_pressure_event_advances_without_provider_timing_or_prose_parsing() -> None:

--- a/tests/test_scene_relative_pacing.py
+++ b/tests/test_scene_relative_pacing.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from storygame.runtime.engine import RuntimeEngine
+from storygame.runtime.facts import Fact
+from storygame.runtime.state import RuntimeState
+from storygame.story_package import StoryPackageError, load_story_package
+
+PACKAGE = load_story_package(Path("data/stories/continuity-initiative"))
+
+
+def _quiet_turn(_input: str) -> dict[str, object]:
+    return {"segments": [{"kind": "narration", "text": "The investigation continues."}]}
+
+
+def test_turn_index_keeps_counting_and_scene_entry_resets_relative_turns() -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.facts.assert_fact(Fact(predicate="michelle_lead_actionable", subject="story", value="true"))
+    state.facts.assert_fact(Fact(predicate="patrol_return_pressure", subject="story", value="true"))
+    engine = RuntimeEngine(state, _quiet_turn)
+
+    engine.turn("I investigate.")
+    assert state.turn_index == 1
+    assert state.current_scene_id == "1A"
+    assert state.turn_index - state.scene_entered_at_turn == 1
+
+    engine.turn("I leave when the lead is ready.")
+    assert state.turn_index == 2
+    assert state.current_scene_id == "1B"
+    assert state.scene_entered_at_turn == 2
+    assert state.turn_index - state.scene_entered_at_turn == 0
+
+    engine.turn("I keep moving.")
+    assert state.turn_index == 3
+    assert state.turn_index - state.scene_entered_at_turn == 1
+
+
+def test_min_turns_floor_blocks_a_committed_trigger_until_source_turns_are_played() -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.facts.assert_fact(Fact(predicate="michelle_lead_actionable", subject="story", value="true"))
+    state.facts.assert_fact(Fact(predicate="patrol_return_pressure", subject="story", value="true"))
+    engine = RuntimeEngine(state, _quiet_turn)
+
+    engine.turn("I rush toward the exit.", clock_seconds=3600)
+    assert state.current_scene_id == "1A"
+
+    engine.turn("I take the lead and go.", clock_seconds=0)
+    assert state.current_scene_id == "1B"
+
+
+def test_each_scene_entry_starts_with_a_full_relative_turn_allowance() -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    engine = RuntimeEngine(state, _quiet_turn)
+
+    for transition in PACKAGE.pacing.transitions:
+        window = next(item for item in PACKAGE.pacing.scenes if item.scene_id == transition.source_scene_id)
+        for _ in range(window.min_turns):
+            engine.turn("I take another careful turn.")
+        for trigger in transition.triggers:
+            state.facts.assert_fact(Fact(predicate=trigger.fact_id, subject="story", value=str(trigger.equals).lower()))
+        engine.turn("I follow the opening.")
+        assert state.current_scene_id == transition.target_scene_id
+        assert state.turn_index == state.scene_entered_at_turn
+
+
+def test_storylet_activation_uses_scene_relative_turns_after_a_late_clock() -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.facts.assert_fact(Fact(predicate="story_elapsed_seconds", subject="story", value="600"))
+    engine = RuntimeEngine(state, _quiet_turn)
+
+    engine._activate_pacing()  # noqa: SLF001 - exercise the pacing boundary directly.
+    assert "SL-1A-B" not in state.active_event_ids
+
+    state.turn_index = 2
+    engine._activate_pacing()  # noqa: SLF001 - the second scene-relative turn opens the storylet.
+    assert "SL-1A-B" in state.active_event_ids
+
+
+def test_loader_rejects_out_of_order_scene_turn_allocation(tmp_path: Path) -> None:
+    root = tmp_path / "package"
+    shutil.copytree(Path("data/stories/continuity-initiative"), root)
+    source = root / "pacing.yaml"
+    old = "min_turns: 2\n  nudge_after_turns: 2"
+    new = "min_turns: 3\n  nudge_after_turns: 2"
+    source.write_text(source.read_text().replace(old, new, 1))
+
+    with pytest.raises(StoryPackageError, match="turn allocations must be ordered"):
+        load_story_package(root)
+
+
+def test_loader_rejects_handoff_sum_over_budget(tmp_path: Path) -> None:
+    root = tmp_path / "package"
+    shutil.copytree(Path("data/stories/continuity-initiative"), root)
+    source = root / "pacing.yaml"
+    source.write_text(source.read_text().replace("budget_seconds: 1800", "budget_seconds: 1799", 1))
+
+    with pytest.raises(StoryPackageError, match="handoff sum.*budget_seconds"):
+        load_story_package(root)

--- a/tests/test_scene_roleplay_contract.py
+++ b/tests/test_scene_roleplay_contract.py
@@ -31,7 +31,10 @@ def _selection_provider(state: RuntimeState, calls: list[str]) -> Callable[[str]
             "segments": [
                 {
                     "kind": "narration",
-                    "text": "The current scene gains a concrete lead.",
+                    "text": (
+                        "Kristin finds Michelle's hidden memory card and damaged recording; the card points to a "
+                        "dead drop at a bench in the park."
+                    ),
                     "grounding_ids": ["k_sl_1a_b_r1"],
                 }
             ],

--- a/tests/test_web_demo.py
+++ b/tests/test_web_demo.py
@@ -98,6 +98,13 @@ def test_hosted_adapter_reports_identity_and_serves_a_story_session(monkeypatch,
     assert opening["scene_id"] == "1A"
     assert turn.json()["segments"][0]["text"] == "The lead sharpens."
     assert turn.json()["lines"] == ["The lead sharpens."]
+    assert turn.json()["delivery"] == {
+        "must_convey_misses": [],
+        "recovery_used": False,
+        "fallback_used": False,
+        "hint_staged": False,
+        "handoff_staged": False,
+    }
 
 
 def test_provider_authored_operations_are_rejected_before_session_mutation(tmp_path) -> None:

--- a/tests/test_web_demo.py
+++ b/tests/test_web_demo.py
@@ -80,6 +80,8 @@ def test_hosted_adapter_reports_identity_and_serves_a_story_session(monkeypatch,
         "fired_storylet_ids": [],
         "fired_pacing_event_ids": [],
         "story_elapsed_seconds": 0,
+        "turn_index": 0,
+        "turns_since_scene_entry": 0,
     }
     opening = session.json()["opening"]
     entry_text = PACKAGE.scenes[0].metadata.entry_text
@@ -105,6 +107,22 @@ def test_hosted_adapter_reports_identity_and_serves_a_story_session(monkeypatch,
         "hint_staged": False,
         "handoff_staged": False,
     }
+
+
+def test_hosted_adapter_reports_turn_index_and_scene_relative_turns(tmp_path) -> None:
+    app = create_demo_app(
+        store_path=tmp_path / "sessions.sqlite",
+        provider_factory=lambda _state: _provider("The lead sharpens."),
+    )
+    with TestClient(app) as client:
+        session = client.post("/api/v1/session", json={"story_id": "continuity_initiative"})
+        session_id = session.json()["session_id"]
+        turn = client.post("/api/v1/turn", json={"session_id": session_id, "player_input": "I listen."})
+
+    assert session.json()["state"]["turn_index"] == 0
+    assert session.json()["state"]["turns_since_scene_entry"] == 0
+    assert turn.json()["state"]["turn_index"] == 1
+    assert turn.json()["state"]["turns_since_scene_entry"] == 1
 
 
 def test_provider_authored_operations_are_rejected_before_session_mutation(tmp_path) -> None:


### PR DESCRIPTION
Fixes the reported Scene 1A → 1B break, and establishes one story-agnostic policy for every scene exit: a scene advances only after the player receives a legible, in-world reason for the destination, and a player who misses evidence is nudged, then carried, by a declared diegetic source — never by prose asserting they discovered something they did not.

Implements `.plans/scene-reveal-delivery-and-travel-bridge.md` in dependency order.

## What was actually wrong

Four defects. The first two are the reported bug; the last two are why the obvious fix would not have held up across the other eight scenes.

1. **Reveal delivery was unverified.** The resolver proved only that the selected knowledge ID appeared in some segment's `grounding_ids`, never that the prose said it. A model could select the memory-card reveal, narrate only its broadcast-warning half, and still commit `michelle_lead_actionable`.
2. **Scene 1A had a content defect.** `k_sl_1a_b_r1` asserted that fact while its own statement named no lead and no place. The reported transcript was a faithful rendering of a defective statement.
3. **Bridge events required a full conjunction of facts.** Storylets fire once and most facts have a single source, so a player who explored differently rather than incompletely was permanently stuck — not late, stuck.
4. **Pacing was absolute, so lateness compounded.** From 2B onward an ordinary player entered every scene already past its window, and storylet activation had the mirror bug: a late arrival found every storylet in the scene active at once.

## The commits

| | |
|---|---|
| `a03df8b` | Verify a reveal is actually told before it commits |
| `ad72d03` | Let a scene exit on a threshold, not a full conjunction |
| `5e3dec3` | Measure pacing from scene entry, counted in turns |
| `f0a292d` | Declare how a missed fact can reach the player, in world |
| `3e816d0` | Hint before handing off, and never assert an unearned discovery |
| `13cd451` | Let the keyword gate survive words nobody authored |
| `ee5b45a` | Count what the delivery system actually does in play |
| `0824d0e` | Point the browser pacing harness at turns |
| `75790e9` | Record the 1A continuity fix in the runbook, and what is still unverified |

## Notable consequences

- **The budget is now 30 minutes**, expressed as 30 turns at 60 story-seconds each. The per-scene handoff allowance sums to exactly that.
- **`SNAPSHOT_VERSION` is 2.** Saved snapshots gain the turn counters.
- **One fact is deliberately exempt from delivery.** `rebecca_observing_infiltrators` is established only by `world_only` definitions, so handing it to the player would leak protected knowledge. The loader enforces both directions: every player-safe bridge fact needs a delivery, and declaring one for a world-only fact is an error.
- **A loosened bridge also fires earlier**, which is why the canon journey defers a Scene 2B realization and why the `min_turns` floor now sits on the source scene.

## Verification

Local, on 2026-08-30:

- `TMPDIR=/tmp uv run pytest -q` — 177 passed, 91.29% coverage (was 127 at 91.10%)
- `npm --prefix frontend test` — 30 passed, 0 failed (was 30 passed, 2 failed)
- Every `test.yml` job run locally, including the parallel coverage gate

**Not yet verified against a deployment.** The hosted `@llm-canon` run is the next step, and the runbook's 2026-08-29 hosted observation is explicitly marked stale: its turn counts predate turn-based pacing, and the `@package-clock` Playwright specs were changed but could not be executed without a live deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd4cgdSQJFk8MP3xjkhqa