### PR TITLE
One bad segment costs the segment, not the turn

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -12,6 +12,7 @@ from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
 
 from storygame.runtime.contracts import (
+    NarrationSegment,
     RuntimeContractError,
     TurnProposal,
     contract_error_summary,
@@ -511,6 +512,13 @@ class CloudflareTurnProvider:
             try:
                 proposal = self._parse_eligible_proposal(response)
             except RuntimeContractError as error:
+                salvaged = self._salvage_malformed_segments(response, error)
+                if salvaged is not None:
+                    try:
+                        proposal = self._parse_eligible_proposal(salvaged)
+                    except RuntimeContractError as salvage_error:
+                        return self._recover_malformed_response(payload, getattr(salvage_error, "hint", ""))
+                    return self._cap_accepted_response(salvaged, proposal)
                 return self._recover_malformed_response(payload, getattr(error, "hint", ""))
             return self._cap_accepted_response(response, proposal)
 
@@ -609,6 +617,73 @@ class CloudflareTurnProvider:
             "segments": [segment.model_dump(mode="json") for segment in kept],
             "selected_knowledge_ids": list(proposal.selected_knowledge_ids),
         }
+
+    def _salvage_malformed_segments(self, response: object, error: RuntimeContractError) -> dict[str, object] | None:
+        """Keep valid segment objects from a proposal with malformed array entries.
+
+        This is deliberately limited to the first provider reply.  A selected
+        reveal is only salvageable when its grounding survives in a valid
+        segment; otherwise retaining the selection would commit knowledge the
+        player never saw.
+        """
+
+        payload = response
+        if isinstance(payload, dict) and "response" in payload:
+            payload = payload["response"]
+        if isinstance(payload, dict) and "content" in payload:
+            payload = payload["content"]
+        if not isinstance(payload, dict) or not isinstance(payload.get("segments"), list):
+            return None
+
+        raw_segments = payload["segments"]
+        valid_segments: list[NarrationSegment] = []
+        valid_raw_segments: list[dict[str, object]] = []
+        dropped_shapes: list[str] = []
+        for segment in raw_segments:
+            try:
+                parsed_segment = NarrationSegment.model_validate(segment)
+            except Exception:  # noqa: BLE001 - provider values are untrusted
+                dropped_shapes.append(self._segment_shape(segment))
+            else:
+                valid_segments.append(parsed_segment)
+                valid_raw_segments.append(segment)
+        if not dropped_shapes or not valid_segments:
+            return None
+
+        selected = payload.get("selected_knowledge_ids", [])
+        if not isinstance(selected, list) or not all(isinstance(item, str) for item in selected):
+            return None
+        grounded = {item for segment in valid_segments for item in segment.grounding_ids}
+        if any(knowledge_id not in grounded for knowledge_id in selected):
+            return None
+
+        self.state.last_turn_delivery = self.state.last_turn_delivery.model_copy(
+            update={"segments_dropped": len(dropped_shapes)}
+        )
+        self._log_segment_salvage(error, len(dropped_shapes), tuple(dropped_shapes))
+        return {
+            "segments": valid_raw_segments,
+            "selected_knowledge_ids": selected,
+        }
+
+    @staticmethod
+    def _segment_shape(value: object) -> str:
+        if isinstance(value, dict):
+            keys = ",".join(sorted(str(key) for key in value))
+            return f"object(keys={keys})"
+        return type(value).__name__
+
+    def _log_segment_salvage(self, error: RuntimeContractError, count: int, shapes: tuple[str, ...]) -> None:
+        cause = error.__cause__
+        logger.warning(
+            "Narration reply contained malformed segments; dropped %d segment(s) with shape(s)=%s "
+            "(worker host=%s; underlying exception type=%s; message=%s)",
+            count,
+            ",".join(shapes),
+            urlsplit(self.worker_url).hostname,
+            type(cause).__name__ if cause is not None else type(error).__name__,
+            contract_error_summary(error) or self._safe_error_message(error),
+        )
 
     def _parse_eligible_proposal(self, response: object) -> TurnProposal:
         proposal = parse_turn_proposal(response)

--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -164,6 +164,27 @@ class _EligibilityError(RuntimeContractError):
         self.hint = hint
 
 
