### PR TITLE
A handoff can cause offstage world state

### DIFF
--- a/storygame/runtime/engine.py
+++ b/storygame/runtime/engine.py
@@ -291,6 +291,23 @@ class RuntimeEngine:
         for event in proposal.events:
             for operation in event.operations:
                 self.state._apply_operation(candidate_facts, operation)
+        pending_bridge_event = next(
+            (
+                event
+                for event in self.state.package.storylet_routes.bridge_events
+                if event.scene_id == self.state.current_scene_id
+                and event.id not in self.state.fired_event_ids
+                and not event.activation.is_satisfied(self._true_facts(self.state.facts))
+            ),
+            None,
+        )
+        world_only_operations = (
+            self._world_only_bridge_operations(pending_bridge_event, candidate_facts)
+            if pending_bridge_event is not None
+            else ()
+        )
+        for operation in world_only_operations:
+            self.state._apply_operation(candidate_facts, operation)
         world_operations = self._world_action_operations(candidate_facts)
         for operation in world_operations:
             self.state._apply_operation(candidate_facts, operation)
@@ -333,7 +350,13 @@ class RuntimeEngine:
         combined = proposal.model_copy(
             update={
                 "segments": segments,
-                "operations": (*proposal.operations, *delivery_operations, *world_operations, *bridge_operations),
+                "operations": (
+                    *proposal.operations,
+                    *delivery_operations,
+                    *world_only_operations,
+                    *world_operations,
+                    *bridge_operations,
+                ),
                 "transition": SceneTransitionProposal(transition_id=transition.id) if transition else None,
             }
         )
@@ -356,6 +379,23 @@ class RuntimeEngine:
             for cost in delivery.costs
         )
         return tuple(operations)
+
+    def _world_only_bridge_operations(self, event, facts) -> tuple[FactOperation, ...]:
+        player_safe_fact_ids = {
+            effect.fact_id
+            for knowledge in self.state.package.knowledge.knowledge
+            if knowledge.audience.player_visible
+            for effect in knowledge.establishes
+        }
+        missing_fact_ids = event.activation.minimal_undelivered_facts(self._true_facts(facts))
+        return tuple(
+            FactOperation(
+                operation="assert",
+                fact=Fact(predicate=fact_id, subject="story", value="true"),
+            )
+            for fact_id in missing_fact_ids
+            if fact_id not in player_safe_fact_ids
+        )
 
     def _world_action_operations(self, facts) -> tuple[FactOperation, ...]:
         operations: list[FactOperation] = []

--- a/storygame/story_package/loader.py
+++ b/storygame/story_package/loader.py
@@ -486,7 +486,12 @@ def _validate(package: StoryPackage) -> None:
 
 
 def _validate_deliveries(package: StoryPackage) -> None:
-    """Fail closed when a canonical bridge cannot safely carry a fact."""
+    """Fail closed when a canonical bridge cannot safely carry a fact.
+
+    Together, the delivery-direction and missing-delivery checks make the
+    bridge invariant explicit: every required fact is either deliverable or
+    has no player-visible knowledge definition and is therefore world-only.
+    """
 
     from storygame.runtime.validation import unconveyed_terms
 

--- a/tests/test_markdown_story_package.py
+++ b/tests/test_markdown_story_package.py
@@ -395,9 +395,11 @@ def test_bridge_required_player_safe_facts_have_one_self_conveying_delivery() ->
         if knowledge.audience.player_visible
         for effect in knowledge.establishes
     }
+    world_only = required - player_safe
     deliveries = {delivery.fact_id: delivery for delivery in package.deliveries}
 
     assert set(deliveries) == required & player_safe
+    assert required <= set(deliveries) | world_only
     assert len(package.deliveries) == len(deliveries)
     assert all(not unconveyed_terms(delivery.must_convey, delivery.fallback_text) for delivery in deliveries.values())
 

--- a/tests/test_pacing_handoff.py
+++ b/tests/test_pacing_handoff.py
@@ -42,6 +42,14 @@ def _state_1b() -> RuntimeState:
     return state
 
 
