### PR TITLE
Give the narrator its beat, and let the judge see the same one

### DIFF
--- a/data/stories/continuity-initiative/storylets.md
+++ b/data/stories/continuity-initiative/storylets.md
@@ -29,7 +29,7 @@ Each entry below is authoring data, not a player action menu.
 
 ### SL-1A-A — The House Does Not Look Abandoned
 
-**Source beats:** [1A.1 — The Empty House](plot.md#scene-1a1--the-empty-house), [1A.2 — Michelle’s Last Investigation](plot.md#scene-1a2--michelles-last-investigation)
+**Source beats:** [1A.1 — Michelle Is Gone](plot.md#scene-1a1--michelle-is-gone), [1A.2 — Michelle’s Last Investigation](plot.md#scene-1a2--michelles-last-investigation)
 
 **Allowed scene:** `1A`
 
@@ -292,7 +292,7 @@ Each entry below is authoring data, not a player action menu.
 
 ### SL-1B-B — Is Brandon Hunter or Rescuer?
 
-**Source beats:** [1B.2 — The Man Following Him](plot.md#scene-1b2--the-man-following-him), [1B.3 — Brandon’s Warning](plot.md#scene-1b3--brandons-warning)
+**Source beats:** [1B.2 — The Man Following Her](plot.md#scene-1b2--the-man-following-her), [1B.3 — Brandon’s Warning](plot.md#scene-1b3--brandons-warning)
 
 **Allowed scene:** `1B`
 

--- a/docs/testing-runbook.md
+++ b/docs/testing-runbook.md
@@ -112,6 +112,83 @@ narration names the memory card *and* the bench before the park paragraph, and
 that a partial narration is retried rather than silently advancing — is still
 outstanding.
 
+## Hosted canon judge — verified state (2026-08-31)
+
+**Purpose:** Record what a full hosted playthrough now proves, and what it does
+not, so the next session does not re-derive it.
+
+**Setup / seed:** Staging on the merged SHA, verified through
+`/api/v1/health` before running. `.env` supplies `E2E_API_BASE_URL`,
+`OPENAI_API_KEY` and the worker credentials.
+
+**Safe actions:** Read-only against staging, plus the billed judge calls named
+below.
+
+**Destructive or external actions:** The `@llm-canon` run makes one OpenAI
+judge call per reached scene — nine on this run. It is the only billed step.
+
+**Steps:**
+
+```bash
+source .env && cd frontend && E2E_TURN_TIMEOUT_MS=90000 npm run test:e2e -- --grep @spine
+source .env && cd frontend && E2E_PACKAGE_CLOCK=1 E2E_TURN_TIMEOUT_MS=90000 npm run test:e2e -- --grep @llm-canon
+```
+
+`E2E_TURN_TIMEOUT_MS=90000` is required. The default is 30 seconds, and a turn
+that spends its recovery makes two model calls, which legitimately exceeds it.
+
+**Verify:** `@spine` passed in 1.8 minutes. `@llm-canon` traversed all nine
+scenes in order — 1A through 3C — and judged every one.
+
+**Observed 2026-08-31.** Every scene FAILS the canon judge on narration
+quality. Passing counts across the nine judged scenes:
+
+| Criterion | Passing |
+| --- | --- |
+| `protected_safe` | 9/9 |
+| `exit_motivated` | 3/9 |
+| `rewards_investigation` | 2/9 |
+| `scene_local` | 1/9 |
+| `progressive` | 1/9 |
+| `canon_consistent` | 0/9 |
+| `rich` | 0/9 |
+
+`protected_safe` passing on every scene is the load-bearing result: no scene
+leaked JANUS, Brandon's role, or any phase-two secret. The state machine holds.
+The failures are prose, not plumbing.
+
+The judge's Scene 1A criticisms are representative and actionable: the canon
+calls for concrete physical evidence — the phone on the kitchen floor, the
+missing laptop and work bag, the overturned chair, the forced back door, the
+carved KMS drawer — and the narration only glances at it; an apt second search
+dead-ended on an invented empty compartment when the memory card was
+canonically available; and one turn collapsed the card discovery, the Continuity
+Initiative exposition, the park-bench lead and the scene exit into a single
+abrupt summary.
+
+**Delivery telemetry from the same session's `@spine` run**, written to
+`artifacts/e2e-spine.json`:
+
+```
+total_turns 37 | turns_with_misses 7 | recovery_turns 17 | fallback_turns 6
+```
+
+Six fallback turns means six turns where a player read authored fallback prose
+instead of narration shaped to what they did. That is the delivery system's
+health metric, and it is the number to watch when widening `must_convey` groups.
+The report also carries a per-fact miss tally naming which reveals missed.
+
+**Cleanup:** None.
+
+**Notes.** Measured narration runs about 350 characters, roughly 60 words,
+against a plan that assumed about 100 words per turn. The model is bimodal in
+length as well as in behaviour: usually far thinner than the game wants, and
+occasionally rambling past 4,000 characters, which is what the 3,600-character
+budget in the turn instruction now bounds. There is a ceiling on narration
+length and no floor, and the judge's `rich` criterion fails on all nine scenes.
+That is the most likely single cause of the quality verdicts and the first thing
+to try.
+
 ## Full-journey acceptance — verified state (2026-08-29)
 
 **Purpose:** Record what the hosted canon playthrough proves and what it does
@@ -155,13 +232,9 @@ in authored order, fires all four pacing events in their own scenes, commits a
 reveal on close to every turn, and reaches the independent judge. Runs vary
 between roughly 22 and 28 turns.
 
-**That observation is stale as of 2026-08-30 and has not been repeated.** It
+**That observation was superseded on 2026-08-31 by the run recorded below.** It
 was taken before pacing became turn-based, so its turn counts were measured
-against the old absolute-seconds windows and the old 20-minute budget. The
-`E2E_PACKAGE_CLOCK` harness was rewritten to arm turn milestones rather than
-inject a clock value, and those Playwright specs have been changed but not
-executed, because they need a live deployment. Re-run this section before
-trusting any number in it.
+against the old absolute-seconds windows and the old 20-minute budget.
 
 **Known open items:**
 

--- a/frontend/e2e/roleplay-judge.js
+++ b/frontend/e2e/roleplay-judge.js
@@ -129,6 +129,10 @@ export async function judgeSceneNarration(
   { environment = process.env, fetchImpl = fetch, canon = sceneCanon(sceneId) } = {},
 ) {
   const { apiKey, model } = judgeConfiguration(environment);
+  const turnsWithBeatContext = turns.map((turn) => ({
+    ...turn,
+    beats_projected: turn.beats_projected || [],
+  }));
   const response = await fetchImpl("https://api.openai.com/v1/responses", {
     method: "POST",
     headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
@@ -144,12 +148,14 @@ export async function judgeSceneNarration(
             "When an opening is supplied, require substantial sensory scene establishment; always require responsive consequences on ordinary turns, " +
             "and progressive revelation rather than dumping future beats or racing a transition. Protected knowledge must " +
             "never be revealed early. Do not require every optional storylet or every beat in a single turn. " +
+            "Judge each TURN against the beat it was actually given. A turn that dramatises its assigned beat poorly still fails; being given a beat is not credit for using it. " +
+            "Judge the SCENE on whether its authored beats were covered in order across its turns. A scene that skips beats entirely still fails. " +
             "A turn marked left_scene is the one the story departed on: fail unless the narration the player actually " +
             "read gives them a reason to go, naming in prose what was found and where it points. A discovery the " +
             "player is never told has not happened, however plainly the canon implies it. Fail too when repeated apt " +
             "searching of what this scene's canon says is here keeps returning nothing the player can act on.",
         },
-        { role: "user", content: JSON.stringify({ canon, opening, turns }) },
+        { role: "user", content: JSON.stringify({ canon, opening, turns: turnsWithBeatContext }) },
       ],
       text: { format: { type: "json_schema", name: "scene_canon_judgment", strict: true, schema: CANON_SCHEMA } },
     }),

--- a/frontend/e2e/scene-runtime.spec.js
+++ b/frontend/e2e/scene-runtime.spec.js
@@ -216,7 +216,12 @@ test("judges every reached scene against the five-file narrative canon @llm-cano
       const departure = entered ? segments.slice(0, -1) : segments;
       const sceneNarration = departure.map((segment) => segment.text).join(" ").trim();
       if (sceneNarration) {
-        byScene.get(sourceSceneId).turns.push({ player_input: input, narration: sceneNarration, left_scene: entered });
+        byScene.get(sourceSceneId).turns.push({
+          player_input: input,
+          narration: sceneNarration,
+          left_scene: entered,
+          beats_projected: payload.delivery?.beats_projected || [],
+        });
       }
       if (entered && !byScene.has(reachedSceneId)) {
         byScene.set(reachedSceneId, { opening: segments.at(-1).text.trim(), turns: [] });

--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -214,9 +214,10 @@ class CloudflareTurnProvider:
         """
 
         setting: dict[str, object] = {"entry_text": self._current_scene().entry_text}
-        if not self.last_projection or not self.last_projection.candidates:
-            return setting
-        beats = self._candidate_beats()
+        beats = self._candidate_beats() if self.last_projection and self.last_projection.candidates else ()
+        self.state.last_turn_delivery = self.state.last_turn_delivery.model_copy(
+            update={"beats_projected": tuple(beat.anchor for beat in beats)}
+        )
         if beats:
             setting["beats"] = [{"title": beat.title, "prose": beat.prose} for beat in beats]
         return setting

--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -205,14 +205,42 @@ class CloudflareTurnProvider:
     def _scene_setting(self) -> dict[str, object]:
         """The authored paragraph the player read on entering, safe to send every turn.
 
-        Deliberately just that. The beat prose describes what the scene is about
-        to reveal - Scene 2B's first beat names JANUS outright - and even the
-        location's own name can carry a protected term, so both would hand the
-        narrator knowledge the player has not earned. The projection already
-        supplies place and objective; this adds the one authored thing it lacks.
+        Beat prose is added only for storylets whose reveals are candidates on
+        this turn. The scene's beats describe what later reveals contain - Scene
+        2B's first beat names JANUS outright - so sending all of them would hand
+        the narrator knowledge the player has not earned. The projection already
+        supplies place and objective; this adds only the authored material the
+        player can earn now.
         """
 
-        return {"entry_text": self._current_scene().entry_text}
+        setting: dict[str, object] = {"entry_text": self._current_scene().entry_text}
+        if not self.last_projection or not self.last_projection.candidates:
+            return setting
+        beats = self._candidate_beats()
+        if beats:
+            setting["beats"] = [{"title": beat.title, "prose": beat.prose} for beat in beats]
+        return setting
+
+    def _candidate_beats(self) -> tuple[SceneBeat, ...]:
+        """Return only the beats belonging to storylets offered this turn."""
+
+        package = self.state.package
+        storylets = {storylet.id: storylet for storylet in package.storylets}
+        beats_by_anchor = {anchor: beat for scene in package.scenes for anchor, beat in scene.beats.items()}
+        seen: set[str] = set()
+        selected: list[SceneBeat] = []
+        for candidate in self.last_projection.candidates if self.last_projection else ():
+            knowledge = package.knowledge_indexes.by_id[candidate.id]
+            if knowledge.source.kind != "storylet_realization" or knowledge.source.storylet_id is None:
+                continue
+            storylet = storylets.get(knowledge.source.storylet_id)
+            if storylet is None:
+                continue
+            for anchor in storylet.source_links:
+                if anchor not in seen and anchor in beats_by_anchor:
+                    seen.add(anchor)
+                    selected.append(beats_by_anchor[anchor])
+        return tuple(selected)
 
     def _scene_entry(self) -> dict[str, object]:
         """Expose the package-authored frame and first beat the opening must dramatize, never invent."""
@@ -397,9 +425,7 @@ class CloudflareTurnProvider:
                 proposal = proposal.model_copy(
                     update={
                         "segments": tuple(
-                            segment.model_copy(
-                                update={"grounding_ids": (*segment.grounding_ids, *undelivered)}
-                            )
+                            segment.model_copy(update={"grounding_ids": (*segment.grounding_ids, *undelivered)})
                             if any(segment is derived_segment for derived_segment in derived_segments)
                             else segment
                             for segment in proposal.segments

--- a/storygame/runtime/state.py
+++ b/storygame/runtime/state.py
@@ -32,6 +32,7 @@ class TurnRecord(BaseModel):
 class TurnDelivery(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
+    beats_projected: tuple[str, ...] = ()
     must_convey_misses: tuple[str, ...] = ()
     recovery_used: bool = False
     fallback_used: bool = False

--- a/storygame/story_package/loader.py
+++ b/storygame/story_package/loader.py
@@ -30,7 +30,7 @@ class StoryPackageError(ValueError):
 
 
 _SCENE = re.compile(r"^## Scene ([1-9][A-Z]) .*$", re.MULTILINE)
-_SCENE_BEAT = re.compile(r"^### Scene ([1-9][A-Z]\.[1-9])\s+[—-]\s+(.+)$", re.MULTILINE)
+_SCENE_BEAT = re.compile(r"^### (?P<heading>Scene (?P<id>[1-9][A-Z]\.[1-9])\s+[—-]\s+(?P<title>.+))$", re.MULTILINE)
 _STORYLET = re.compile(r"^### (SL-([1-9][A-Z])-[A-Z]) — (.+)$", re.MULTILINE)
 _SECTION = re.compile(r"^\*\*([^*]+)\*\*\s*(.*?)(?=^\*\*|^---\s*$|\Z)", re.MULTILINE | re.DOTALL)
 _REQUIRED_STORYLET_SECTIONS = {
@@ -78,22 +78,64 @@ def _parse_scenes(text: str) -> tuple[Scene, ...]:
         if set(metadata.bridge_text) != set(metadata.transition_ids):
             raise StoryPackageError(f"scene {match.group(1)} bridge_text keys must match transition_ids exactly")
         prose = body[frontmatter.end() :].strip()
-        scenes.append(Scene(metadata=metadata, prose=prose, opening_beat=_parse_opening_beat(metadata.scene_id, prose)))
+        scenes.append(
+            Scene(
+                metadata=metadata,
+                prose=prose,
+                beats=_parse_scene_beats(metadata.scene_id, prose),
+                opening_beat=_parse_opening_beat(metadata.scene_id, prose),
+            )
+        )
     return tuple(scenes)
+
+
+def _beat_anchor(heading: str) -> str:
+    """Convert an authored beat heading to the exact anchor used by source links."""
+
+    filtered = (character for character in heading.lower() if character.isalnum() or character in " -")
+    return "".join("-" if character == " " else character for character in filtered)
+
+
+def _parse_scene_beats(scene_id: str, prose: str) -> dict[str, SceneBeat]:
+    matches = [match for match in _SCENE_BEAT.finditer(prose) if match.group("id").startswith(f"{scene_id}.")]
+    beats: dict[str, SceneBeat] = {}
+    for match in matches:
+        end = next((other.start() for other in matches if other.start() > match.start()), len(prose))
+        beat_prose = prose[match.end() : end].strip()
+        beat_id = match.group("id")
+        if not beat_prose:
+            raise StoryPackageError(f"scene {scene_id} beat {beat_id} has no prose")
+        anchor = _beat_anchor(match.group("heading"))
+        if anchor in beats:
+            raise StoryPackageError(f"scene {scene_id} has duplicate beat anchor '{anchor}'")
+        beats[anchor] = SceneBeat(
+            id=beat_id,
+            anchor=anchor,
+            title=match.group("title").strip(),
+            prose=beat_prose,
+        )
+    if not beats:
+        raise StoryPackageError(f"scene {scene_id} contains no beat headings")
+    return beats
 
 
 def _parse_opening_beat(scene_id: str, prose: str) -> SceneBeat:
     """Isolate the scene's first authored beat so an opening embellishes canon instead of inventing it."""
 
     matches = list(_SCENE_BEAT.finditer(prose))
-    first = next((match for match in matches if match.group(1) == f"{scene_id}.1"), None)
+    first = next((match for match in matches if match.group("id") == f"{scene_id}.1"), None)
     if first is None:
         raise StoryPackageError(f"scene {scene_id} lacks an opening beat heading '### Scene {scene_id}.1'")
     end = next((match.start() for match in matches if match.start() > first.start()), len(prose))
     body = prose[first.end() : end].strip()
     if not body:
         raise StoryPackageError(f"scene {scene_id} opening beat has no prose")
-    return SceneBeat(id=first.group(1), title=first.group(2).strip(), prose=body)
+    return SceneBeat(
+        id=first.group("id"),
+        anchor=_beat_anchor(first.group("heading")),
+        title=first.group("title").strip(),
+        prose=body,
+    )
 
 
 def _turn(value: str) -> int:
@@ -103,7 +145,7 @@ def _turn(value: str) -> int:
     return int(match.group(1))
 
 
-def _parse_storylets(text: str, plot_anchors: set[str]) -> tuple[Storylet, ...]:
+def _parse_storylets(text: str, plot_beat_anchors: set[str], plot_scene_ids: set[str]) -> tuple[Storylet, ...]:
     matches = list(_STORYLET.finditer(text))
     if not matches:
         raise StoryPackageError("storylets.md contains no SL-* headings")
@@ -117,11 +159,16 @@ def _parse_storylets(text: str, plot_anchors: set[str]) -> tuple[Storylet, ...]:
         allowed = re.search(r"`([1-9][A-Z])`", sections["Allowed scene:"])
         if not allowed or allowed.group(1) != match.group(2):
             raise StoryPackageError(f"storylet {match.group(1)} has invalid allowed scene")
+        if match.group(2) not in plot_scene_ids:
+            raise StoryPackageError(f"storylet {match.group(1)} references an unknown scene")
         links = tuple(re.findall(r"\]\(plot\.md#([^)]+)\)", sections["Source beats:"]))
         if not links:
             raise StoryPackageError(f"storylet {match.group(1)} lacks plot.md source links")
-        if any(not any(link.startswith(anchor) for anchor in plot_anchors) for link in links):
-            raise StoryPackageError(f"storylet {match.group(1)} links to an unknown plot heading")
+        unresolved = next((link for link in links if link not in plot_beat_anchors), None)
+        if unresolved is not None:
+            raise StoryPackageError(
+                f"storylet {match.group(1)} links to an unknown plot heading; unresolved beat anchor '{unresolved}'"
+            )
         window = dict(re.findall(r"-\s*(earliest|target|latest):\s*`([^`]+)`", sections["Pacing window"]))
         if set(window) != {"earliest", "target", "latest"}:
             raise StoryPackageError(f"storylet {match.group(1)} has an invalid pacing window")
@@ -505,9 +552,11 @@ def load_story_package(root: Path) -> StoryPackage:
     try:
         plot_text = (root / "plot.md").read_text(encoding="utf-8")
         scenes = _parse_scenes(plot_text)
-        scene_ids = re.findall(r"^### Scene ([1-9][A-Z])\.\d+", plot_text, re.MULTILINE)
-        plot_anchors = {f"scene-{scene.lower()}" for scene in scene_ids}
-        storylets = _parse_storylets((root / "storylets.md").read_text(encoding="utf-8"), plot_anchors)
+        plot_beat_anchors = {anchor for scene in scenes for anchor in scene.beats}
+        plot_scene_ids = {scene.metadata.scene_id for scene in scenes}
+        storylets = _parse_storylets(
+            (root / "storylets.md").read_text(encoding="utf-8"), plot_beat_anchors, plot_scene_ids
+        )
         world = WorldSource.model_validate(_yaml(root / "world.yaml"))
         pacing = PacingSource.model_validate(_yaml(root / "pacing.yaml"))
         routes_raw = _yaml(root / "storylet-routes.yaml")

--- a/storygame/story_package/models.py
+++ b/storygame/story_package/models.py
@@ -184,6 +184,7 @@ class SceneBeat(_Model):
     """One authored sub-beat of a scene, quoted verbatim as narration context."""
 
     id: str = Field(pattern=r"^[1-9][A-Z]\.[1-9]$")
+    anchor: str = Field(pattern=r"^[a-z0-9-]+$")
     title: str = Field(min_length=1)
     prose: str = Field(min_length=1)
 
@@ -191,6 +192,7 @@ class SceneBeat(_Model):
 class Scene(_Model):
     metadata: SceneMetadata
     prose: str = Field(min_length=1)
+    beats: Mapping[str, SceneBeat]
     opening_beat: SceneBeat
 
 

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -52,6 +52,7 @@ def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None
 
     assert provider("I listen.") == {"segments": [{"kind": "narration", "text": "A valid proposal."}]}
     assert len(attempts) == 1
+    assert state.last_turn_delivery.beats_projected == ()
     assert captured["headers"]["Authorization"] == "Bearer secret"
     assert "Mozilla/5.0" in captured["headers"]["User-agent"]
     assert captured["payload"]["max_tokens"] == 1024
@@ -102,6 +103,7 @@ def test_recording_candidate_is_absent_until_its_route_is_eligible(monkeypatch) 
     beats = {anchor: beat for scene in PACKAGE.scenes for anchor, beat in scene.beats.items()}
     expected_beats = [{"title": beats[link].title, "prose": beats[link].prose} for link in storylet.source_links]
     assert scene_setting["beats"] == expected_beats
+    assert state.last_turn_delivery.beats_projected == storylet.source_links
     assert len(scene_setting["beats"]) < len(PACKAGE.scenes[0].beats)
 
 

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -97,6 +97,13 @@ def test_recording_candidate_is_absent_until_its_route_is_eligible(monkeypatch) 
     )
     assert any(candidate["id"] == "k_sl_1a_b_r2" for candidate in contexts[2]["candidates"])
 
+    scene_setting = json.loads(captured[2]["user"])["scene_setting"]
+    storylet = next(storylet for storylet in PACKAGE.storylets if storylet.id == "SL-1A-B")
+    beats = {anchor: beat for scene in PACKAGE.scenes for anchor, beat in scene.beats.items()}
+    expected_beats = [{"title": beats[link].title, "prose": beats[link].prose} for link in storylet.source_links]
+    assert scene_setting["beats"] == expected_beats
+    assert len(scene_setting["beats"]) < len(PACKAGE.scenes[0].beats)
+
 
 def test_transport_unwraps_the_workers_narration_envelope(monkeypatch) -> None:
     provider = CloudflareTurnProvider(

--- a/tests/test_markdown_story_package.py
+++ b/tests/test_markdown_story_package.py
@@ -48,6 +48,41 @@ def test_continuity_package_loads_all_scene_headings_and_storylets() -> None:
             assert effects == set(realization.operations)
 
 
+def test_scene_beats_are_parsed_and_addressable_by_authored_anchor() -> None:
+    package = load_story_package(PACKAGE)
+    scene = package.scenes[0]
+
+    assert list(scene.beats) == [
+        "scene-1a1--michelle-is-gone",
+        "scene-1a2--michelles-last-investigation",
+        "scene-1a3--the-interrupted-message",
+        "scene-1a4--the-first-threat",
+    ]
+    assert [beat.id for beat in scene.beats.values()] == ["1A.1", "1A.2", "1A.3", "1A.4"]
+    assert [beat.anchor for beat in scene.beats.values()] == list(scene.beats)
+    assert scene.opening_beat == scene.beats["scene-1a1--michelle-is-gone"]
+    assert all(beat.title and beat.prose for beat in scene.beats.values())
+
+
+def test_every_shipped_storylet_source_link_resolves_to_a_scene_beat() -> None:
+    package = load_story_package(PACKAGE)
+    beats = {anchor for scene in package.scenes for anchor in scene.beats}
+    links = [link for storylet in package.storylets for link in storylet.source_links]
+
+    assert len(set(links)) == 36
+    assert all(link in beats for link in set(links))
+
+
+def test_loader_rejects_a_storylet_linking_to_a_nonexistent_beat_anchor(tmp_path: Path) -> None:
+    package = copied_package(tmp_path)
+    storylets = package / "storylets.md"
+    contents = storylets.read_text(encoding="utf-8")
+    storylets.write_text(contents.replace("scene-1a2--michelles-last-investigation", "scene-1a2--missing-beat", 1))
+
+    with pytest.raises(StoryPackageError, match="SL-1A-A.*scene-1a2--missing-beat"):
+        load_story_package(package)
+
+
 def test_a_scene_without_a_first_beat_fails_to_load(tmp_path: Path) -> None:
     package = copied_package(tmp_path)
     plot = package / "plot.md"

--- a/tests/test_web_demo.py
+++ b/tests/test_web_demo.py
@@ -1,5 +1,6 @@
 """Hosted scene-runtime adapter contracts."""
 
+import json
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -101,12 +102,14 @@ def test_hosted_adapter_reports_identity_and_serves_a_story_session(monkeypatch,
     assert turn.json()["segments"][0]["text"] == "The lead sharpens."
     assert turn.json()["lines"] == ["The lead sharpens."]
     assert turn.json()["delivery"] == {
+        "beats_projected": [],
         "must_convey_misses": [],
         "recovery_used": False,
         "fallback_used": False,
         "hint_staged": False,
         "handoff_staged": False,
     }
+    json.dumps(turn.json())
 
 
 def test_hosted_adapter_reports_turn_index_and_scene_relative_turns(tmp_path) -> None:


### PR DESCRIPTION
The hosted canon judge failed all nine scenes. One recurring complaint was that a turn collapses several authored beats into one abrupt summary — for Scene 1A it merged the memory-card discovery, the Continuity Initiative exposition, the park-bench lead and the scene exit into a single turn.

The narrator was not ignoring the beat order. It could not see it.

## What was missing

`plot.md` authors four beats per scene, but `_parse_opening_beat` extracted only the first — the rest sat inside `scene.prose` as undifferentiated text. And `_scene_setting` sent the arrival paragraph and nothing else, every turn, for the whole scene. After the opening the narrator had no idea which beat it was standing in.

The mapping was already authored. Every storylet declares its `**Source beats:**` as links into plot.md, kept as `Storylet.source_links`.

## Giving the narrator its beat

All 36 beats are now parsed and addressable by the same anchor form the links use: lowercase the heading, drop everything that is not a letter, digit, space or hyphen, then replace spaces with hyphens — which is why the removed em dash leaves a **double** hyphen.

Source links must now resolve exactly. Scene-prefix validation is what let two links rot unnoticed after their beats were retitled:

| Was | Now |
|---|---|
| `1A.1 — The Empty House` | `1A.1 — Michelle Is Gone` |
| `1B.2 — The Man Following Him` | `1B.2 — The Man Following Her` |

`plot.md` is ground truth; the links were wrong.

**The gate is the safety property.** A turn carries the beat prose of the storylets whose reveals are candidates *on that turn*, and nothing more — the narrator sees an authored beat exactly when the player can earn it, never ahead. Scene 2B's first beat names JANUS outright, which is why the old code refused to send any of them. A turn with no candidates still carries only `entry_text`, and a single turn never receives a whole scene. Verified: a candidate turn in 1A receives **2 of 4** beats.

## Letting the judge see the same beat

The judge received the whole scene block and every turn, with no indication of which beat any turn was working from, and inferred intent from the player's input. Harmless while the narrator was equally blind; a mismatch once it isn't.

The beat anchors a turn actually sent are now recorded per turn, surfaced through the API `delivery` block the harness already collects, and passed to the judge alongside the **unchanged** scene canon — additional context, never a replacement, so the judge can still catch invention and early leaks against ground truth.

Two clauses keep it strict:

- Judge each **turn** against the beat it was given. Dramatising it poorly still fails; being given a beat is not credit for using it.
- Judge each **scene** on whether its beats were covered in order across its turns. A scene that skips beats still fails.

Without the second, telling the judge what we assigned would only teach it to accept whatever we did.

Every existing criterion keeps its wording. `exit_motivated` is deliberately **not** tightened — the engine already enforces at commit time that a reveal's prose names what was found and where it points, and a second copy in the judge would drift from it.

## Verification

- `TMPDIR=/tmp uv run pytest -q -n 2` — **193 passed**, 91.66% coverage
- `npm --prefix frontend test` — 30 passed, 0 failed

The judge's verdicts are re-measured against the same nine scenes after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd4cgdSQJFk8MP3xjkhqa