### PR TITLE
Stop losing turns to an oversized generation cap, and log why when one is lost

### DIFF
--- a/frontend/e2e/scene-runtime.spec.js
+++ b/frontend/e2e/scene-runtime.spec.js
@@ -308,7 +308,6 @@ test("samples optional storylets without presenting a menu @storylets", async ({
 });
 
 test("keeps the display budget clock independent from turn-based pressure @timed-events", async ({ page }) => {
-  test.skip(!process.env.E2E_TEST_CLOCK_SECONDS, "requires the local test clock");
   await startSceneSession(page);
   await submitTurn(page, "I pause long enough for the house's pressure to build.");
   const payload = await submitTurn(page, "I listen for the pressure that follows.");

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -19,7 +19,6 @@ export default defineConfig({
       ...process.env,
       VITE_API_BASE_URL: apiBaseUrl,
       VITE_DEPLOYMENT_CHANNEL: process.env.E2E_DEPLOYMENT_CHANNEL || "production",
-      VITE_E2E_TEST_CLOCK_SECONDS: process.env.E2E_TEST_CLOCK_SECONDS || "",
     },
   },
 });

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,7 +3,6 @@ import { turnBlocks } from "./turn_rendering.js";
 
 const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || "").trim().replace(/\/+$/, "");
 const DEPLOYMENT_CHANNEL = (import.meta.env.VITE_DEPLOYMENT_CHANNEL || "production").trim();
-const E2E_TEST_CLOCK_SECONDS = (import.meta.env.VITE_E2E_TEST_CLOCK_SECONDS || "").trim();
 const DEFAULT_SESSION_PAYLOAD = { story_id: "continuity_initiative" };
 
 const transcriptElement = document.querySelector("#transcript");
