### PR TITLE
Keep a reveal's statement when nothing else names it

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -247,8 +247,10 @@ class CloudflareTurnProvider:
         covered_ids = self._beat_covered_candidate_ids(beat_anchors)
         context["candidates"] = [
             (
+                # An empty must_convey leaves the statement as the only name for the fact;
+                # removing both exposed scene 3C's candidates as bare IDs and stalled it.
                 {key: value for key, value in candidate.items() if key != "statement"}
-                if candidate["id"] in covered_ids
+                if candidate["id"] in covered_ids and candidate["must_convey"]
                 else candidate
             )
             for candidate in context["candidates"]

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -72,15 +72,32 @@ def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None
     provider("I search the desk drawer for Michelle's recording.")
     drawer_context = json.loads(captured["payload"]["user"])["knowledge_context"]["player"]
     candidate = next(item for item in drawer_context["candidates"] if item["id"] == "k_sl_1a_b_r2")
-    assert "statement" not in candidate
-    assert set(candidate) == {"id", "must_convey"}
+    assert "statement" in candidate
+    assert set(candidate) == {"id", "statement", "must_convey"}
     assert candidate["must_convey"] == []
+    grouped_candidate = next(item for item in drawer_context["candidates"] if item["id"] == "k_sl_1a_b_r1")
+    assert "statement" not in grouped_candidate
+    assert set(grouped_candidate) == {"id", "must_convey"}
     assert provider.last_projection is not None
     assert "damaged recording" in next(
         item.statement for item in provider.last_projection.candidates if item.id == candidate["id"]
     )
     unbeat_context = provider._serialized_player_context({"beats": []})
     assert "statement" in next(item for item in unbeat_context["candidates"] if item["id"] == candidate["id"])
+
+
+def test_beat_covered_candidate_without_must_convey_keeps_its_statement() -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.active_event_ids.add("SL-1A-B")
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+    provider.last_projection = provider.projector.project(state, "player", "I search the desk drawer.")
+
+    scene_setting = provider._scene_setting()
+    context = provider._serialized_player_context(scene_setting)
+    candidate = next(item for item in context["candidates"] if item["id"] == "k_sl_1a_b_r2")
+
+    assert candidate["must_convey"] == []
+    assert candidate["statement"] == PACKAGE.knowledge_indexes.by_id["k_sl_1a_b_r2"].statement
 
 
 def test_recording_candidate_is_absent_until_its_route_is_eligible(monkeypatch) -> None:


### PR DESCRIPTION
Dropping a beat-covered candidate's `statement` assumed its `must_convey` groups would still tell the narrator what claim to deliver. Most reveals declare no groups: **53 of the story's 61** are beat-covered with an empty `must_convey`, so they reached the model as a bare `{"id": ...}` with nothing naming the fact.

A hosted playthrough against staging found it. The story reached scene 3C — whose ten reveals all declare no groups — and stalled there for five turns committing nothing, tripping the harness's stall assertion before the judge ever ran.

The statement is now dropped only where `must_convey` exists to carry the obligation in its place: the eight reveals that declare groups. Everywhere else it stays.

196 tests, 91.63% coverage, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd4cgdSQJFk8MP3xjkhqa