### PR TITLE
Apply the segment limit instead of asking for it

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -24,6 +24,8 @@ from storygame.story_package.models import Scene, SceneBeat, SceneMetadata
 
 logger = logging.getLogger(__name__)
 
+MAX_TURN_SEGMENTS = 5
+
 # Cloudflare's Browser Integrity Check rejects urllib's default bot-like signature
 # before a request can reach the Worker at all, so every caller must send this.
 BROWSER_USER_AGENT = (
@@ -294,7 +296,8 @@ class CloudflareTurnProvider:
             f"applies, and never ground on a candidate you do not select. Dialogue may use only its speaker's "
             f"sayable context. {selection_rule} {handoff_rule} Never return "
             "source IDs, events, operations, facts, or transitions. Return several paragraphs as separate segments, "
-            "with each segment containing one paragraph of roughly 30 to 55 words. Return at most five segments so "
+            f"with each segment containing one paragraph of roughly 30 to 55 words. Return at most {MAX_TURN_SEGMENTS} "
+            "segments so "
             "the turn stays bounded, and write the JSON on one line with no indentation. Return only TurnProposal "
             "fields: never "
             "echo knowledge_context, player_input, or response_schema back. Never copy, reproduce, or reuse a beat's "
@@ -318,7 +321,8 @@ class CloudflareTurnProvider:
                 "invent evidence, characters, or events absent from that context, do not state conclusions the "
                 "protagonist has not yet earned, do not act for the protagonist or resolve the objective, and do not "
                 "offer a menu of choices. Return several paragraphs as separate segments, with each segment containing "
-                "one paragraph of roughly 30 to 55 words; return at most five segments. authored entry_text and "
+                f"one paragraph of roughly 30 to 55 words; return at most {MAX_TURN_SEGMENTS} segments. "
+                "authored entry_text and "
                 "authored beat details are already true: do not contradict, soften, or reopen them as questions. Do "
                 "not invent physical objects, items, or contents absent from that authored context. Leave "
                 "selected_knowledge_ids empty. Never return source IDs, events, operations, facts, or transitions."
@@ -505,10 +509,10 @@ class CloudflareTurnProvider:
             raise NarrationProviderError("narration service is unavailable") from error
         else:
             try:
-                self._parse_eligible_proposal(response)
+                proposal = self._parse_eligible_proposal(response)
             except RuntimeContractError as error:
                 return self._recover_malformed_response(payload, getattr(error, "hint", ""))
-            return response
+            return self._cap_accepted_response(response, proposal)
 
         fallback_payload = {key: value for key, value in payload.items() if key != "response_format"}
         self._record_recovery()
@@ -556,12 +560,12 @@ class CloudflareTurnProvider:
         """
 
         try:
-            self._parse_eligible_proposal(response)
+            proposal = self._parse_eligible_proposal(response)
         except _EligibilityError:
             proposal = parse_turn_proposal(response)
             if self.last_projection and self.last_projection.handoff_deliveries:
                 return self._fallback_handoff()
-            return {
+            narration_only = {
                 "segments": [
                     {
                         "kind": segment.kind,
@@ -572,6 +576,9 @@ class CloudflareTurnProvider:
                 ],
                 "selected_knowledge_ids": [],
             }
+            return self._cap_accepted_response(
+                narration_only, proposal.model_copy(update={"selected_knowledge_ids": ()})
+            )
         except RuntimeContractError as error:
             if self.last_projection and self.last_projection.handoff_deliveries:
                 return self._fallback_handoff()
@@ -581,7 +588,27 @@ class CloudflareTurnProvider:
                 502,
                 "INVALID_PROPOSAL",
             ) from error
-        return response
+        return self._cap_accepted_response(response, proposal)
+
+    def _cap_accepted_response(self, response: object, proposal: TurnProposal) -> object:
+        """Bound accepted narration while retaining an out-of-band reveal segment."""
+
+        if len(proposal.segments) <= MAX_TURN_SEGMENTS:
+            return response
+        kept = list(proposal.segments[:MAX_TURN_SEGMENTS])
+        if proposal.selected_knowledge_ids:
+            selected_id = proposal.selected_knowledge_ids[0]
+            delivering = next(
+                (segment for segment in proposal.segments if selected_id in segment.grounding_ids),
+                None,
+            )
+            if delivering is not None and delivering not in kept:
+                kept.append(delivering)
+        self.state.last_turn_delivery = self.state.last_turn_delivery.model_copy(update={"segments_truncated": True})
+        return {
+            "segments": [segment.model_dump(mode="json") for segment in kept],
+            "selected_knowledge_ids": list(proposal.selected_knowledge_ids),
+        }
 
     def _parse_eligible_proposal(self, response: object) -> TurnProposal:
         proposal = parse_turn_proposal(response)

--- a/storygame/runtime/state.py
+++ b/storygame/runtime/state.py
@@ -38,6 +38,7 @@ class TurnDelivery(BaseModel):
     fallback_used: bool = False
     hint_staged: bool = False
     handoff_staged: bool = False
+    segments_truncated: bool = False
 
 
 class RuntimeSnapshot(BaseModel):

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -10,7 +10,7 @@ from urllib.error import HTTPError, URLError
 
 import pytest
 
-from storygame.runtime.cloudflare import CloudflareTurnProvider, NarrationProviderError
+from storygame.runtime.cloudflare import MAX_TURN_SEGMENTS, CloudflareTurnProvider, NarrationProviderError
 from storygame.runtime.contracts import RuntimeContractError, parse_turn_proposal
 from storygame.runtime.facts import Fact
 from storygame.runtime.knowledge import KnowledgeProjector
@@ -83,6 +83,7 @@ def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None
     instruction = captured["payload"]["system"]
     assert "several paragraphs as separate segments" in instruction
     assert "roughly 30 to 55 words" in instruction
+    assert f"at most {MAX_TURN_SEGMENTS} segments" in instruction
     assert "contradict" in instruction and "authored entry_text" in instruction
     assert "invent physical objects, items, or contents" in instruction
     assert "at most two sentences" not in instruction
@@ -109,6 +110,51 @@ def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None
     )
     unbeat_context = provider._serialized_player_context({"beats": []})
     assert "statement" in next(item for item in unbeat_context["candidates"] if item["id"] == candidate["id"])
+
+
+def test_transport_caps_long_reply_and_records_telemetry(monkeypatch) -> None:
+    reply = {"segments": [{"kind": "narration", "text": f"Opening {index}."} for index in range(9)]}
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", lambda *_args, **_kwargs: _Response(reply))
+    state = RuntimeState.bootstrap(PACKAGE)
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+
+    result = provider("I look around.")
+
+    assert [segment["text"] for segment in result["segments"]] == [f"Opening {i}." for i in range(5)]
+    assert state.last_turn_delivery.segments_truncated is True
+
+
+def test_transport_leaves_short_reply_untouched(monkeypatch) -> None:
+    reply = {"segments": [{"kind": "narration", "text": f"Paragraph {index}."} for index in range(3)]}
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", lambda *_args, **_kwargs: _Response(reply))
+    state = RuntimeState.bootstrap(PACKAGE)
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+
+    result = provider("I listen.")
+
+    assert result == reply
+    assert state.last_turn_delivery.segments_truncated is False
+
+
+def test_transport_keeps_selected_reveal_delivery_after_segment_cap(monkeypatch) -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.active_event_ids.add("SL-1A-B")
+    filler = [{"kind": "narration", "text": f"Filler {index}."} for index in range(MAX_TURN_SEGMENTS + 1)]
+    delivery = {
+        "kind": "narration",
+        "text": "Taped beneath the drawer she finds Michelle's hidden memory card and a damaged recording, "
+        "naming a dead drop at a bench in the park.",
+        "grounding_ids": ["k_sl_1a_b_r1"],
+    }
+    reply = {"segments": [*filler, delivery], "selected_knowledge_ids": ["k_sl_1a_b_r1"]}
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", lambda *_args, **_kwargs: _Response(reply))
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+
+    result = provider("I search under the drawers.")
+
+    assert len(result["segments"]) == MAX_TURN_SEGMENTS + 1
+    assert result["segments"][-1]["grounding_ids"] == ["k_sl_1a_b_r1"]
+    assert "memory card" in result["segments"][-1]["text"]
 
 
 def test_beat_covered_candidate_without_must_convey_keeps_its_statement() -> None:
@@ -827,6 +873,7 @@ def test_opening_prompt_carries_the_authored_scene_frame_without_player_input(mo
     opening_instruction = captured["payload"]["system"]
     assert "several paragraphs as separate segments" in opening_instruction
     assert "roughly 30 to 55 words" in opening_instruction
+    assert f"at most {MAX_TURN_SEGMENTS} segments" in opening_instruction
     assert "contradict" in opening_instruction and "authored entry_text" in opening_instruction
     assert "invent physical objects, items, or contents" in opening_instruction
     user = json.loads(captured["payload"]["user"])

--- a/tests/test_web_demo.py
+++ b/tests/test_web_demo.py
@@ -108,6 +108,7 @@ def test_hosted_adapter_reports_identity_and_serves_a_story_session(monkeypatch,
         "fallback_used": False,
         "hint_staged": False,
         "handoff_staged": False,
+        "segments_truncated": False,
     }
     json.dumps(turn.json())
 


### PR DESCRIPTION
The instruction asked for at most five segments of 30–55 words. Measured against staging, consecutive turns returned **5, 22, 21, 5, 3, 25, 5, 5, 26** segments — and the long ones weren't paragraphs, each was a single 13–23 word sentence. The tail of the 26 ran past the player's action entirely:

```
11. She grabs her keys and heads out the door, determined to uncover the truth.
12. The park is just a few blocks away, and Kristin can feel her heart pounding...
```

That's a scene transition the engine owns. Two hosted playthroughs died on it — one 502 where segment 11 returned `response_schema` fragments (`items`, `type`) instead of prose, one where scene 2A overran its handoff turn.

Same lesson as the character budget earlier in this branch: a limit a small model won't hold must be **applied**, not requested. `MAX_TURN_SEGMENTS` is now a constant, the instruction text derives from it so they can't drift, and a long reply is cut to its earliest segments.

The segment delivering a selected reveal survives the cut even from beyond the cap — dropping it would commit a fact whose narration the player never read. Truncation is recorded in the turn telemetry.

Shared by both bakeoff arms.

221 tests, 90.67% coverage, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd4cgdSQJFk8MP3xjkhqa