### PR TITLE
A declared beat must not be outrun by a quick player

### DIFF
--- a/data/stories/continuity-initiative/pacing.yaml
+++ b/data/stories/continuity-initiative/pacing.yaml
@@ -46,15 +46,15 @@ scenes:
   nudge_after_turns: 3
   handoff_after_turns: 4
 - scene_id: 2C
-  min_turns: 1
+  min_turns: 2
   nudge_after_turns: 2
   handoff_after_turns: 3
 - scene_id: 3A
-  min_turns: 1
-  nudge_after_turns: 2
+  min_turns: 3
+  nudge_after_turns: 3
   handoff_after_turns: 3
 - scene_id: 3B
-  min_turns: 2
+  min_turns: 4
   nudge_after_turns: 4
   handoff_after_turns: 5
 - scene_id: 3C

--- a/storygame/story_package/loader.py
+++ b/storygame/story_package/loader.py
@@ -363,6 +363,11 @@ def _validate(package: StoryPackage) -> None:
         window = windows[event.scene_id]
         if not 0 <= event.at_turn <= window.handoff_after_turns:
             raise StoryPackageError(f"pacing event '{event.id}' escapes its scene pacing window")
+        if event.at_turn > window.min_turns:
+            raise StoryPackageError(
+                f"pacing event '{event.id}' at turn {event.at_turn} in scene {event.scene_id} "
+                f"exceeds its min_turns floor {window.min_turns}"
+            )
     for storylet in package.storylets:
         if storylet.scene_id not in scenes:
             raise StoryPackageError(f"storylet '{storylet.id}' references unknown scene")

--- a/tests/test_markdown_story_package.py
+++ b/tests/test_markdown_story_package.py
@@ -250,6 +250,30 @@ def test_loader_rejects_storylet_window_outside_parent_scene(tmp_path: Path) -> 
         load_story_package(root)
 
 
+def test_loader_rejects_pacing_event_past_scene_floor(tmp_path: Path) -> None:
+    root = copied_package(tmp_path)
+    source = root / "pacing.yaml"
+    pacing = yaml.safe_load(source.read_text())
+    event = next(item for item in pacing["events"] if item["id"] == "pressure_1a")
+    event["at_turn"] = 3
+    source.write_text(yaml.safe_dump(pacing, sort_keys=False))
+
+    with pytest.raises(StoryPackageError, match="pressure_1a.*turn 3.*scene 1A.*floor 2"):
+        load_story_package(root)
+
+
+def test_loader_rejects_scene_floor_below_its_pacing_event(tmp_path: Path) -> None:
+    root = copied_package(tmp_path / "lowered-floor")
+    source = root / "pacing.yaml"
+    pacing = yaml.safe_load(source.read_text())
+    scene = next(item for item in pacing["scenes"] if item["scene_id"] == "2C")
+    scene["min_turns"] = 1
+    source.write_text(yaml.safe_dump(pacing, sort_keys=False))
+
+    with pytest.raises(StoryPackageError, match="purge_2c.*turn 2.*scene 2C.*floor 1"):
+        load_story_package(root)
+
+
 def test_loader_rejects_transition_dependency_cycle(tmp_path: Path) -> None:
     root = copied_package(tmp_path)
     source = root / "pacing.yaml"

--- a/tests/test_scene_relative_pacing.py
+++ b/tests/test_scene_relative_pacing.py
@@ -60,11 +60,20 @@ def test_each_scene_entry_starts_with_a_full_relative_turn_allowance() -> None:
         window = next(item for item in PACKAGE.pacing.scenes if item.scene_id == transition.source_scene_id)
         for _ in range(window.min_turns):
             engine.turn("I take another careful turn.")
-        for trigger in transition.triggers:
-            state.facts.assert_fact(Fact(predicate=trigger.fact_id, subject="story", value=str(trigger.equals).lower()))
-        engine.turn("I follow the opening.")
+        if state.current_scene_id != transition.target_scene_id:
+            for trigger in transition.triggers:
+                state.facts.assert_fact(
+                    Fact(predicate=trigger.fact_id, subject="story", value=str(trigger.equals).lower())
+                )
+            engine.turn("I follow the opening.")
         assert state.current_scene_id == transition.target_scene_id
         assert state.turn_index == state.scene_entered_at_turn
+
+
+def test_every_declared_pacing_event_lands_by_its_scene_floor() -> None:
+    windows = {window.scene_id: window for window in PACKAGE.pacing.scenes}
+
+    assert all(event.at_turn <= windows[event.scene_id].min_turns for event in PACKAGE.pacing.events)
 
 
 def test_storylet_activation_uses_scene_relative_turns_after_a_late_clock() -> None:


### PR DESCRIPTION
Found by the hosted `@llm-canon` run, which failed during traversal — before any judge call, so it cost nothing to find.

## The defect

The playthrough fired three of four pacing events. It left scene 3B before `destruction_3b` arrived:

```
Turn N is missing pacing event destruction_3b
Received: ["override_deadline_3a", "pressure_1a", "purge_2c"]
```

The cause is an interaction between two authored numbers. `destruction_3b` fires at turn 4 of 3B, but 3B's `min_turns` was 2 — the earliest turn a player who has earned the exit may leave. A quick player is gone before the beat lands.

Three of the four were exposed this way:

| Event | Fires at | Scene floor | |
|---|---|---|---|
| `pressure_1a` | turn 2 of 1A | 2 | lands exactly at the earliest exit |
| `purge_2c` | turn 2 of 2C | 1 | **outrunnable** |
| `override_deadline_3a` | turn 3 of 3A | 1 | **outrunnable** |
| `destruction_3b` | turn 4 of 3B | 2 | **outrunnable** |

This is the stranding bug inverted: not a player stuck because a beat cannot fire, but an authored beat lost because the player was quick.

The existing loader rule checks `at_turn <= handoff_after_turns` — it proves a beat *can* fire. It does not prove it *will*.

## The change

Require every pacing event to land at or before its own scene's `min_turns`. The rule binds from both directions, since scheduling a beat late and lowering a floor beneath an existing beat are the same defect.

The floors were raised rather than the beats moved, so each complication keeps its authored dramatic position and its scene is guaranteed to reach it:

| Scene | Before | After |
|---|---|---|
| 2C | (1,2,3) | **(2,2,3)** |
| 3A | (1,2,3) | **(3,3,3)** |
| 3B | (2,4,5) | **(4,4,5)** |

No `handoff_after_turns` changed. The nine still sum to exactly 30 turns against the unchanged 1800-second ceiling — this was paid for out of `min_turns` and `nudge_after_turns` only.

## Verification

- `TMPDIR=/tmp uv run pytest -q -n 2` — **190 passed**, 91.91% coverage
- New tests cover both directions of the rule, plus a package-driven assertion that no declared beat can be outrun, so the story cannot reacquire this by authoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd4cgdSQJFk8MP3xjkhqa