### PR TITLE
Send the narrator each fact once, and say what a beat is for

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -96,6 +96,7 @@ class CloudflareTurnProvider:
             }
         )
         speaker_contexts = self._speaker_contexts(player_input)
+        scene_setting = self._scene_setting()
         return self._dispatch(
             self._turn_instruction(),
             {
@@ -104,11 +105,11 @@ class CloudflareTurnProvider:
                 # of frame and a few terse statements, so the narrator has nothing authored to
                 # be concrete with and answers an apt search with "you find nothing". This is
                 # the scene's first beat only, so it cannot narrate ahead of the player.
-                "scene_setting": self._scene_setting(),
+                "scene_setting": scene_setting,
                 "knowledge_context": {
                     # sayable_knowledge is the speakers' dialogue basis; repeating it for the
                     # player doubled the largest field in every request for no reader.
-                    "player": self.last_projection.model_dump(mode="json", exclude={"sayable_knowledge"}),
+                    "player": self._serialized_player_context(scene_setting),
                     "speakers": speaker_contexts,
                 },
             },
@@ -133,8 +134,8 @@ class CloudflareTurnProvider:
                 f"This turn offers these candidate reveals: [{offered}]. If the player's action earns one of them, "
                 "you MUST reveal it by placing exactly that one ID in selected_knowledge_ids - narrating the "
                 "moment without selecting it leaves the story unable to move on. You must also tell it: one of your "
-                "segments has to state, in the narration the player reads, what that candidate's statement says, and "
-                "that segment must list the ID in its grounding_ids. Every must_convey synonym group shown for the "
+                "segments has to convey that candidate through the beat it was given plus its must_convey groups, "
+                "and that segment must list the ID in its grounding_ids. Every must_convey synonym group shown for the "
                 "candidate must appear through at least one of its phrasings in that grounded narration. Selecting a "
                 "reveal the narration never delivers is rejected. Leave the list empty only when none of them fits "
                 "what just happened."
@@ -177,7 +178,8 @@ class CloudflareTurnProvider:
             f"sayable context. {selection_rule} {handoff_rule} Never return "
             "source IDs, events, operations, facts, or transitions. Return at most three segments, each at most two "
             "sentences, and write the JSON on one line with no indentation. Return only TurnProposal fields: never "
-            "echo knowledge_context, player_input, or response_schema back."
+            "echo knowledge_context, player_input, or response_schema back. Never copy, reproduce, or reuse a beat's "
+            "own sentences verbatim; beats are world state to dramatize, not text to repeat."
         )
 
     def opening(self) -> object:
@@ -219,8 +221,53 @@ class CloudflareTurnProvider:
             update={"beats_projected": tuple(beat.anchor for beat in beats)}
         )
         if beats:
-            setting["beats"] = [{"title": beat.title, "prose": beat.prose} for beat in beats]
+            setting["beats"] = [
+                {
+                    "title": beat.title,
+                    "anchor": beat.anchor,
+                    "already_true_in_the_world": beat.prose,
+                    "your_job": (
+                        "Dramatize this world state only as far as the player's action reaches; "
+                        "never reproduce its wording."
+                    ),
+                }
+                for beat in beats
+            ]
         return setting
+
+    def _serialized_player_context(self, scene_setting: dict[str, object]) -> dict[str, object]:
+        """Serialize candidate context without repeating facts already carried by beats."""
+
+        if self.last_projection is None:
+            return {}
+        context = self.last_projection.model_dump(mode="json", exclude={"sayable_knowledge"})
+        beat_anchors = {
+            beat["anchor"] for beat in scene_setting.get("beats", []) if isinstance(beat, dict)
+        }
+        covered_ids = self._beat_covered_candidate_ids(beat_anchors)
+        context["candidates"] = [
+            (
+                {key: value for key, value in candidate.items() if key != "statement"}
+                if candidate["id"] in covered_ids
+                else candidate
+            )
+            for candidate in context["candidates"]
+        ]
+        return context
+
+    def _beat_covered_candidate_ids(self, beat_anchors: set[object]) -> set[str]:
+        """Find offered facts whose authored storylet beat is already serialized."""
+
+        package = self.state.package
+        storylets = {storylet.id: storylet for storylet in package.storylets}
+        covered: set[str] = set()
+        for candidate in self.last_projection.candidates if self.last_projection else ():
+            knowledge = package.knowledge_indexes.by_id[candidate.id]
+            source = knowledge.source
+            storylet = storylets.get(source.storylet_id) if source.storylet_id else None
+            if source.kind == "storylet_realization" and storylet and beat_anchors & set(storylet.source_links):
+                covered.add(candidate.id)
+        return covered
 
     def _candidate_beats(self) -> tuple[SceneBeat, ...]:
         """Return only the beats belonging to storylets offered this turn."""

--- a/storygame/runtime/knowledge.py
+++ b/storygame/runtime/knowledge.py
@@ -118,9 +118,8 @@ class KnowledgeProjector:
 
         Committed knowledge accumulates for the whole playthrough, so an unbounded
         projection makes every later turn slower than the last until the narration
-        call times out and the player loses the turn. Scene-local knowledge is kept
-        first, then the most recently authored, so the current scene stays fully
-        grounded while distant history is what gives way.
+        call times out and the player loses the turn. Only knowledge available in
+        the current scene is projected, then the numeric cap keeps that scene bounded.
 
         The resolver validates segment grounding against this same projection, so
         the provider is never asked to ground on knowledge it was not shown.
