### PR TITLE
Brandon concealed threats to the conspiracy, not threats generally

### DIFF
--- a/data/stories/continuity-initiative/plot.md
+++ b/data/stories/continuity-initiative/plot.md
@@ -34,7 +34,7 @@ A 31-year-old molecular biology and biotechnology researcher and author whose re
 
 ### Brandon Corfman
 
-A 54-year-old former software developer who now lives as an isolated conspiracy researcher estranged from his family. His warnings about a shadow emergency program were widely dismissed before the disappearances. He helps Kristin but conceals his own past involvement in the program: writing AI software to identify threats.
+A 54-year-old former software developer who now lives as an isolated conspiracy researcher estranged from his family. His warnings about a shadow emergency program were widely dismissed before the disappearances. He helps Kristin but conceals his own past involvement in the program: writing AI software to identify threats to the conspiracy.
 
 ### Charles Jenkins
 


### PR DESCRIPTION
Brandon's authored edit to his own character description in `plot.md`: the AI software he wrote identified threats *to the conspiracy*, which is what makes his concealment a betrayal rather than ordinary security work.

Applied identically to both arms of the narration bakeoff so the measured builds differ only in narration strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd4cgdSQJFk8MP3xjkhqa