### PR TITLE
Record the verbatim prompt for a turn, behind a flag that is off

### DIFF
--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -91,9 +91,10 @@ export async function startSceneSession(page) {
   const controller = packageClockControllers.get(page);
   const sessionState = controller ? sessionResponseFor(page, controller) : null;
   await page.getByRole("button", { name: "New Session" }).click();
-  if (sessionState) await sessionState;
+  const payload = sessionState ? await sessionState : undefined;
   await expect(page.locator("#status-line")).toContainText("Scene 1A");
   await expect(page.locator("#transcript")).not.toBeEmpty();
+  return payload;
 }
 
 export async function submitTurn(page, action) {

--- a/frontend/e2e/scene-runtime.spec.js
+++ b/frontend/e2e/scene-runtime.spec.js
@@ -112,9 +112,11 @@ test("judges every reached scene against the five-file narrative canon @llm-cano
   test.setTimeout(20 * 60_000);
   const pacing = loadPackagePacing({ storyId: "continuity_initiative" });
   const controller = await installPackageClock(page);
-  await startSceneSession(page);
+  const sessionPayload = await startSceneSession(page);
   const opening = (await page.locator(".entry-output").first().textContent())?.trim() || "";
-  const byScene = new Map([["1A", { opening, turns: [] }]]);
+  const byScene = new Map([
+    ["1A", { opening, turns: [], ...(sessionPayload?.prompt ? { opening_prompt: sessionPayload.prompt } : {}) }],
+  ]);
   const sceneOrder = pacing.sceneOrder;
   let sceneId = "1A";
   let turnIndex = 0;
@@ -221,10 +223,15 @@ test("judges every reached scene against the five-file narrative canon @llm-cano
           narration: sceneNarration,
           left_scene: entered,
           beats_projected: payload.delivery?.beats_projected || [],
+          ...(payload.prompt ? { prompt: payload.prompt } : {}),
         });
       }
       if (entered && !byScene.has(reachedSceneId)) {
-        byScene.set(reachedSceneId, { opening: segments.at(-1).text.trim(), turns: [] });
+        byScene.set(reachedSceneId, {
+          opening: segments.at(-1).text.trim(),
+          turns: [],
+          ...(payload.prompt ? { opening_prompt: payload.prompt } : {}),
+        });
       }
       sceneId = reachedSceneId;
       turnIndex = payload.state?.turn_index;

--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -201,6 +201,7 @@ class CloudflareTurnProvider:
         self.state = state
         self.projector = projector or KnowledgeProjector()
         self.last_projection: TurnKnowledgeContext | None = None
+        self.last_prompt: dict[str, str] | None = None
         self.grounding_attributions: tuple[str, ...] = ()
 
     @classmethod
@@ -997,6 +998,7 @@ class CloudflareTurnProvider:
                 raise error from first_failure
 
     def _request(self, payload: dict[str, object]) -> object:
