### PR TITLE
Give the narrator a length budget, and recover a reply cut in half

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -175,7 +175,8 @@ class CloudflareTurnProvider:
             "one candidate ID you place in selected_knowledge_ids; leave grounding_ids empty when neither "
             f"applies, and never ground on a candidate you do not select. Dialogue may use only its speaker's "
             f"sayable context. {selection_rule} {handoff_rule} Never return "
-            "source IDs, events, operations, facts, or transitions. Return only TurnProposal fields: never echo "
+            "source IDs, events, operations, facts, or transitions. The entire JSON response must stay under 3,600 "
+            "characters. Return only TurnProposal fields: never echo "
             "knowledge_context, player_input, or response_schema back."
         )
 
@@ -246,7 +247,9 @@ class CloudflareTurnProvider:
             self._log_typed_worker_error(error, worker_error_code)
             if worker_error_code != "AI_JSON_MODE_REJECTED":
                 raise self._narration_error(error) from error
-        except (URLError, OSError, TimeoutError, ValueError, json.JSONDecodeError) as error:
+        except json.JSONDecodeError:
+            return self._recover_malformed_response(payload)
+        except (URLError, OSError, TimeoutError, ValueError) as error:
             self._log_unavailable(error)
             raise NarrationProviderError("narration service is unavailable") from error
         else:

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -37,8 +37,10 @@ class _Response:
 
 def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None:
     captured: dict[str, object] = {}
+    attempts: list[int] = []
 
     def open_request(request, timeout):
+        attempts.append(1)
         captured["headers"] = dict(request.header_items())
         captured["payload"] = json.loads(request.data)
         captured["timeout"] = timeout
@@ -49,6 +51,7 @@ def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None
     provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="secret", state=state)
 
     assert provider("I listen.") == {"segments": [{"kind": "narration", "text": "A valid proposal."}]}
+    assert len(attempts) == 1
     assert captured["headers"]["Authorization"] == "Bearer secret"
     assert "Mozilla/5.0" in captured["headers"]["User-agent"]
     assert captured["payload"]["max_tokens"] == 1024
@@ -56,6 +59,7 @@ def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None
     context = json.loads(captured["payload"]["user"])["knowledge_context"]
     assert "response_schema" in captured["payload"]["user"]
     assert "concrete immediate consequence" in captured["payload"]["system"]
+    assert "The entire JSON response must stay under 3,600 characters." in captured["payload"]["system"]
     assert "selected_knowledge_ids" in captured["payload"]["system"]
     assert context["player"]["scene_id"] == "1A"
     assert context["player"]["candidates"] == []
@@ -184,6 +188,25 @@ def test_transport_recovers_once_from_a_malformed_provider_envelope(monkeypatch)
 
     assert provider("I listen.") == {"segments": [{"kind": "action", "text": "Kristin checks the door."}]}
     assert len(payloads) == 2
+
+
+def test_transport_recovers_once_from_a_truncated_first_reply(monkeypatch) -> None:
+    payloads: list[dict[str, object]] = []
+    provider = CloudflareTurnProvider(
+        worker_url="https://worker.example/turn", token="", state=RuntimeState.bootstrap(PACKAGE)
+    )
+
+    def open_request(request, timeout):
+        payloads.append(json.loads(request.data))
+        if len(payloads) == 1:
+            return _Response({"narration": '{"segments":[{"kind":"narration","text":"cut off"}]'})
+        return _Response({"narration": '{"segments":[{"kind":"narration","text":"Recovered."}]}'})
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
+
+    assert provider("I listen.") == {"segments": [{"kind": "narration", "text": "Recovered."}]}
+    assert len(payloads) == 2
+    assert "Your previous response was invalid." in payloads[1]["system"]
 
 
 def test_transport_recovers_once_when_provider_selects_unavailable_knowledge(monkeypatch) -> None:
@@ -652,15 +675,19 @@ def test_transport_marks_untyped_worker_errors_for_diagnosis(monkeypatch) -> Non
     assert caught.value.error_code == "UNKNOWN"
 
 
-def test_truncated_worker_response_fails_closed_and_logs_decode_cause(monkeypatch, caplog) -> None:
+def test_truncated_worker_response_fails_closed_after_one_recovery_and_logs_decode_cause(monkeypatch, caplog) -> None:
+    payloads: list[dict[str, object]] = []
     provider = CloudflareTurnProvider(
         worker_url="https://worker.example/turn",
         token="",
         state=RuntimeState.bootstrap(PACKAGE),
     )
-    response = _Response({"narration": '{"segments":[{"kind":"narration","text":"cut off"}]}'})
-    response.body = response.body[:-1]
-    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", lambda *_args, **_kwargs: response)
+
+    def open_request(request, **_kwargs):
+        payloads.append(json.loads(request.data))
+        return _Response({"narration": '{"segments":[{"kind":"narration","text":"cut off"}]'})
+
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", open_request)
 
     with (
         caplog.at_level(logging.WARNING, logger="storygame.runtime.cloudflare"),
@@ -668,6 +695,8 @@ def test_truncated_worker_response_fails_closed_and_logs_decode_cause(monkeypatc
     ):
         provider("I listen.")
 
+    assert len(payloads) == 2
+    assert "Your previous response was invalid." in payloads[1]["system"]
     assert any(
         record.levelno >= logging.WARNING and "JSONDecodeError" in record.getMessage() for record in caplog.records
     )


### PR DESCRIPTION
The logging added in #412 named the cause of the hosted 503s on the first failure.

## What the log said

```
type=JSONDecodeError; message=Unterminated string starting at: line 95 column 15 (char 4284)
type=JSONDecodeError; message=Expecting property name enclosed in double quotes: line 73 column 6 (char 4163)
```

Both raised at `json.loads(body["narration"])` on the **first** request. The model's reply was cut off mid-JSON, having run past the generation cap.

## The behaviour is bimodal

Sent the exact production payload, the model normally replies with **about 350 characters** — one segment, well formed, nowhere near any cap. Occasionally it rambles past 4,000 and gets truncated.

That tail is the entire failure. It is why the problem looked intermittent, and why small samples kept misleading me — at one point twelve consecutive successes looked like a fix, and the next run failed on turn one with the same prompt.

## The change

The two cuts landed at 4,284 and 4,163 characters against a cap of exactly 1024 tokens, putting this model's JSON at **~4.1 characters per token**.

- **Tell the narrator its budget, in characters.** The whole response must stay under **3,600** — about 900 tokens, and ten times what an ordinary turn uses. Characters because a model can roughly judge them; it cannot count its own tokens.
- **`max_tokens` stays 1024**, ~17% above the instruction, so the authored budget shapes the reply and the cap only catches a model that ignores it. 2048 is more than this game needs and only makes a rambling reply costlier before it fails.
- **A reply cut mid-JSON is a malformed response**, so route it to the recovery that already exists for malformed responses — whose prompt already reads *"Your previous response was invalid. Return only a complete JSON TurnProposal."* It was unreachable from a decode failure. Now a truncated reply costs a retry instead of the turn.

Bounded: it spends the single existing recovery and no more, and still fails closed if the recovery is truncated too. `_request_allowing_one_transient_retry` is untouched — its policy stays exactly as documented.

## Verification

- `TMPDIR=/tmp uv run pytest -q -n 2` — **187 passed**, 91.61% coverage
- New tests cover the budget wording, the cap, a recovered truncation costing exactly two requests with the correction present in the second, and a twice-truncated reply still failing closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd4cgdSQJFk8MP3xjkhqa