+def _state_2a() -> RuntimeState:
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.current_scene_id = "2A"
+    state.phase = next(scene.metadata.freytag_phase for scene in PACKAGE.scenes if scene.metadata.scene_id == "2A")
+    state._assert_scene_entry_fact("2A")
+    return state
+
+
 def _fallback_delivery_text(state: RuntimeState) -> str:
     deliveries = {delivery.fact_id: delivery for delivery in PACKAGE.deliveries}
     return " ".join(deliveries[fact_id].fallback_text for fact_id in state.staged_handoff_fact_ids)
@@ -109,6 +117,27 @@ def test_hint_then_handoff_delivers_only_missing_facts_costs_and_transition() ->
     )
     target_entry = next(scene.metadata.entry_text for scene in PACKAGE.scenes if scene.metadata.scene_id == "1C")
     assert texts.index(source_bridge) < texts.index(target_entry)
+
+
+def test_scene_2a_handoff_asserts_hidden_bridge_fact_without_projecting_it() -> None:
+    state = _state_2a()
+    engine = RuntimeEngine(state, lambda _input: {"segments": [{"kind": "narration", "text": "I wait."}]})
+
+    engine.turn("I wait at the facility entrance.")
+    engine.turn("I keep watching the security desk.")
+    handoff = engine.turn("I wait for an opening.")
+
+    assert state.current_scene_id == "2B"
+    assert state.facts.has("false_identities_ready", "story", value="true")
+    assert state.facts.has("rebecca_observing_infiltrators", "story", value="true")
+    assert "bridge_2a_restricted_access" in state.fired_event_ids
+    assert state.last_turn_delivery.handoff_staged is True
+    assert any("false credentials" in segment.text.casefold() for segment in handoff.segments)
+
+    projection = KnowledgeProjector().project(state, "player", "I look around.")
+    projected_ids = {item.id for item in (*projection.committed_knowledge, *projection.candidates)}
+    assert "k_sl_2a_c_r2_rebecca_observes" not in projected_ids
+    assert "rebecca_observing_infiltrators" not in projection.model_dump_json()
 
 
 def test_projected_handoff_contract_is_player_safe_and_prompt_preserves_agency(monkeypatch) -> None:


### PR DESCRIPTION
Found by the hosted `@llm-canon` run, during traversal — before any judge call, so it cost nothing to find.

```
Scene 2A exceeded its handoff turn 3.
```

## The defect

`bridge_2a_restricted_access` mandatorily requires two facts:

| Fact | Reachable at handoff? |
|---|---|
| `false_identities_ready` | yes — has a `FactDelivery` |
| `rebecca_observing_infiltrators` | **no** |

The second is established only by knowledge marked `world_only` with `player_visible: false`, so handing it to the player would leak protected knowledge and the loader rightly refuses a delivery for it. But nothing else asserted it either — it comes only from storylet realizations `SL-2A-C-R1` and `R2`.

So a handoff delivered the first fact, could not produce the second, and the exit never opened. A player who never fired `SL-2A-C` was stranded past the handoff turn: the exact class of defect that threshold activation and delivery contracts were built to eliminate, still alive in one scene.

An earlier probe excused this on the assumption that a world-only fact *"arrives by world action once its own preconditions hold."* Nothing arrives on its own. That assumption was wrong, and it was mine.

## The change

A handoff already stages a declared in-world intervention. Let it cause the offstage state that intervention implies: for each fact the eligible bridge still needs that **no player-visible knowledge establishes**, assert it in the same atomic commit.

- No narration, no delivery contract, no `must_convey`. `player_visible: false` means there is nothing to tell the player and nothing to verify in prose — which is precisely what makes asserting it safe.
- Only facts the eligible bridge actually still needs.
- Player-safe facts are untouched: they still require a delivery and its prose check.
- Still atomic — if any part fails, none of it commits.

The player is still never told: the fact stays absent from the player-facing projection after it is asserted, and that is asserted by test.

The loader half already existed — Round 4's rule refuses a package where a player-safe bridge fact has no delivery — so the invariant is stated in one place rather than duplicated.

## Verification

- `TMPDIR=/tmp uv run pytest -q -n 2` — **194 passed**, 91.69% coverage
- New tests: the 2A regression end to end (deliver, assert, fire the bridge, leave the scene), the projection is unaffected, and every bridge-required fact is either deliverable or world-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd4cgdSQJFk8MP3xjkhqa