### PR TITLE
Do not teach grounding by example; attribute it instead

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -310,20 +310,13 @@ class CloudflareTurnProvider:
         ]
         if handoff_rule:
             rules.append(handoff_rule)
-        if candidates:
-            offered_id = candidates[0].id
-            example = (
-                '<output_example>{"segments":['
-                '{"kind":"narration","text":"The drawer sticks, then gives. Inside, under a curl of packing tape, '
-                "her fingers find the flat edge of something that was never meant to be seen from above, and the "
-                'kitchen behind her goes very quiet.","grounding_ids":["' + offered_id + '"]},'
-                '{"kind":"narration","text":"She works it loose and turns it over in the light from the window. '
-                "The plastic is scuffed at one corner, as though it had been pressed into place in a hurry, and "
-                'the initials carved into the drawer front suddenly read less like affection than instruction."}],'
-                '"selected_knowledge_ids":["' + offered_id + '"]}</output_example>'
-            )
-        else:
-            example = (
+        # The example is not the place to teach grounding. Showing a grounded
+        # selection here made the model ground on IDs it had not selected, and a
+        # live sample went from no failures in sixteen turns to six in eighteen -
+        # five of them HTTP 409 for grounding on knowledge that was neither
+        # committed nor selected. The engine attributes the delivering segment
+        # itself, so the model never needs to be shown how.
+        example = (
                 '<output_example>{"segments":['
                 '{"kind":"narration","text":"The drawer sticks, then gives. Inside, under a curl of packing tape, '
                 "her fingers find the flat edge of something that was never meant to be seen from above, and the "

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -748,8 +748,14 @@ def test_turn_prompt_matches_what_the_turn_actually_offers(monkeypatch) -> None:
     assert "must_convey" in offered_prompt
     assert "offers no candidates" not in offered_prompt
     offered_id = provider.last_projection.candidates[0].id
-    assert f'"grounding_ids":["{offered_id}"]' in offered_prompt
-    assert f'"selected_knowledge_ids":["{offered_id}"]' in offered_prompt
+    assert offered_id in payloads[-1]["user"], "the offered candidate must still reach the model"
+    # The example deliberately does NOT ground. Showing a grounded selection here
+    # taught the model to ground on IDs it had not selected: a live sample went
+    # from no failures in sixteen turns to six in eighteen, five of them HTTP 409
+    # for grounding on knowledge neither committed nor selected. The engine
+    # attributes the delivering segment itself.
+    assert '"grounding_ids":[' not in offered_prompt
+    assert '"selected_knowledge_ids":[]' in offered_prompt
 
 
 def test_recovery_hint_tells_the_provider_a_quiet_turn_offers_nothing(monkeypatch) -> None:


### PR DESCRIPTION
Showing a grounded selection in the output example was meant to stop the model returning `grounding_ids: null`. It did — and taught it to ground on IDs it had never selected.

A live sample went from **0 failures in 16 turns** to **6 in 18**: five HTTP 409 for grounding on knowledge neither committed nor selected, plus a 502 where the model put a candidate ID in as a segment *key* (`segments.13.k_sl_2a_a_r1`).

That's the third time the example changed behaviour more than the rule beside it:

| example shows | model returns |
|---|---|
| one 5-word segment | one 15-word segment |
| two 30–55 word paragraphs | 3–5 paragraphs, 88–143 words |
| a grounded selection | grounding everywhere, earned or not |

So the example goes back to showing no grounding, and the engine keeps attributing the delivering segment itself (merged in #428). The model is never asked to do the bookkeeping it kept getting wrong.

229 tests, 90.32% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd4cgdSQJFk8MP3xjkhqa