@@ -129,16 +128,13 @@ class KnowledgeProjector:
         established = [
             item
             for item in state.package.knowledge.knowledge
-            if self._established(item, state) and self._visible_to(item, audience_id)
+            if state.current_scene_id in item.available_in_scenes
+            and self._established(item, state)
+            and self._visible_to(item, audience_id)
         ]
         if len(established) <= limit:
             return tuple(self._projected(item) for item in established)
-        ranked = sorted(
-            enumerate(established),
-            key=lambda pair: (state.current_scene_id not in pair[1].available_in_scenes, -pair[0]),
-        )
-        keep = {index for index, _ in ranked[:limit]}
-        return tuple(self._projected(item) for index, item in enumerate(established) if index in keep)
+        return tuple(self._projected(item) for item in established[-limit:])
 
     @staticmethod
     def _projected(item: KnowledgeDefinition) -> ProjectedKnowledge:

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -62,6 +62,7 @@ def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None
     assert "concrete immediate consequence" in captured["payload"]["system"]
     assert "at most three segments, each at most two sentences" in captured["payload"]["system"]
     assert "selected_knowledge_ids" in captured["payload"]["system"]
+    assert "Never copy, reproduce, or reuse a beat's own sentences verbatim" in captured["payload"]["system"]
     assert context["player"]["scene_id"] == "1A"
     assert context["player"]["candidates"] == []
     serialized = json.dumps(context).casefold()
@@ -71,10 +72,15 @@ def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None
     provider("I search the desk drawer for Michelle's recording.")
     drawer_context = json.loads(captured["payload"]["user"])["knowledge_context"]["player"]
     candidate = next(item for item in drawer_context["candidates"] if item["id"] == "k_sl_1a_b_r2")
-    assert "damaged recording" in candidate["statement"]
-    assert set(candidate) == {"id", "statement", "must_convey"}
+    assert "statement" not in candidate
+    assert set(candidate) == {"id", "must_convey"}
     assert candidate["must_convey"] == []
     assert provider.last_projection is not None
+    assert "damaged recording" in next(
+        item.statement for item in provider.last_projection.candidates if item.id == candidate["id"]
+    )
+    unbeat_context = provider._serialized_player_context({"beats": []})
+    assert "statement" in next(item for item in unbeat_context["candidates"] if item["id"] == candidate["id"])
 
 
 def test_recording_candidate_is_absent_until_its_route_is_eligible(monkeypatch) -> None:
@@ -101,7 +107,18 @@ def test_recording_candidate_is_absent_until_its_route_is_eligible(monkeypatch) 
     scene_setting = json.loads(captured[2]["user"])["scene_setting"]
     storylet = next(storylet for storylet in PACKAGE.storylets if storylet.id == "SL-1A-B")
     beats = {anchor: beat for scene in PACKAGE.scenes for anchor, beat in scene.beats.items()}
-    expected_beats = [{"title": beats[link].title, "prose": beats[link].prose} for link in storylet.source_links]
+    expected_beats = [
+        {
+            "title": beats[link].title,
+            "anchor": beats[link].anchor,
+            "already_true_in_the_world": beats[link].prose,
+            "your_job": (
+                "Dramatize this world state only as far as the player's action reaches; "
+                "never reproduce its wording."
+            ),
+        }
+        for link in storylet.source_links
+    ]
     assert scene_setting["beats"] == expected_beats
     assert state.last_turn_delivery.beats_projected == storylet.source_links
     assert len(scene_setting["beats"]) < len(PACKAGE.scenes[0].beats)

--- a/tests/test_knowledge_projection.py
+++ b/tests/test_knowledge_projection.py
@@ -218,7 +218,10 @@ def test_committed_projection_stays_bounded_as_the_story_accumulates() -> None:
     projector = KnowledgeProjector()
     projection = projector.project(state, "player", "I act.")
 
-    assert len(projection.committed_knowledge) == projector.max_committed_knowledge
+    scene_local = [
+        item for item in package.knowledge.knowledge if "3C" in item.available_in_scenes
+    ]
+    assert len(projection.committed_knowledge) == min(projector.max_committed_knowledge, len(scene_local))
     assert projection.payload_size() < 8000, "a late-game turn must not approach the narration timeout"
 
     # The current scene keeps its grounding; distant history is what gives way.


### PR DESCRIPTION
Tonight's canon run failed all nine scenes on one complaint: the narration restates canon instead of dramatizing it. The 1A opening turn reproduced the authored beat paragraph almost verbatim — "not burglarized", "making it worth looking at more closely" — and named the carved initials, the overturned chair and the forced back door two and three times inside a hundred words.

On a turn offering a reveal, the same fact reached the model four ways: the beat paragraph, the candidate's `statement`, its `must_convey` phrasings, and up to 24 prior statements resent every turn. The instruction then told it to "state what that candidate's statement says."

**Fix 1 — each fact once.** A candidate a projected beat already describes is serialized without its `statement`, keeping its ID and `must_convey` gate. The in-memory projection the resolver validates against is untouched. `committed_knowledge` is scoped to the scene being played rather than the 24 most recently authored.

**Fix 2 — name the beat's role.** A beat no longer arrives as a bare paragraph under `prose`; it carries its anchor, labels the paragraph as world state already true, states the narrator's job, and the turn instruction forbids reusing its sentences.

A 3A turn's context drops 10,517 → 7,844 chars. A 1A turn grows by 131 — the labels cost slightly more than the statement saved, and early scenes have no history to shed.

195 tests, 91.63% coverage, ruff clean. Built and verified through Ringer (13-assertion acceptance probe, PASS first attempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd4cgdSQJFk8MP3xjkhqa