@@ -173,7 +172,6 @@ async function runCommand(command, echoInput = true) {
     const payload = await apiRequest("/api/v1/turn", {
       session_id: sessionId,
       player_input: command,
-      ...(E2E_TEST_CLOCK_SECONDS ? { test_clock_seconds: Number(E2E_TEST_CLOCK_SECONDS) } : {}),
     });
     renderTurn(payload);
     setStatus(`Scene ${payload.state.scene_id} • ${payload.state.phase.replaceAll("_", " ")}`);

--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from os import getenv
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
 
 from storygame.runtime.contracts import (
@@ -18,6 +20,8 @@ from storygame.runtime.knowledge import KnowledgeProjector, TurnKnowledgeContext
 from storygame.runtime.state import RuntimeState
 from storygame.runtime.validation import unconveyed_terms
 from storygame.story_package.models import Scene, SceneBeat, SceneMetadata
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -64,7 +68,18 @@ class CloudflareTurnProvider:
     def from_environment(cls, state: RuntimeState) -> CloudflareTurnProvider:
         worker_url = getenv("CLOUDFLARE_WORKER_URL", "").strip()
         if not worker_url:
-            raise NarrationProviderError("narration service is unavailable")
+            configuration_error = ValueError("CLOUDFLARE_WORKER_URL is not configured")
+            try:
+                raise configuration_error
+            except ValueError as error:
+                logger.warning(
+                    "Narration service unavailable (worker host=unconfigured; "
+                    "underlying exception type=%s; message=%s)",
+                    type(error).__name__,
+                    str(error),
+                    exc_info=True,
+                )
+                raise NarrationProviderError("narration service is unavailable") from error
         return cls(
             worker_url=worker_url,
             token=getenv("CLOUDFLARE_WORKER_TOKEN", "").strip(),
@@ -221,15 +236,18 @@ class CloudflareTurnProvider:
         payload = {
             "system": system,
             "user": json.dumps({**user, "response_schema": TurnProposal.model_json_schema()}, separators=(",", ":")),
-            "max_tokens": 2048,
+            "max_tokens": 1024,
             "response_format": {"type": "json_object"},
         }
         try:
             response = self._request_allowing_one_transient_retry(payload)
         except HTTPError as error:
-            if self._worker_error_code(error) != "AI_JSON_MODE_REJECTED":
+            worker_error_code = self._worker_error_code(error)
+            self._log_typed_worker_error(error, worker_error_code)
+            if worker_error_code != "AI_JSON_MODE_REJECTED":
                 raise self._narration_error(error) from error
         except (URLError, OSError, TimeoutError, ValueError, json.JSONDecodeError) as error:
+            self._log_unavailable(error)
             raise NarrationProviderError("narration service is unavailable") from error
         else:
             try:
@@ -243,8 +261,10 @@ class CloudflareTurnProvider:
         try:
             response = self._request_allowing_one_transient_retry(fallback_payload)
         except HTTPError as error:
+            self._log_typed_worker_error(error, self._worker_error_code(error))
             raise self._narration_error(error) from error
         except (URLError, OSError, TimeoutError, ValueError, json.JSONDecodeError) as error:
+            self._log_unavailable(error)
             raise NarrationProviderError("narration service is unavailable") from error
         return self._eligible_or_narration_only(response)
 
@@ -263,8 +283,10 @@ class CloudflareTurnProvider:
         try:
             response = self._request_allowing_one_transient_retry(recovery_payload)
         except HTTPError as error:
+            self._log_typed_worker_error(error, self._worker_error_code(error))
             raise self._narration_error(error) from error
         except (URLError, OSError, TimeoutError, ValueError, json.JSONDecodeError) as error:
+            self._log_unavailable(error)
             raise NarrationProviderError("narration service is unavailable") from error
         return self._eligible_or_narration_only(response)
 
@@ -505,6 +527,32 @@ class CloudflareTurnProvider:
         if isinstance(body, dict) and isinstance(body.get("narration"), str):
             return json.loads(body["narration"])
         return body
+
+    def _log_unavailable(self, error: BaseException) -> None:
+        logger.warning(
+            "Narration service unavailable (worker host=%s; underlying exception type=%s; message=%s)",
+            urlsplit(self.worker_url).hostname,
+            type(error).__name__,
+            self._safe_error_message(error),
+            exc_info=True,
+        )
+
+    def _log_typed_worker_error(self, error: HTTPError, worker_error_code: str) -> None:
+        logger.warning(
+            "Narration worker returned a typed error (worker host=%s; underlying exception type=%s; message=%s; "
+            "worker error code=%s)",
+            urlsplit(self.worker_url).hostname,
+            type(error).__name__,
+            self._safe_error_message(error),
+            worker_error_code or "UNKNOWN",
+            exc_info=True,
+        )
+
+    @staticmethod
+    def _safe_error_message(error: BaseException) -> str:
+        if isinstance(error, (HTTPError, URLError)):
+            return str(error.reason)
+        return str(error)
 
     @staticmethod
     def _worker_error_code(error: HTTPError) -> str:

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from io import BytesIO
 from pathlib import Path
 from urllib.error import HTTPError, URLError
@@ -50,7 +51,7 @@ def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None
     assert provider("I listen.") == {"segments": [{"kind": "narration", "text": "A valid proposal."}]}
     assert captured["headers"]["Authorization"] == "Bearer secret"
     assert "Mozilla/5.0" in captured["headers"]["User-agent"]
-    assert captured["payload"]["max_tokens"] == 2048
+    assert captured["payload"]["max_tokens"] == 1024
     assert captured["payload"]["response_format"] == {"type": "json_object"}
     context = json.loads(captured["payload"]["user"])["knowledge_context"]
     assert "response_schema" in captured["payload"]["user"]
@@ -585,7 +586,7 @@ def test_transport_reports_safe_contract_shape_after_failed_recovery(monkeypatch
     assert len(payloads) == 2
 
 
-def test_transport_preserves_worker_capacity_classification(monkeypatch) -> None:
+def test_transport_preserves_worker_capacity_classification(monkeypatch, caplog) -> None:
     provider = CloudflareTurnProvider(
         worker_url="https://worker.example/turn",
         token="",
@@ -600,10 +601,14 @@ def test_transport_preserves_worker_capacity_classification(monkeypatch) -> None
     )
     monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", lambda *_args, **_kwargs: (_ for _ in ()).throw(error))
 
-    with pytest.raises(NarrationProviderError) as caught:
+    with (
+        caplog.at_level(logging.WARNING, logger="storygame.runtime.cloudflare"),
+        pytest.raises(NarrationProviderError) as caught,
+    ):
         provider("I listen.")
     assert caught.value.status_code == 429
     assert caught.value.message == "narration service is at capacity"
+    assert any("AI_CAPACITY_EXCEEDED" in record.getMessage() for record in caplog.records)
 
 
 def test_transport_marks_untyped_worker_errors_for_diagnosis(monkeypatch) -> None:
@@ -618,6 +623,27 @@ def test_transport_marks_untyped_worker_errors_for_diagnosis(monkeypatch) -> Non
     with pytest.raises(NarrationProviderError) as caught:
         provider("I listen.")
     assert caught.value.error_code == "UNKNOWN"
+
+
+def test_truncated_worker_response_fails_closed_and_logs_decode_cause(monkeypatch, caplog) -> None:
+    provider = CloudflareTurnProvider(
+        worker_url="https://worker.example/turn",
+        token="",
+        state=RuntimeState.bootstrap(PACKAGE),
+    )
+    response = _Response({"narration": '{"segments":[{"kind":"narration","text":"cut off"}]}'})
+    response.body = response.body[:-1]
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", lambda *_args, **_kwargs: response)
+
+    with (
+        caplog.at_level(logging.WARNING, logger="storygame.runtime.cloudflare"),
+        pytest.raises(NarrationProviderError, match="unavailable"),
+    ):
+        provider("I listen.")
+
+    assert any(
+        record.levelno >= logging.WARNING and "JSONDecodeError" in record.getMessage() for record in caplog.records
+    )
 
 
 @pytest.mark.parametrize(("status", "expected"), ((429, 429), (500, 502)))


### PR DESCRIPTION
Follow-up to #411, fixing what the first hosted run against staging exposed.

## Two problems the hosted run found

**1. The browser sent a test clock it had no token for.** `main.js` added `test_clock_seconds` to every turn whenever a build-time variable was set, and never sent `test_clock_token`. The Playwright harness used to rewrite outgoing bodies and attach the token; that rewriter was removed in #411 when pacing became turn-based, because injecting a story-clock value can no longer advance anything. What remained was a request any deployment with the test clock enabled answers **403** on.

Removed the injection and the variable feeding it. `@timed-events` keeps its assertions and loses its skip guard — it needed no clock already, since two ordinary turns put the elapsed display at 120, `turn_index` at 2, and fire `pressure_1a` at turn 2 of 1A. Server-side `test_clock_seconds` handling is untouched.

**2. Roughly one turn in three died with 503 "narration service is unavailable".** Measured directly against the narration Worker with the real request shape, varying only the generation cap:

| `max_tokens` | Worker latency |
|---|---|
| 2048 (what we sent) | **8–16s** |
| 1024 | 5.2–6.1s |
| 512 | 2.5–3.4s |

Staging's successful turns took 1.5–3.2s; its failures took **10.5–13.2s** — the 2048 band exactly. A generation that long has its connection cut mid-response, the body arrives truncated, `json.loads` raises, and the outer handler reports the service unavailable. One attempt, not two, because the transient retry deliberately covers only `TimeoutError`, `URLError` and `OSError`.

A turn's narration is 100–150 words, about 200 tokens. 2048 reserved ten times what is used and paid for it in latency. Now 1024 — **not** 512, because handoff turns carry the longest narration in the game and truncating one would trip the delivery check and spend the recovery.

## Why it took so long to find

The deployment logs showed only a bare 503. The underlying exception was caught and converted to an `HTTPException` without ever being written down, so no traceback existed to read. Every site that reports the service unavailable now logs the exception type, a sanitised message, the worker host and a traceback — and never the payload, the narration, the prompts, or the token.

Ruled out along the way, each by direct measurement rather than inference: the Worker itself (200 in 0.57s), an 11KB payload (6/6), JSON mode (8/8), the free-plan Worker CPU limit, the model ID, and `CLOUDFLARE_TIMEOUT` — nothing was reaching a 60s ceiling, which is why raising it changed nothing.

## Verification

- `TMPDIR=/tmp uv run pytest -q` — 178 passed, 91.21% coverage
- `npm --prefix frontend test` — 30 passed, 0 failed
- The truncated-response case is now a test: it still raises `NarrationProviderError`, and now logs a WARNING naming the cause

Still unverified against a deployment: the hosted `@llm-canon` run, which is what this unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd4cgdSQJFk8MP3xjkhqa