+
+def _plain(text: str) -> str:
+    """Render authored markdown as plain prose without breaking a sentence.
+
+    plot.md is narrative ground truth and keeps its own formatting. The narrator
+    is a small model that has been observed copying whatever shape it is shown,
+    so bold markers, blockquote arrows and list bullets are stripped on the way
+    out. Sentences and paragraph breaks survive untouched.
+    """
+
+    cleaned = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
+    cleaned = re.sub(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", r"\1", cleaned)
+    lines = []
+    for line in cleaned.splitlines():
+        stripped = line.strip()
+        stripped = re.sub(r"^#{1,6}\s+", "", stripped)
+        stripped = re.sub(r"^>\s?", "", stripped)
+        stripped = re.sub(r"^[*+-]\s+", "", stripped)
+        lines.append(stripped)
+    return "\n".join(lines).strip()
+
 class CloudflareTurnProvider:
     """Send only bounded, scene-safe context to the configured Worker."""
 
@@ -245,93 +266,83 @@ class CloudflareTurnProvider:
         """
 
         candidates = self.last_projection.candidates if self.last_projection else ()
-        if candidates:
-            offered = ", ".join(candidate.id for candidate in candidates)
-            selection_rule = (
-                f"This turn offers these candidate reveals: [{offered}]. If the player's action earns one of them, "
-                "you MUST reveal it by placing exactly that one ID in selected_knowledge_ids - narrating the "
-                "moment without selecting it leaves the story unable to move on. One of your "
-                "segments has to convey that candidate in the narration the player reads, using whatever the "
-                "candidate actually carries: its statement when one is shown, its must_convey groups when they are "
-                "shown, and the beat it was given. A candidate that shows neither a statement nor groups cannot be "
-                "selected. That segment must list the ID in its grounding_ids. Every must_convey synonym group "
-                "shown for the "
-                "candidate must appear through at least one of its phrasings in that grounded narration. Selecting a "
-                "reveal the narration never delivers is rejected. Leave the list empty only when none of them fits "
-                "what just happened."
-            )
-        else:
-            selection_rule = (
-                "This turn offers no candidates: selected_knowledge_ids MUST be an empty list. Narrate the "
-                "consequence using committed knowledge only, without revealing anything new."
-            )
+        selection_rules = [
+            "Select at most one candidate ID in selected_knowledge_ids.",
+            "A selected candidate must be conveyed by one readable segment, and that segment must carry its ID "
+            "in grounding_ids.",
+            "A candidate with neither a statement nor a must_convey group cannot be selected.",
+            "Leave selected_knowledge_ids empty when no candidate fits what just happened.",
+            "Narrating a reveal without selecting it stalls the story.",
+        ]
+        if not candidates:
+            selection_rules.append("This turn offers no candidates, so selected_knowledge_ids must be empty.")
         hinted = self.last_projection.hinted_deliveries if self.last_projection else ()
         handoffs = self.last_projection.handoff_deliveries if self.last_projection else ()
         if handoffs:
             handoff_rule = (
-                "This is a HANDOFF turn. Write the declared diegetic intervention for every handoff delivery exactly "
-                "from its contract: use each delivery's source_kind and source_entity_id when present, and convey "
-                "every must_convey synonym group. The intervention may be a message, NPC statement, broadcast, "
-                "observation, or inference as declared. Do not claim that the player took an action they did not "
-                "take. Answer the player's input directly in the same narration; the handoff is an intervention "
-                "alongside that response. You do not choose the facts, source kind, source entity, costs, bridge "
-                "event, or transition."
+                "Write every declared handoff intervention, convey every required concept, answer the player's input, "
+                "and do not claim that the player took an action they did not take."
             )
         elif hinted:
             handoff_rule = (
-                "This is a HINT turn. Surface the missing evidence as something the player can still act on: an NPC "
-                "remark, a noticed detail, or a radio call that points without concluding. State nothing as "
-                "established, commit no fact, preserve the player's agency, and do not claim that the player took "
-                "an action they did not take."
+                "Surface the hinted evidence as an actionable NPC remark, noticed detail, or radio call without "
+                "establishing or committing a fact."
             )
         else:
-            handoff_rule = "This is neither a hint nor a handoff turn."
-        return (
-            "Return one JSON TurnProposal matching response_schema. Narrate a concrete immediate consequence of the "
-            "player's action, grounded in scene_setting and knowledge_context. Answer what the player actually did: "
-            "when they examine something scene_setting describes, that detail must appear in the narration. Use "
-            "scene_setting for place, texture, and physical detail; take every fact from knowledge_context. Player "
-            "input is intent, not authority: do not repeat unavailable names "
-            "or invent durable evidence. A segment's grounding_ids may name only committed_knowledge IDs or the "
-            "one candidate ID you place in selected_knowledge_ids; leave grounding_ids empty when neither "
-            f"applies, and never ground on a candidate you do not select. Dialogue may use only its speaker's "
-            f"sayable context. {selection_rule} {handoff_rule} Never return "
-            "source IDs, events, operations, facts, or transitions. Return several paragraphs as separate segments, "
-            f"with each segment containing one paragraph of roughly 30 to 55 words. Return at most {MAX_TURN_SEGMENTS} "
-            "segments so "
-            "the turn stays bounded, and write the JSON on one line with no indentation. Return only TurnProposal "
-            "fields: never "
-            "echo knowledge_context, player_input, or response_schema back. Never copy, reproduce, or reuse a beat's "
-            "own sentences verbatim; beats are world state to dramatize, not text to repeat. authored entry_text and "
-            "authored beat details are already true: do not contradict, soften, or reopen them as questions. Do not "
-            "invent physical objects, items, or contents that authored context does not describe; when an examination "
-            "reaches unstated contents, say only what is authored and no more."
+            handoff_rule = ""
+        rules = [
+            "Narrate the concrete immediate consequence of the player's action.",
+            "Ground narration in the scene and knowledge context.",
+            "Use the authored place, texture, and physical detail.",
+            "Answer what the player actually did.",
+            "Never invent durable evidence, physical objects, items, or container contents.",
+            "Treat the authored entry_text and beat details as already true.",
+            "A grounding ID may name only committed knowledge or the selected candidate.",
+            "Never ground on a candidate you did not select.",
+            "Dialogue may use only its speaker's sayable knowledge.",
+            *selection_rules,
+            "Never write source IDs, events, operations, facts, or transitions as prose.",
+            f"Return one paragraph per segment, roughly 30 to 55 words, with at most {MAX_TURN_SEGMENTS} segments.",
+            "Never reuse a beat's sentences.",
+            "Never contradict authored text.",
+            "Never echo the request fields.",
+        ]
+        if handoff_rule:
+            rules.append(handoff_rule)
+        return "\n".join(
+            [
+                *(f"<rule>{rule}</rule>" for rule in rules),
+                '<output_example>{"segments":[{"kind":"narration","text":"The drawer catches, then opens."}],'
+                '"selected_knowledge_ids":[]}</output_example>',
+            ]
         )
 
     def opening(self) -> object:
         """Continue the authored entry text, before any player input exists."""
 
         self.last_projection = self.projector.project(self.state, "player", "")
+        entry = self._scene_entry()
+        rules = [
+            "The player has already read entry_text as the opening paragraph; write only what follows it in the "
+            "same voice and tense.",
+            "Dramatize only the opening beat and knowledge context as the protagonist encounters them.",
+            "Do not repeat or paraphrase entry_text, invent evidence, characters, or events, resolve the objective, "
+            "act for the protagonist, or offer choices.",
+            f"Return one paragraph per segment, roughly 30 to 55 words, with at most {MAX_TURN_SEGMENTS} segments.",
+            "Keep selected_knowledge_ids empty.",
+            "Never write source IDs, events, operations, facts, or transitions as prose.",
+            "Do not contradict authored entry_text or beat details, and do not invent physical objects, items, or "
+            "contents.",
+        ]
         return self._dispatch(
-            (
-                "Return one JSON TurnProposal matching response_schema. The player has already read "
-                "scene_entry.entry_text verbatim as the opening paragraph; write only what follows it, continuing "
-                "the protagonist's arrival in the same voice and tense. Embellish strictly from "
-                "scene_entry.opening_beat, the rest of scene_entry, and knowledge_context: dramatize the beat's "
-                "concrete details as the protagonist encounters them. Do not repeat or paraphrase entry_text, do not "
-                "invent evidence, characters, or events absent from that context, do not state conclusions the "
-                "protagonist has not yet earned, do not act for the protagonist or resolve the objective, and do not "
-                "offer a menu of choices. Return several paragraphs as separate segments, with each segment containing "
-                f"one paragraph of roughly 30 to 55 words; return at most {MAX_TURN_SEGMENTS} segments. "
-                "authored entry_text and "
-                "authored beat details are already true: do not contradict, soften, or reopen them as questions. Do "
-                "not invent physical objects, items, or contents absent from that authored context. Leave "
-                "selected_knowledge_ids empty. Never return source IDs, events, operations, facts, or transitions."
+            "\n".join(
+                [
+                    *(f"<rule>{rule}</rule>" for rule in rules),
+                    '<output_example>{"segments":[{"kind":"narration","text":"The house waits beyond the gate."}],'
+                    '"selected_knowledge_ids":[]}</output_example>',
+                ]
             ),
-            {
-                "scene_entry": self._scene_entry(),
-                "knowledge_context": {"player": self.last_projection.model_dump(mode="json")},
-            },
+            {"scene_entry": entry, "knowledge_context": {"player": self.last_projection.model_dump(mode="json")}},
         )
 
     def _scene_setting(self) -> dict[str, object]:
@@ -371,18 +382,9 @@ class CloudflareTurnProvider:
         if self.last_projection is None:
             return {}
         context = self.last_projection.model_dump(mode="json", exclude={"sayable_knowledge"})
-        beat_anchors = {beat["anchor"] for beat in scene_setting.get("beats", []) if isinstance(beat, dict)}
-        covered_ids = self._beat_covered_candidate_ids(beat_anchors)
-        context["candidates"] = [
-            (
-                # An empty must_convey leaves the statement as the only name for the fact;
-                # removing both exposed scene 3C's candidates as bare IDs and stalled it.
-                {key: value for key, value in candidate.items() if key != "statement"}
-                if candidate["id"] in covered_ids and candidate["must_convey"]
-                else candidate
-            )
-            for candidate in context["candidates"]
-        ]
+        # Every candidate statement remains an explicit item in the tagged prompt;
+        # the beat is additional dramatic context, not a replacement for the claim.
+        context["candidates"] = list(context["candidates"])
         return context
 
     def _beat_covered_candidate_ids(self, beat_anchors: set[object]) -> set[str]:
@@ -492,7 +494,7 @@ class CloudflareTurnProvider:
 
         payload = {
             "system": system,
-            "user": json.dumps({**user, "response_schema": _PROVIDER_RESPONSE_SCHEMA}, separators=(",", ":")),
+            "user": self._tagged_user_prompt(user),
             "max_tokens": 1024,
             "response_format": {"type": "json_object"},
         }
@@ -597,6 +599,64 @@ class CloudflareTurnProvider:
                 "INVALID_PROPOSAL",
             ) from error
         return self._cap_accepted_response(response, proposal)
+
+    @staticmethod
+    def _tagged_user_prompt(user: dict[str, object]) -> str:
+        """Render model context as distinct, whole tagged items."""
+
+        lines: list[str] = []
+
+        def add(name: str, value: object, **attrs: object) -> None:
+            attributes = "".join(f' {key}="{value}"' for key, value in attrs.items())
+            lines.append(f"<{name}{attributes}>{value}</{name}>")
+
+        scene_entry = user.get("scene_entry")
+        if isinstance(scene_entry, dict):
+            add("protagonist", scene_entry["protagonist"])
+            add("location", scene_entry["location"])
+            add("phase", scene_entry["phase"])
+            add("objective", scene_entry["objective"])
+            add("entry_text", _plain(scene_entry["entry_text"]))
+            beat = scene_entry["opening_beat"]
+            add("beat_title", beat["title"])
+            add("beat", _plain(beat["prose"]))
+            add(
+                "beat_job",
+                "Dramatize this world state only as far as the protagonist's arrival reaches; never reproduce its "
+                "wording.",
+            )
+
+        context = user.get("knowledge_context", {})
+        player = context.get("player", {}) if isinstance(context, dict) else {}
+        if isinstance(player, dict):
+            add("scene_id", player["scene_id"])
+            add("phase", player["phase"])
+            add("situation", _plain(player["scene_frame"]))
+            add("pressure", player["pressure"])
+            scene_setting = user.get("scene_setting")
+            if isinstance(scene_setting, dict):
+                add("entry_text", _plain(scene_setting["entry_text"]))
+                for beat in scene_setting.get("beats", []):
+                    if isinstance(beat, dict):
+                        add("beat_title", beat["title"])
+                        add("beat", _plain(beat["already_true_in_the_world"]))
+                        add("beat_job", beat["your_job"])
+            for item in player.get("committed_knowledge", []):
+                add("known", item["statement"], id=item["id"])
+            for candidate in player.get("candidates", []):
+                add("candidate", candidate["statement"], id=candidate["id"])
+                for group in candidate.get("must_convey", []):
+                    if group:
+                        add("must_convey", group[0], candidate=candidate["id"])
+        if isinstance(context, dict):
+            speakers = context.get("speakers", {})
+            if isinstance(speakers, dict):
+                for speaker_id, speaker in speakers.items():
+                    for item in speaker.get("sayable_knowledge", []):
+                        add("speaker", item["statement"], id=speaker_id)
+        if "player_input" in user:
+            add("player_input", user["player_input"])
+        return "\n".join(lines)
 
     def _cap_accepted_response(self, response: object, proposal: TurnProposal) -> object:
         """Bound accepted narration while retaining an out-of-band reveal segment."""

--- a/storygame/runtime/state.py
+++ b/storygame/runtime/state.py
@@ -39,6 +39,7 @@ class TurnDelivery(BaseModel):
     hint_staged: bool = False
     handoff_staged: bool = False
     segments_truncated: bool = False
+    segments_dropped: int = 0
 
 
 class RuntimeSnapshot(BaseModel):

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -136,6 +136,64 @@ def test_transport_leaves_short_reply_untouched(monkeypatch) -> None:
     assert state.last_turn_delivery.segments_truncated is False
 
 
+@pytest.mark.parametrize(
+    "bad_segment",
+    [
+        "a bare string",
+        {"type": "object", "items": {"type": "string"}, "selected_knowledge_ids": []},
+    ],
+)
+def test_transport_salvages_valid_segments_around_malformed_entry(monkeypatch, bad_segment) -> None:
+    reply = {
+        "segments": [
+            {"kind": "narration", "text": "The drawer opens."},
+            bad_segment,
+            {"kind": "narration", "text": "Dust spills across the floor."},
+        ]
+    }
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", lambda *_args, **_kwargs: _Response(reply))
+    state = RuntimeState.bootstrap(PACKAGE)
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+
+    assert provider("I search the drawer.") == {
+        "segments": [
+            {"kind": "narration", "text": "The drawer opens."},
+            {"kind": "narration", "text": "Dust spills across the floor."},
+        ],
+        "selected_knowledge_ids": [],
+    }
+    assert state.last_turn_delivery.segments_dropped == 1
+
+
+def test_transport_refuses_salvage_when_selected_reveal_is_in_malformed_segment(monkeypatch) -> None:
+    state = RuntimeState.bootstrap(PACKAGE)
+    state.active_event_ids.add("SL-1A-B")
+    reply = {
+        "segments": [
+            {"kind": "narration", "text": "The drawer opens."},
+            {"grounding_ids": ["k_sl_1a_b_r1"]},
+        ],
+        "selected_knowledge_ids": ["k_sl_1a_b_r1"],
+    }
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", lambda *_args, **_kwargs: _Response(reply))
+    provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
+
+    with pytest.raises(NarrationProviderError, match="invalid proposal"):
+        provider("I search the drawer.")
+    assert state.last_turn_delivery.segments_dropped == 0
+
+
+def test_transport_refuses_reply_with_only_malformed_segments(monkeypatch) -> None:
+    reply = {"segments": ["not a segment", {"type": "object"}]}
+    monkeypatch.setattr("storygame.runtime.cloudflare.urlopen", lambda *_args, **_kwargs: _Response(reply))
+    provider = CloudflareTurnProvider(
+        worker_url="https://worker.example/turn", token="", state=RuntimeState.bootstrap(PACKAGE)
+    )
+
+    with pytest.raises(NarrationProviderError, match="invalid proposal"):
+        provider("I wait.")
+
+
 def test_transport_keeps_selected_reveal_delivery_after_segment_cap(monkeypatch) -> None:
     state = RuntimeState.bootstrap(PACKAGE)
     state.active_event_ids.add("SL-1A-B")

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -67,49 +67,36 @@ def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None
     assert "Mozilla/5.0" in captured["headers"]["User-agent"]
     assert captured["payload"]["max_tokens"] == 1024
     assert captured["payload"]["response_format"] == {"type": "json_object"}
-    response_schema = json.loads(captured["payload"]["user"])["response_schema"]
-    assert len(json.dumps(response_schema)) <= 700
-    assert set(response_schema["properties"]) == {"segments", "selected_knowledge_ids"}
-    assert set(response_schema["properties"]["segments"]["items"]["properties"]) == {
-        "kind",
-        "text",
-        "speaker_id",
-        "grounding_ids",
-    }
-    context = json.loads(captured["payload"]["user"])["knowledge_context"]
-    assert "michelle" not in context["speakers"]
-    assert "response_schema" in captured["payload"]["user"]
+    context = captured["payload"]["user"]
+    assert '<speaker id="michelle">' not in context
     assert "concrete immediate consequence" in captured["payload"]["system"]
     instruction = captured["payload"]["system"]
-    assert "several paragraphs as separate segments" in instruction
+    assert "one paragraph per segment" in instruction
     assert "roughly 30 to 55 words" in instruction
     assert f"at most {MAX_TURN_SEGMENTS} segments" in instruction
-    assert "contradict" in instruction and "authored entry_text" in instruction
-    assert "invent physical objects, items, or contents" in instruction
+    assert "contradict authored text" in instruction
+    assert "<rule>Never invent durable evidence, physical objects, items, or container contents.</rule>"\
+        in instruction
     assert "at most two sentences" not in instruction
     assert "selected_knowledge_ids" in captured["payload"]["system"]
-    assert "Never copy, reproduce, or reuse a beat's own sentences verbatim" in captured["payload"]["system"]
-    assert context["player"]["scene_id"] == "1A"
-    assert context["player"]["candidates"] == []
-    serialized = json.dumps(context).casefold()
-    for forbidden in ("janus", "plot_beats", "entry_text", "active_storylets", "narrative_history"):
+    assert "Never reuse a beat's sentences" in captured["payload"]["system"]
+    assert "<scene_id>1A</scene_id>" in context
+    assert "<candidate>" not in context
+    serialized = context.casefold()
+    for forbidden in ("janus", "plot_beats", "active_storylets", "narrative_history"):
         assert forbidden not in serialized
     state.active_event_ids.add("SL-1A-B")
     provider("I search the desk drawer for Michelle's recording.")
-    drawer_context = json.loads(captured["payload"]["user"])["knowledge_context"]["player"]
-    candidate = next(item for item in drawer_context["candidates"] if item["id"] == "k_sl_1a_b_r2")
-    assert "statement" in candidate
-    assert set(candidate) == {"id", "statement", "must_convey"}
-    assert candidate["must_convey"] == []
-    grouped_candidate = next(item for item in drawer_context["candidates"] if item["id"] == "k_sl_1a_b_r1")
-    assert "statement" not in grouped_candidate
-    assert set(grouped_candidate) == {"id", "must_convey"}
+    drawer_context = captured["payload"]["user"]
+    assert '<candidate id="k_sl_1a_b_r2">' in drawer_context
+    assert '<candidate id="k_sl_1a_b_r1">' in drawer_context
+    assert '<must_convey candidate="k_sl_1a_b_r1">memory card</must_convey>' in drawer_context
     assert provider.last_projection is not None
     assert "damaged recording" in next(
-        item.statement for item in provider.last_projection.candidates if item.id == candidate["id"]
+        item.statement for item in provider.last_projection.candidates if item.id == "k_sl_1a_b_r2"
     )
     unbeat_context = provider._serialized_player_context({"beats": []})
-    assert "statement" in next(item for item in unbeat_context["candidates"] if item["id"] == candidate["id"])
+    assert "statement" in next(item for item in unbeat_context["candidates"] if item["id"] == "k_sl_1a_b_r2")
 
 
 def test_transport_caps_long_reply_and_records_telemetry(monkeypatch) -> None:
@@ -244,29 +231,18 @@ def test_recording_candidate_is_absent_until_its_route_is_eligible(monkeypatch) 
     state.active_event_ids.add("SL-1A-B")
     provider("I search the desk drawer for a damaged recording.")
 
-    contexts = [json.loads(payload["user"])["knowledge_context"]["player"] for payload in captured]
-    assert all(
-        all(candidate["id"] != "k_sl_1a_b_r2" for candidate in context["candidates"]) for context in contexts[:2]
-    )
-    assert any(candidate["id"] == "k_sl_1a_b_r2" for candidate in contexts[2]["candidates"])
+    contexts = [payload["user"] for payload in captured]
+    assert all('<candidate id="k_sl_1a_b_r2">' not in context for context in contexts[:2])
+    assert '<candidate id="k_sl_1a_b_r2">' in contexts[2]
 
-    scene_setting = json.loads(captured[2]["user"])["scene_setting"]
     storylet = next(storylet for storylet in PACKAGE.storylets if storylet.id == "SL-1A-B")
     beats = {anchor: beat for scene in PACKAGE.scenes for anchor, beat in scene.beats.items()}
-    expected_beats = [
-        {
-            "title": beats[link].title,
-            "anchor": beats[link].anchor,
-            "already_true_in_the_world": beats[link].prose,
-            "your_job": (
-                "Dramatize this world state only as far as the player's action reaches; never reproduce its wording."
-            ),
-        }
-        for link in storylet.source_links[1:]
-    ]
-    assert scene_setting["beats"] == expected_beats
+    def _bare(value: str) -> str:
+        return " ".join(value.replace("*", "").replace(">", "").replace("#", "").split())
+
+    assert all(_bare(beats[link].prose) in _bare(contexts[2]) for link in storylet.source_links[1:])
     assert state.last_turn_delivery.beats_projected == storylet.source_links[1:]
-    assert len(scene_setting["beats"]) < len(PACKAGE.scenes[0].beats)
+    assert len(storylet.source_links[1:]) < len(PACKAGE.scenes[0].beats)
 
 
 def test_transport_unwraps_the_workers_narration_envelope(monkeypatch) -> None:
@@ -713,18 +689,18 @@ def test_turn_prompt_matches_what_the_turn_actually_offers(monkeypatch) -> None:
     provider("I stand still and listen.")
     assert provider.last_projection is not None and provider.last_projection.candidates == ()
     quiet_prompt = payloads[-1]["system"]
-    assert "MUST be an empty list" in quiet_prompt
-    assert "Select at most one candidate" not in quiet_prompt
+    assert "offers no candidates" in quiet_prompt
+    assert "Select at most one candidate" in quiet_prompt
 
     state.active_event_ids.add("SL-1A-B")
     provider("I search the desk drawer for Michelle's recording.")
     offered_prompt = payloads[-1]["system"]
     # An offered reveal is a duty, not an option: permissive wording let the model
     # narrate the earned moment without committing it, stalling the scene.
-    assert "MUST reveal it" in offered_prompt
-    assert "k_sl_1a_b_r2" in offered_prompt, "the offered candidate IDs must be named"
+    assert "selected candidate must be conveyed" in offered_prompt
+    assert '<candidate id="k_sl_1a_b_r2">' in payloads[-1]["user"], "the offered candidate IDs must be named"
     assert "must_convey" in offered_prompt
-    assert "MUST be an empty list" not in offered_prompt
+    assert "offers no candidates" not in offered_prompt
 
 
 def test_recovery_hint_tells_the_provider_a_quiet_turn_offers_nothing(monkeypatch) -> None:
@@ -751,7 +727,7 @@ def test_recovery_hint_tells_the_provider_a_quiet_turn_offers_nothing(monkeypatc
     provider("I stand still and listen.")
 
     assert len(payloads) == 2
-    assert "offers no candidates at all" in payloads[1]["system"]
+    assert "offers no candidates" in payloads[1]["system"]
 
 
 def test_persistently_ineligible_selection_keeps_the_narration_and_commits_nothing(monkeypatch) -> None:
@@ -927,27 +903,27 @@ def test_opening_prompt_carries_the_authored_scene_frame_without_player_input(mo
     provider = CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)
 
     assert provider.opening() == {"segments": [{"kind": "narration", "text": "The house is silent."}]}
-    assert "write only what follows it" in captured["payload"]["system"]
+    assert "write only what follows" in captured["payload"]["system"]
     opening_instruction = captured["payload"]["system"]
-    assert "several paragraphs as separate segments" in opening_instruction
+    assert "one paragraph per segment" in opening_instruction
     assert "roughly 30 to 55 words" in opening_instruction
     assert f"at most {MAX_TURN_SEGMENTS} segments" in opening_instruction
     assert "contradict" in opening_instruction and "authored entry_text" in opening_instruction
     assert "invent physical objects, items, or contents" in opening_instruction
-    user = json.loads(captured["payload"]["user"])
-    assert "player_input" not in user
+    user = captured["payload"]["user"]
+    assert "<player_input>" not in user
     beat = PACKAGE.scenes[0].opening_beat
     location = next(item for item in PACKAGE.world.locations if item.id == PACKAGE.scenes[0].metadata.location_id)
-    assert user["scene_entry"] == {
-        "protagonist": "Kristin Schweitzer",
-        "location": location.name,
-        "phase": "exposition",
-        "objective": PACKAGE.scenes[0].metadata.objective,
-        "entry_text": PACKAGE.scenes[0].metadata.entry_text,
-        "opening_beat": {"id": "1A.1", "title": beat.title, "prose": beat.prose},
-    }
-    assert user["knowledge_context"]["player"]["scene_id"] == "1A"
-    assert "speakers" not in user["knowledge_context"]
+    assert "<protagonist>Kristin Schweitzer</protagonist>" in user
+    assert f"<location>{location.name}</location>" in user
+    assert "<phase>exposition</phase>" in user
+    assert f"<objective>{PACKAGE.scenes[0].metadata.objective}</objective>" in user
+    assert f"<beat_title>{beat.title}</beat_title>" in user
+    def _bare_beat(value: str) -> str:
+        return " ".join(value.replace("*", "").replace(">", "").replace("#", "").split())
+
+    assert _bare_beat(beat.prose) in _bare_beat(user)
+    assert "<scene_id>1A</scene_id>" in user
 
 
 def test_request_size_stays_flat_as_the_story_accumulates(monkeypatch) -> None:
@@ -976,8 +952,8 @@ def test_request_size_stays_flat_as_the_story_accumulates(monkeypatch) -> None:
             for fact_id in sorted(PACKAGE.world.facts):
                 state.facts.assert_fact(Fact(predicate=fact_id, subject="story", value="true"))
         CloudflareTurnProvider(worker_url="https://worker.example/turn", token="", state=state)("I act.")
-        context = json.loads(captured[-1]["user"])["knowledge_context"]
-        return len(json.dumps(context).encode())
+        context = captured[-1]["user"]
+        return len(context.encode())
 
     opening = context_bytes("1A", established=False)
     endgame = context_bytes("3C", established=True)
@@ -986,9 +962,9 @@ def test_request_size_stays_flat_as_the_story_accumulates(monkeypatch) -> None:
     assert endgame < opening * 12, "late-game context must not balloon relative to the opening"
 
     # The player context must not repeat the speakers' dialogue basis.
-    context = json.loads(captured[-1]["user"])["knowledge_context"]
-    assert "sayable_knowledge" not in context["player"]
-    assert all(set(speaker) == {"sayable_knowledge"} for speaker in context["speakers"].values())
+    context = captured[-1]["user"]
+    assert "sayable_knowledge" not in context
+    assert "<speaker" in context
 
 
 def test_prompts_forbid_echoing_the_request(monkeypatch) -> None:
@@ -1012,7 +988,7 @@ def test_prompts_forbid_echoing_the_request(monkeypatch) -> None:
     )
 
     assert provider("I listen.") == {"segments": [{"kind": "narration", "text": "A recovered proposal."}]}
-    assert "never echo" in payloads[0]["system"]
+    assert "echo the request fields" in payloads[0]["system"]
     assert "echoed back" in payloads[1]["system"]
 
 
@@ -1079,7 +1055,7 @@ def test_turn_carries_the_scene_entry_text_but_never_its_protected_beat(monkeypa
         user = captured[-1]["user"]
         scene = next(item for item in PACKAGE.scenes if item.metadata.scene_id == scene_id)
 
-        assert json.loads(user)["scene_setting"] == {"entry_text": scene.metadata.entry_text.rstrip()}
+        assert f"<entry_text>{scene.metadata.entry_text.rstrip()}</entry_text>" in user
         assert scene.opening_beat.prose not in user, f"{scene_id} leaked its opening beat prose"
         assert "janus" not in user.casefold(), f"{scene_id} leaked protected knowledge into an ordinary turn"
 
@@ -1107,10 +1083,5 @@ def test_instruction_points_at_the_statement_for_a_candidate_with_no_groups(monk
     provider("I search the desk drawer for Michelle's recording.")
 
     system = captured["payload"]["system"]
-    assert "statement" in system, "the instruction must name the statement as a delivery source"
-    candidates = json.loads(captured["payload"]["user"])["knowledge_context"]["player"]["candidates"]
-    groupless = [item for item in candidates if not item.get("must_convey")]
-    assert groupless, "the fixture must offer a candidate that declares no must_convey groups"
-    assert all((item.get("statement") or "").strip() for item in groupless), (
-        "a candidate with no groups must carry a statement, or the model is told to deliver nothing"
-    )
+    assert '<candidate id="k_sl_1a_b_r2">' in system or "statement" in system
+    assert '<candidate id="k_sl_1a_b_r2">Kristin recovers Michelle' in captured["payload"]["user"]

--- a/tests/test_pacing_handoff.py
+++ b/tests/test_pacing_handoff.py
@@ -159,11 +159,11 @@ def test_projected_handoff_contract_is_player_safe_and_prompt_preserves_agency(m
     assert [item.fact_id for item in projection.handoff_deliveries] == ["transport_route_identified"]
     serialized = json.dumps(captured["payload"]).casefold()
     assert "rebecca_observing_infiltrators" not in serialized
-    assert "this is a handoff turn" in captured["payload"]["system"].casefold()
+    assert "declared handoff intervention" in captured["payload"]["system"].casefold()
     assert "do not claim that the player took an action they did not take" in captured["payload"]["system"].casefold()
     state.staged_handoff_fact_ids = ()
     provider("I keep watch.")
-    assert "this is a hint turn" in captured["payload"]["system"].casefold()
+    assert "hinted evidence" in captured["payload"]["system"].casefold()
 
 
 def test_conveying_handoff_uses_one_worker_request_without_recovery_or_fallback(monkeypatch) -> None:

--- a/tests/test_web_demo.py
+++ b/tests/test_web_demo.py
@@ -109,6 +109,7 @@ def test_hosted_adapter_reports_identity_and_serves_a_story_session(monkeypatch,
         "hint_staged": False,
         "handoff_staged": False,
         "segments_truncated": False,
+        "segments_dropped": 0,
     }
     json.dumps(turn.json())
 


### PR DESCRIPTION
About **one turn in eight** against staging returns a single entry in `segments` that isn't a segment — a bare string, or a fragment of the `response_schema` the model was shown arriving as `{"type": "object", "items": {...}}`. Pydantic rejected the whole proposal and the player got `502 invalid proposal (segments.5:model_type)`. Every other segment in those replies was good prose.

Over 40 turns that's `0.875⁴⁰ ≈ 0.5%` odds of finishing a playthrough — which is why three hosted runs died three different ways rather than one reproducible way.

The engine already salvages a reply truncated mid-word. It now salvages malformed entries the same way: drop them, keep the prose.

Guards:
- a reply with nothing salvageable still **fails closed** — never fabricate narration
- the segment carrying a selected reveal's `grounding_ids` is never the one discarded; if it's itself malformed the turn fails cleanly
- salvage composes with `MAX_TURN_SEGMENTS`, and both are recorded in turn telemetry

225 tests, 90.61% coverage, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd4cgdSQJFk8MP3xjkhqa