### PR TITLE
Bakeoff: put Arm C on main for four fresh judge runs

### DIFF
--- a/storygame/runtime/cloudflare.py
+++ b/storygame/runtime/cloudflare.py
@@ -297,7 +297,8 @@ class CloudflareTurnProvider:
             "Ground narration in the scene and knowledge context.",
             "Use the authored place, texture, and physical detail.",
             "Answer what the player actually did.",
-            "Never invent durable evidence.",
+            "Never invent durable evidence, physical objects, items, or container contents.",
+            "Treat the authored entry_text and beat details as already true.",
             "A grounding ID may name only committed knowledge or the selected candidate.",
             "Never ground on a candidate you did not select.",
             "Dialogue may use only its speaker's sayable knowledge.",
@@ -305,6 +306,7 @@ class CloudflareTurnProvider:
             "Never write source IDs, events, operations, facts, or transitions as prose.",
             f"Return one paragraph per segment, roughly 30 to 55 words, with at most {MAX_TURN_SEGMENTS} segments.",
             "Never reuse a beat's sentences.",
+            "Never contradict authored text.",
             "Never echo the request fields.",
         ]
         if handoff_rule:
@@ -340,6 +342,8 @@ class CloudflareTurnProvider:
             "act for the protagonist, or offer choices.",
             f"Return one paragraph per segment, roughly 30 to 55 words, with at most {MAX_TURN_SEGMENTS} segments.",
             "Keep selected_knowledge_ids empty.",
+            "Do not contradict authored entry_text or beat details.",
+            "Do not invent physical objects, items, or contents the authored context does not describe.",
             "Never write source IDs, events, operations, facts, or transitions as prose.",
         ]
         return self._dispatch(

--- a/tests/test_cloudflare_transport.py
+++ b/tests/test_cloudflare_transport.py
@@ -75,9 +75,10 @@ def test_transport_sends_bounded_context_and_optional_token(monkeypatch) -> None
     assert "one paragraph per segment" in instruction
     assert "roughly 30 to 55 words" in instruction
     assert f"at most {MAX_TURN_SEGMENTS} segments" in instruction
-    assert "contradict" not in instruction, "Arm B carries no anti-contradiction prohibition"
-    assert "<rule>Never invent durable evidence.</rule>" in instruction
-    assert "physical objects, items, or container contents" not in instruction
+    # Arm C keeps Arm B's subtraction of beat prose AND Arm A's prohibitions.
+    assert "contradict authored text" in instruction
+    assert "<rule>Never invent durable evidence, physical objects, items, or container contents.</rule>" in instruction
+    assert "already true" in instruction
     assert "at most two sentences" not in instruction
     assert "selected_knowledge_ids" in captured["payload"]["system"]
     assert "Never reuse a beat's sentences" in captured["payload"]["system"]
@@ -968,8 +969,8 @@ def test_opening_prompt_carries_the_authored_scene_frame_without_player_input(mo
     assert "one paragraph per segment" in opening_instruction
     assert "roughly 30 to 55 words" in opening_instruction
     assert f"at most {MAX_TURN_SEGMENTS} segments" in opening_instruction
-    assert "contradict" not in opening_instruction
-    assert "invent physical objects, items, or contents" not in opening_instruction
+    assert "contradict" in opening_instruction
+    assert "invent physical objects, items, or contents" in opening_instruction
     user = captured["payload"]["user"]
     assert "<player_input>" not in user
     beat = PACKAGE.scenes[0].opening_beat


### PR DESCRIPTION
Sets `main`'s tree exactly equal to `bakeoff-arm-c` (6a45574) — Arm C, which sends `<beat_detail>` noun phrases **and** keeps the three prohibition rules.

Arm C's four existing scores (21, 17, 18, 13) were measured in an earlier era. Since then `protected_safe` has fallen from 9/9 (recorded 2026-08-31) to roughly 5/9, on code paths that do not touch protected knowledge — so those older totals sit about three points above what the same arm scores today. Re-running C under tonight's conditions is what makes the three-arm comparison honest.

Verified with `git diff --quiet 6a45574 <this branch>`.

Arm A scored a fresh mean of 13.75 (sd 1.50) and Arm B 13.00 (sd 2.71), both measured tonight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUndB8xHGsZcdRSm8wz2Eq