### PR TITLE
Let the prose prove which segment reveals a fact

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -18,7 +18,7 @@ from storygame.runtime.contracts import (
 )
 from storygame.runtime.knowledge import KnowledgeProjector, TurnKnowledgeContext
 from storygame.runtime.state import RuntimeState
-from storygame.runtime.validation import unconveyed_terms
+from storygame.runtime.validation import derive_grounding, unconveyed_terms
 from storygame.story_package.models import Scene, SceneBeat, SceneMetadata
 
 logger = logging.getLogger(__name__)
@@ -380,13 +380,33 @@ class CloudflareTurnProvider:
                 "candidate you selected. Resend the same narration with an empty grounding_ids list; only if that ID "
                 "is one of this turn's candidates may you instead place it in selected_knowledge_ids.",
             )
+        candidates = {candidate.id: candidate for candidate in self.last_projection.candidates}
         # Selecting a reveal without telling it commits the fact silently: the scene's exit
         # unlocks and the player is moved somewhere the narration gave them no reason to go.
-        # The ID on a segment is the model's own claim that this is the sentence that reveals it.
+        # When the prose proves the reveal, derive the missing bookkeeping from that evidence.
         grounded = {grounding_id for segment in proposal.segments for grounding_id in segment.grounding_ids}
         undelivered = sorted(
             {knowledge_id for knowledge_id in proposal.selected_knowledge_ids if knowledge_id not in grounded}
         )
+        if undelivered:
+            derived_segments = derive_grounding(candidates[undelivered[0]].must_convey, proposal.segments)
+            if derived_segments:
+                proposal = proposal.model_copy(
+                    update={
+                        "segments": tuple(
+                            segment.model_copy(
+                                update={"grounding_ids": (*segment.grounding_ids, *undelivered)}
+                            )
+                            if any(segment is derived_segment for derived_segment in derived_segments)
+                            else segment
+                            for segment in proposal.segments
+                        )
+                    }
+                )
+            grounded = {grounding_id for segment in proposal.segments for grounding_id in segment.grounding_ids}
+            undelivered = sorted(
+                {knowledge_id for knowledge_id in proposal.selected_knowledge_ids if knowledge_id not in grounded}
+            )
         if undelivered:
             raise _EligibilityError(
                 "selected knowledge must be grounded in the segment that reveals it",
@@ -394,7 +414,6 @@ class CloudflareTurnProvider:
                 "learn it. Resend with a segment whose text actually states what that reveal says, listing that ID "
                 "in its grounding_ids - or, if the player has not earned it yet, with selected_knowledge_ids empty.",
             )