+        self.last_prompt = {"system": payload["system"], "user": payload["user"]}
         headers = {
             "Content-Type": "application/json",
             "User-Agent": BROWSER_USER_AGENT,

--- a/storygame/web_demo.py
+++ b/storygame/web_demo.py
@@ -84,7 +84,10 @@ def _state_summary(state: RuntimeState) -> dict[str, object]:
 
 
 def _turn_payload(
-    state: RuntimeState, proposal: ResolvedTurnProposal | str, game_break: object | None = None
+    state: RuntimeState,
+    proposal: ResolvedTurnProposal | str,
+    game_break: object | None = None,
+    prompt: dict[str, str] | None = None,
 ) -> dict[str, object]:
     """Keep structured segments primary while retaining migration-era lines."""
     if isinstance(proposal, str):
@@ -95,13 +98,16 @@ def _turn_payload(
         segments = [item.model_dump(mode="json") for item in proposal.segments] or [
             {"kind": "narration", "text": narration}
         ]
-    return {
+    payload = {
         "segments": segments,
         "lines": [narration],
         "game_break": game_break,
         "delivery": state.last_turn_delivery.model_dump(mode="json"),
         "state": _state_summary(state),
     }
+    if prompt is not None:
+        payload["prompt"] = prompt
+    return payload
 
 
 def _narration_http_error(error: NarrationProviderError) -> HTTPException:
@@ -195,7 +201,8 @@ def create_demo_app(
             raise HTTPException(status_code=404, detail="story does not exist")
         state = RuntimeState.bootstrap(package)
         try:
-            opening = RuntimeEngine(state, provider_for(state)).opening()
+            provider = provider_for(state)
+            opening = RuntimeEngine(state, provider).opening()
         except NarrationProviderError as error:
             raise _narration_http_error(error) from error
         except RuntimeContractError as error:
@@ -203,7 +210,7 @@ def create_demo_app(
         session_id = uuid4().hex
         store.save(session_id, state)
         scene = package.scenes[0].metadata
-        return {
+        payload = {
             "session_id": session_id,
             "state": _state_summary(state),
             "opening": {
@@ -213,14 +220,20 @@ def create_demo_app(
                 "segments": [item.model_dump(mode="json") for item in opening.segments],
             },
         }
+        if getenv("FREYTAG_EXPOSE_PROMPT", "") == "1":
+            prompt = getattr(provider, "last_prompt", None)
+            if prompt is not None:
+                payload["prompt"] = prompt
+        return payload
 
     @app.post("/api/v1/turn")
     def turn(body: TurnRequest, request: Request) -> dict[str, object]:
         require_rate_limit(request)
         state = load_state(body.session_id)
         try:
+            provider = provider_for(state)
             test_clock = _test_clock_seconds(body, request)
-            proposal = RuntimeEngine(state, provider_for(state)).turn(body.input_text, clock_seconds=test_clock)
+            proposal = RuntimeEngine(state, provider).turn(body.input_text, clock_seconds=test_clock)
         except NarrationProviderError as error:
             raise _narration_http_error(error) from error
         except RuntimeContractError as error:
@@ -229,7 +242,8 @@ def create_demo_app(
             raise HTTPException(status_code=409, detail=str(error)) from error
         store.save(body.session_id, state)
         warning = proposal.game_break.model_dump(mode="json") if proposal.game_break else None
-        return _turn_payload(state, proposal, warning)
+        prompt = getattr(provider, "last_prompt", None) if getenv("FREYTAG_EXPOSE_PROMPT", "") == "1" else None
+        return _turn_payload(state, proposal, warning, prompt)
 
     @app.post("/api/v1/game-break")
     def resolve_game_break(body: BreakResolutionRequest) -> dict[str, object]:

--- a/tests/test_web_demo.py
+++ b/tests/test_web_demo.py
@@ -28,6 +28,14 @@ class _StubProvider:
         return {"segments": [{"kind": "narration", "text": self.turn_text}]}
 
 
+class _PromptProvider(_StubProvider):
+    last_prompt = {"system": "<system>verbatim system</system>", "user": "<user>verbatim user</user>"}
+
+
+def _prompt_provider(_state):
+    return _PromptProvider("The prompt is captured.", "The opening is captured.")
+
+
 class _TurnFailureProvider(_StubProvider):
     """Keep the scene opening valid so a test can isolate an ordinary-turn failure."""
 
@@ -112,6 +120,40 @@ def test_hosted_adapter_reports_identity_and_serves_a_story_session(monkeypatch,
         "segments_dropped": 0,
     }
     json.dumps(turn.json())
+
+
+def test_prompt_is_absent_by_default(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("FREYTAG_EXPOSE_PROMPT", raising=False)
+    app = create_demo_app(store_path=tmp_path / "sessions.sqlite", provider_factory=_prompt_provider)
+
+    with TestClient(app) as client:
+        session = client.post("/api/v1/session", json={"story_id": "continuity_initiative"})
+        turn = client.post(
+            "/api/v1/turn", json={"session_id": session.json()["session_id"], "player_input": "I listen."}
+        )
+
+    assert "prompt" not in session.json()
+    assert "prompt" not in turn.json()
+
+
+def test_prompt_is_exposed_verbatim_on_session_and_turn(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("FREYTAG_EXPOSE_PROMPT", "1")
+    app = create_demo_app(store_path=tmp_path / "sessions.sqlite", provider_factory=_prompt_provider)
+    expected = _PromptProvider.last_prompt
+
+    with TestClient(app) as client:
+        session = client.post("/api/v1/session", json={"story_id": "continuity_initiative"})
+        turn = client.post(
+            "/api/v1/turn", json={"session_id": session.json()["session_id"], "player_input": "I listen."}
+        )
+
+    assert session.json()["prompt"] == expected
+    assert turn.json()["prompt"] == expected
+    for response in (session, turn):
+        serialized = response.text
+        assert "Authorization" not in serialized
+        assert "Bearer" not in serialized
+        assert "CLOUDFLARE_WORKER_TOKEN" not in serialized
 
 
 def test_hosted_adapter_reports_turn_index_and_scene_relative_turns(tmp_path) -> None:


### PR DESCRIPTION
Diagnosing narration has repeatedly meant reconstructing a prompt after the fact by guessing which storylets were active — producing something wider than the turn actually was.

The provider now keeps the exact `system` and `user` strings it last sent, and both `/api/v1/session` and `/api/v1/turn` return them under a top-level `prompt` key — **only when `FREYTAG_EXPOSE_PROMPT=1`**.

- With the flag unset (default, and production) the responses are unchanged and no `prompt` key exists.
- The captured strings are the prompt only: never headers, never `CLOUDFLARE_WORKER_TOKEN`.
- The E2E harness records whatever it finds into each turn of the run artifact, and behaves exactly as today against a deployment without the flag.

**This needs a new Railway env var on staging to take effect.** While enabled, the full prompt is returned over the API — authored story content and IDs, no credentials. Set it deliberately; the harness runs fine without it.

231 tests, 90.35% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd4cgdSQJFk8MP3xjkhqa