-        candidates = {candidate.id: candidate for candidate in self.last_projection.candidates}
         for knowledge_id in proposal.selected_knowledge_ids:
             candidate = candidates[knowledge_id]
             grounded_text = " ".join(

--- a/storygame/runtime/validation.py
+++ b/storygame/runtime/validation.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import re
 from collections.abc import Iterable
 from copy import deepcopy
+from itertools import combinations
 
 from storygame.runtime.contracts import (
     FactOperation,
+    NarrationSegment,
     ResolvedTurnProposal,
     SceneTransitionProposal,
     StoryEventProposal,
@@ -64,6 +66,22 @@ def unconveyed_terms(groups: tuple[tuple[str, ...], ...], text: str) -> tuple[st
         if not any(phrase_matches(phrasing, normalized_text) for phrasing in group):
             missing.append(group[0] if group else "")
     return tuple(missing)
+
+
+def derive_grounding(
+    groups: tuple[tuple[str, ...], ...], segments: tuple[NarrationSegment, ...]
+) -> tuple[NarrationSegment, ...]:
+    """Return the smallest ordered evidence set whose text conveys every group."""
+
+    if not groups:
+        return ()
+    for size in range(1, len(segments) + 1):
+        for indexes in combinations(range(len(segments)), size):
+            selected = tuple(segments[index] for index in indexes)
+            combined_text = " ".join(segment.text for segment in selected)
+            if not unconveyed_terms(groups, combined_text):
+                return selected
+    return ()
 
 
 def predicate_matches(predicate: FactPredicate, facts: FactStore) -> bool:
@@ -129,7 +147,25 @@ class SelectedRevealResolver:
         grounded = {grounding_id for segment in resolved.segments for grounding_id in segment.grounding_ids}
         undelivered = sorted(knowledge_id for knowledge_id in selected if knowledge_id not in grounded)
         if undelivered:
-            raise ProposalValidationError("selected knowledge must be grounded in the segment that reveals it")
+            knowledge = self.package.knowledge_indexes.by_id[undelivered[0]]
+            derived_segments = derive_grounding(knowledge.must_convey, resolved.segments)
+            if derived_segments:
+                resolved = resolved.model_copy(
+                    update={
+                        "segments": tuple(
+                            segment.model_copy(
+                                update={"grounding_ids": (*segment.grounding_ids, *undelivered)}
+                            )
+                            if any(segment is derived_segment for derived_segment in derived_segments)
+                            else segment
+                            for segment in resolved.segments
+                        )
+                    }
+                )
+            grounded = {grounding_id for segment in resolved.segments for grounding_id in segment.grounding_ids}
+            undelivered = sorted(knowledge_id for knowledge_id in selected if knowledge_id not in grounded)
+            if undelivered:
+                raise ProposalValidationError("selected knowledge must be grounded in the segment that reveals it")
         for knowledge_id in selected:
             knowledge = self.package.knowledge_indexes.by_id[knowledge_id]
             grounded_text = " ".join(

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -266,6 +266,33 @@ def test_transport_recovers_once_when_provider_grounds_on_unselected_knowledge(m
     assert "grounding_ids" in payloads[1]["system"]
 
 
+def test_transport_derives_grounding_without_a_recovery_request(monkeypatch) -> None:
+    payloads: list[dict[str, object]] = []
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.active_event_ids.add("SL-1A-B")
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+
+    def open_request(request, timeout):
+        payloads.append(json.loads(request.data))
+        return _Response(
+            {
+                "narration": (
+                    '{"segments":[{"kind":"narration","text":"Kristin finds Michelle\'s memory card and '
+                    'damaged recording; the card points to a dead drop at the park bench."}],'
+                    '"selected_knowledge_ids":["k_sl_1a_b_r1"]}'
+                )
+            }
+        )
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+
+    proposal = provider("I look under the workstation.")
+
+    assert proposal["selected_knowledge_ids"] == ["k_sl_1a_b_r1"]
+    assert len(payloads) == 1
+    assert state.last_turn_delivery.recovery_used is False
+
+
 def test_transport_retries_a_reveal_the_narration_never_delivers(monkeypatch) -> None:
     """Selecting a candidate without telling it must cost a guided retry, not the player's turn."""
 

--- a/tests/test_must_convey.py
+++ b/tests/test_must_convey.py
@@ -4,10 +4,59 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from storygame.runtime.validation import unconveyed_terms
+from storygame.runtime.contracts import NarrationSegment
+from storygame.runtime.validation import derive_grounding, unconveyed_terms
 from storygame.story_package import load_story_package
 
 PACKAGE = Path("data/stories/continuity-initiative")
+
+REVEAL_GROUPS = (
+    ("memory card", "card"),
+    ("damaged recording", "recording"),
+    ("Michelle's",),
+    ("dead drop",),
+    ("park bench", "bench in the park"),
+)
+
+
+def test_derive_grounding_returns_the_smallest_segment_set_that_tells_the_reveal() -> None:
+    segments = (
+        NarrationSegment(kind="narration", text="A drawer sticks."),
+        NarrationSegment(
+            kind="narration",
+            text="Kristin finds Michelle's memory card and damaged recording at a dead drop by the park bench.",
+        ),
+        NarrationSegment(kind="narration", text="The room goes quiet."),
+    )
+
+    assert derive_grounding(REVEAL_GROUPS, segments) == (segments[1],)
+
+
+def test_derive_grounding_returns_nothing_when_prose_tells_none_of_the_reveal() -> None:
+    segments = (NarrationSegment(kind="narration", text="The drawer sticks."),)
+
+    assert derive_grounding(REVEAL_GROUPS, segments) == ()
+
+
+def test_derive_grounding_returns_nothing_when_prose_tells_only_part_of_the_reveal() -> None:
+    segments = (NarrationSegment(kind="narration", text="Kristin finds Michelle's memory card."),)
+
+    assert derive_grounding(REVEAL_GROUPS, segments) == ()
+
+
+def test_derive_grounding_can_span_segments_in_narration_order() -> None:
+    segments = (
+        NarrationSegment(kind="narration", text="Kristin finds Michelle's memory card and damaged recording."),
+        NarrationSegment(kind="narration", text="It points to a dead drop at the park bench."),
+    )
+
+    assert derive_grounding(REVEAL_GROUPS, segments) == segments
+
+
+def test_derive_grounding_never_derives_an_empty_requirement() -> None:
+    segments = (NarrationSegment(kind="narration", text="Anything at all."),)
+
+    assert derive_grounding((), segments) == ()
 
 
 def test_unconveyed_terms_normalizes_case_curly_punctuation_dashes_and_spacing() -> None:

--- a/tests/test_scene_progression_phase4.py
+++ b/tests/test_scene_progression_phase4.py
@@ -139,6 +139,49 @@ def test_a_fully_conveyed_reveal_commits_and_opens_the_scene_exit() -> None:
     assert state.current_scene_id == "1B"
 
 
+def test_an_ungrounded_fully_conveyed_reveal_derives_its_grounding_and_commits() -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.active_event_ids.add("SL-1A-B")
+    engine = RuntimeEngine(
+        state,
+        lambda _: {
+            "segments": [
+                {
+                    "kind": "narration",
+                    "text": (
+                        "Kristin finds Michelle's memory card and damaged recording; the card points to a dead drop "
+                        "at a bench in the park."
+                    ),
+                }
+            ],
+            "selected_knowledge_ids": ["k_sl_1a_b_r1"],
+        },
+    )
+
+    proposal = engine.turn("I look under the workstation.", clock_seconds=120)
+
+    assert proposal.selected_knowledge_ids == ("k_sl_1a_b_r1",)
+    assert proposal.segments[0].grounding_ids == ("k_sl_1a_b_r1",)
+    assert state.facts.has("continuity_initiative_known", "story", value="true")
+
+
+def test_an_ungrounded_partially_told_reveal_is_still_rejected() -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.active_event_ids.add("SL-1A-B")
+    engine = RuntimeEngine(
+        state,
+        lambda _: {
+            "segments": [{"kind": "narration", "text": "Kristin finds Michelle's memory card."}],
+            "selected_knowledge_ids": ["k_sl_1a_b_r1"],
+        },
+    )
+
+    with pytest.raises(ProposalValidationError, match="grounded"):
+        engine.turn("I look under the workstation.", clock_seconds=120)
+
+    assert not state.facts.has("continuity_initiative_known", "story", value="true")
+
+
 def test_declared_pressure_event_advances_without_provider_timing_or_prose_parsing() -> None:
     state = RuntimeState.bootstrap(PACKAGE)
     engine = RuntimeEngine(state, lambda _: _turn("Dust shifts beneath the door."))


### PR DESCRIPTION
The hosted run kept dying with 503s. Instrumenting it (#412) showed why, and the cause was not where I expected.

## What the deployment logs showed

The 503 is not a network failure. The sequence is:

1. The model selects a reveal but does not put its id in any segment's `grounding_ids`
2. The engine refuses the commit — `_EligibilityError: selected knowledge must be grounded in the segment that reveals it`
3. That triggers a recovery call, which generates 1000+ tokens, overruns the cap, and arrives as truncated JSON — `JSONDecodeError: Unterminated string starting at char 3912`
4. The player gets HTTP 503

## How often

Measured against staging with the Round 7 telemetry:

```
12 turns: 8 succeeded, 4 returned 503
3 of the 8 successes had spent a recovery call
```

So roughly **half of all turns** fail to ground and pay for a second model call. It is the dominant behaviour, not an edge case.

## The rejected narration is usually correct

This satisfies all five of `k_sl_1a_b_r1`'s `must_convey` groups — card, recording, Michelle, dead drop, park bench:

> Under the false bottom of the drawer Kristin found Michelle's memory card and a damaged recording. The card's only file was a photograph of a park bench, marked as a dead drop.

With the id in `grounding_ids` it commits. With an empty `grounding_ids` it is rejected and burns a recovery. Character-for-character identical prose.

## The change

The grounding id was always a *proxy* for "which sentence tells this?", asked of the model because the engine could not check it. `must_convey` checks it directly, and is the stronger property — it tests what the prose actually says rather than what the model claims about it.

So derive the grounding: the smallest ordered set of segments whose combined text satisfies every group. Reject only when no such set exists.

Three rules keep the original guarantee intact, each with a test:

- **A reveal with no `must_convey` groups is never derived** — no evidence, no derivation, or any prose at all would commit it
- **Partial telling is still refused** — naming the card but not the destination is the original Scene 1A bug
- **A reveal may span segments** — real narration is several sentences

Both enforcement sites share one helper. The transport's copy is the one that matters: that raise is what spends the recovery.

Out of scope and unchanged: the retry policy, `max_tokens`, the recovery prompt, and every other rejection reason. A selection that is not one of this turn's candidates is still refused.

## Verification

- `TMPDIR=/tmp uv run pytest -q` — **186 passed**, 91.44% coverage (was 178 / 91.21%)
- `npm --prefix frontend test` — 30 passed, 0 failed

The real measure is `recovery_used` against the deployment, which I will take after this merges and staging redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd4cgdSQJFk8MP3xjkhqa